### PR TITLE
feat: permission model with auto/confirm/plan cycling

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"b553c99c-815d-4910-b287-318cd25b9faf","pid":23319,"acquiredAt":1774312017901}

--- a/packages/cli/src/components/StatusBar.tsx
+++ b/packages/cli/src/components/StatusBar.tsx
@@ -1,20 +1,31 @@
 import React from 'react';
 import { Box, Text } from 'ink';
+import type { PermissionMode } from '@brainstorm/shared';
 
 interface StatusBarProps {
   strategy: string;
   currentModel?: string;
   sessionCost: number;
   modelCount: { local: number; cloud: number };
+  permissionMode?: PermissionMode;
 }
 
-export function StatusBar({ strategy, currentModel, sessionCost, modelCount }: StatusBarProps) {
+const MODE_LABELS: Record<PermissionMode, { label: string; color: string }> = {
+  auto: { label: 'AUTO', color: 'green' },
+  confirm: { label: 'CONFIRM', color: 'yellow' },
+  plan: { label: 'PLAN', color: 'cyan' },
+};
+
+export function StatusBar({ strategy, currentModel, sessionCost, modelCount, permissionMode = 'confirm' }: StatusBarProps) {
+  const mode = MODE_LABELS[permissionMode];
   return (
     <Box borderStyle="single" borderColor="gray" paddingX={1} flexDirection="row" justifyContent="space-between">
       <Text>
         <Text color="cyan" bold>brainstorm</Text>
         <Text color="gray"> | </Text>
         <Text color="yellow">{strategy}</Text>
+        <Text color="gray"> | </Text>
+        <Text color={mode.color}>{mode.label}</Text>
       </Text>
       <Text>
         {currentModel && (

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -61,6 +61,7 @@ const modelOverrideSchema = z.object({
 const generalSchema = z.object({
   defaultStrategy: z.enum(['cost-first', 'quality-first', 'rule-based', 'combined']).default('combined'),
   confirmTools: z.boolean().default(true),
+  defaultPermissionMode: z.enum(['auto', 'confirm', 'plan']).default('confirm'),
   theme: z.enum(['dark', 'light']).default('dark'),
   maxSteps: z.number().default(10),
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
 export { runAgentLoop, type AgentLoopOptions } from './agent/loop.js';
 export { buildSystemPrompt } from './agent/context.js';
 export { SessionManager } from './session/manager.js';
+export { PermissionManager } from './permissions/manager.js';

--- a/packages/core/src/permissions/manager.ts
+++ b/packages/core/src/permissions/manager.ts
@@ -1,0 +1,85 @@
+import type { ToolPermission } from '@brainstorm/shared';
+
+export type PermissionMode = 'auto' | 'confirm' | 'plan';
+
+const MODE_CYCLE: PermissionMode[] = ['auto', 'confirm', 'plan'];
+
+/**
+ * PermissionManager controls tool execution approval.
+ *
+ * Three modes cycle with Shift+Tab:
+ * - auto: all tools execute without asking (fastest, trust the model)
+ * - confirm: write/shell tools require [y/n/always] confirmation
+ * - plan: only read-only tools allowed (no writes, no shell)
+ */
+export class PermissionManager {
+  private mode: PermissionMode;
+  private sessionAlways = new Set<string>(); // tools the user said "always" for this session
+
+  constructor(defaultMode: PermissionMode = 'confirm') {
+    this.mode = defaultMode;
+  }
+
+  getMode(): PermissionMode {
+    return this.mode;
+  }
+
+  /** Cycle to the next permission mode. */
+  cycle(): PermissionMode {
+    const idx = MODE_CYCLE.indexOf(this.mode);
+    this.mode = MODE_CYCLE[(idx + 1) % MODE_CYCLE.length];
+    return this.mode;
+  }
+
+  setMode(mode: PermissionMode): void {
+    this.mode = mode;
+  }
+
+  /**
+   * Check if a tool is allowed to execute in the current mode.
+   * Returns: 'allow' (proceed), 'confirm' (ask user), 'deny' (blocked).
+   */
+  check(toolName: string, toolPermission: ToolPermission): 'allow' | 'confirm' | 'deny' {
+    // Plan mode: only allow 'auto' (read-only) tools
+    if (this.mode === 'plan') {
+      return toolPermission === 'auto' ? 'allow' : 'deny';
+    }
+
+    // Tool explicitly denied in config
+    if (toolPermission === 'deny') return 'deny';
+
+    // Auto mode: everything allowed
+    if (this.mode === 'auto') return 'allow';
+
+    // Confirm mode: auto tools pass through, confirm tools need approval
+    if (toolPermission === 'auto') return 'allow';
+
+    // Check session "always allow" list
+    if (this.sessionAlways.has(toolName)) return 'allow';
+
+    return 'confirm';
+  }
+
+  /** Mark a tool as "always allow" for this session. */
+  alwaysAllow(toolName: string): void {
+    this.sessionAlways.add(toolName);
+  }
+
+  /** Get description of current mode for TUI display. */
+  getModeDescription(): string {
+    switch (this.mode) {
+      case 'auto': return 'Auto (all tools allowed)';
+      case 'confirm': return 'Confirm (approve writes/shell)';
+      case 'plan': return 'Plan (read-only)';
+    }
+  }
+
+  /** Get mode color for TUI. */
+  getModeColor(): string {
+    switch (this.mode) {
+      case 'auto': return 'green';
+      case 'confirm': return 'yellow';
+      case 'plan': return 'cyan';
+    }
+  }
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -158,6 +158,7 @@ export type AgentEvent =
 // ── Tool System ──────────────────────────────────────────────────────
 
 export type ToolPermission = 'auto' | 'confirm' | 'deny';
+export type PermissionMode = 'auto' | 'confirm' | 'plan';
 
 export interface ToolDefinition {
   name: string;


### PR DESCRIPTION
## Summary
- `PermissionManager` with 3 modes: auto (green), confirm (yellow), plan (cyan)
- `check(toolName, toolPermission)` returns allow/confirm/deny based on current mode
- Session-level "always allow" for tools user approves once
- StatusBar shows current mode with color coding
- Config: `general.defaultPermissionMode` in brainstorm.toml

## PR #2 of 20 — Feature Parity Build Plan

The permission model is what makes a coding assistant feel safe. Auto mode for speed, confirm mode for safety, plan mode for read-only exploration.

## Test plan
- [ ] `storm config` shows `defaultPermissionMode: confirm`
- [ ] StatusBar renders mode indicator (verify in terminal)
- [ ] PermissionManager.check() returns correct results for each mode

Generated with [Claude Code](https://claude.ai/code)