### PR TITLE
feat: streaming markdown rendering in terminal

### DIFF
--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -7,6 +7,7 @@ import { createDefaultToolRegistry } from '@brainstorm/tools';
 import { runAgentLoop, buildSystemPrompt, SessionManager } from '@brainstorm/core';
 import { AgentManager, parseAgentNL } from '@brainstorm/agents';
 import { runWorkflow, getPresetWorkflow, autoSelectPreset, PRESET_WORKFLOWS } from '@brainstorm/workflow';
+import { renderMarkdownToString } from '../components/MarkdownRenderer.js';
 
 const program = new Command();
 
@@ -364,12 +365,13 @@ program
           break;
         case 'text-delta':
           fullResponse += event.delta;
-          process.stdout.write(event.delta);
           break;
         case 'tool-call-start':
           process.stderr.write(`\n[tool: ${event.toolName}]\n`);
           break;
         case 'done':
+          // Render full response with markdown formatting
+          process.stdout.write(renderMarkdownToString(fullResponse));
           process.stdout.write(`\n\n[cost: $${event.totalCost.toFixed(4)}]\n`);
           break;
         case 'error':

--- a/packages/cli/src/components/MarkdownRenderer.tsx
+++ b/packages/cli/src/components/MarkdownRenderer.tsx
@@ -1,0 +1,58 @@
+import React, { useMemo } from 'react';
+import { Text } from 'ink';
+
+/**
+ * Simple terminal markdown renderer.
+ * Handles code blocks, headers, bold, italic, lists, and horizontal rules.
+ * No external dependencies — uses ANSI escape codes directly.
+ */
+function renderTerminalMarkdown(input: string): string {
+  let text = input;
+
+  // Code blocks: ```lang\ncode\n``` → dim + indented
+  text = text.replace(/```[\w]*\n([\s\S]*?)```/g, (_match, code: string) => {
+    const lines = code.trimEnd().split('\n');
+    return '\n' + lines.map((l: string) => `  \x1b[2m${l}\x1b[22m`).join('\n') + '\n';
+  });
+
+  // Inline code: `code` → dim
+  text = text.replace(/`([^`]+)`/g, '\x1b[2m$1\x1b[22m');
+
+  // Headers: ## Header → bold
+  text = text.replace(/^(#{1,4})\s+(.+)$/gm, (_match, _hashes: string, title: string) => {
+    return `\x1b[1m${title}\x1b[22m`;
+  });
+
+  // Bold: **text** → bold
+  text = text.replace(/\*\*(.+?)\*\*/g, '\x1b[1m$1\x1b[22m');
+
+  // Italic: *text* → italic
+  text = text.replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, '\x1b[3m$1\x1b[23m');
+
+  // Unordered lists: - item or * item → bullet
+  text = text.replace(/^[\s]*[-*]\s+/gm, '  • ');
+
+  // Ordered lists: 1. item → numbered
+  text = text.replace(/^[\s]*(\d+)\.\s+/gm, '  $1. ');
+
+  // Horizontal rules: --- or *** → line
+  text = text.replace(/^(-{3,}|\*{3,})$/gm, '─────────────────────────────────────');
+
+  return text;
+}
+
+interface MarkdownRendererProps {
+  content: string;
+}
+
+export function MarkdownRenderer({ content }: MarkdownRendererProps) {
+  const rendered = useMemo(() => renderTerminalMarkdown(content), [content]);
+  return <Text>{rendered}</Text>;
+}
+
+/**
+ * Render markdown to a plain string (for non-Ink contexts like `storm run`).
+ */
+export function renderMarkdownToString(content: string): string {
+  return renderTerminalMarkdown(content);
+}

--- a/packages/cli/src/components/StreamingMessage.tsx
+++ b/packages/cli/src/components/StreamingMessage.tsx
@@ -1,0 +1,33 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Box, Text } from 'ink';
+import { MarkdownRenderer } from './MarkdownRenderer.js';
+
+interface StreamingMessageProps {
+  /** Text accumulated so far (grows as deltas arrive) */
+  content: string;
+  /** Whether the message is still streaming */
+  isStreaming: boolean;
+  /** Agent/role name to display */
+  sender?: string;
+  /** Model name */
+  model?: string;
+}
+
+export function StreamingMessage({ content, isStreaming, sender, model }: StreamingMessageProps) {
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Box>
+        <Text color="green" bold>{sender ?? 'brainstorm'} </Text>
+        {model && <Text color="gray" dimColor>[{model}] </Text>}
+      </Box>
+      <Box paddingLeft={0}>
+        {content ? (
+          <MarkdownRenderer content={content} />
+        ) : (
+          isStreaming && <Text color="gray">thinking...</Text>
+        )}
+        {isStreaming && content && <Text color="cyan" bold>{'_'}</Text>}
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- MarkdownRenderer component: renders code blocks (dim), headers (bold), inline code, bold, italic, lists, horizontal rules using ANSI escape codes
- StreamingMessage component for Ink TUI: sender label, model tag, streaming cursor
- `storm run` renders full response with markdown formatting after collection
- Zero external dependencies — pure ANSI rendering

## PR #1 of 20 — Feature Parity Build Plan

Part of the Claude Code parity roadmap. This is the first visual improvement — makes `storm` output feel professional with formatted code blocks, bold headers, and bullet lists.

## Test plan
- [ ] `storm run "Explain closures with code examples"` → code blocks render dim, headers bold
- [ ] `storm run "List 3 things about TypeScript"` → numbered/bullet lists render correctly
- [ ] Verify in real terminal (not pipe) that ANSI codes render correctly

Generated with [Claude Code](https://claude.ai/code)