### PR TITLE
feat: conversation management — sessions, resume, fork

### DIFF
--- a/packages/cli/bin/brainstorm
+++ b/packages/cli/bin/brainstorm
@@ -1,0 +1,1 @@
+../lib/node_modules/@brainstorm/cli/dist/brainstorm.js

--- a/packages/cli/bin/storm
+++ b/packages/cli/bin/storm
@@ -1,0 +1,1 @@
+../lib/node_modules/@brainstorm/cli/dist/brainstorm.js

--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -385,11 +385,39 @@ program
     }
   });
 
+// ── Sessions Command ───────────────────────────────────────────────
+
+program
+  .command('sessions')
+  .description('List recent chat sessions')
+  .option('-n, --limit <count>', 'Number of sessions to show', '10')
+  .action(async (opts: { limit: string }) => {
+    const db = getDb();
+    const sessionManager = new SessionManager(db);
+    const sessions = sessionManager.listRecent(parseInt(opts.limit));
+
+    console.log('\n  Recent Sessions:\n');
+    if (sessions.length === 0) {
+      console.log('    No sessions found.');
+    }
+    for (const s of sessions) {
+      const age = Math.floor((Date.now() / 1000 - s.updatedAt) / 60);
+      const ageStr = age < 60 ? `${age}m ago` : age < 1440 ? `${Math.floor(age / 60)}h ago` : `${Math.floor(age / 1440)}d ago`;
+      console.log(`    ${s.id.slice(0, 8)}  ${s.messageCount} msgs  $${s.totalCost.toFixed(4)}  ${ageStr}  ${s.projectPath}`);
+    }
+    console.log();
+  });
+
+// ── Chat Command ──────────────────────────────────────────────────
+
 program
   .command('chat', { isDefault: true })
   .description('Start an interactive chat session')
   .option('--simple', 'Use simple readline interface instead of TUI')
-  .action(async (opts: { simple?: boolean }) => {
+  .option('--continue', 'Resume the most recent session')
+  .option('--resume <id>', 'Resume a specific session by ID')
+  .option('--fork <id>', 'Fork a session (copy history, new session)')
+  .action(async (opts: { simple?: boolean; continue?: boolean; resume?: string; fork?: string }) => {
     const config = loadConfig();
     const db = getDb();
     const registry = await createProviderRegistry(config);
@@ -398,7 +426,25 @@ program
     const tools = createDefaultToolRegistry();
     const sessionManager = new SessionManager(db);
     const projectPath = process.cwd();
-    const session = sessionManager.start(projectPath);
+
+    // Session management: resume, fork, or start new
+    let session: any;
+    if (opts.fork) {
+      session = sessionManager.fork(opts.fork);
+      if (!session) { console.error(`  Session '${opts.fork}' not found.`); process.exit(1); }
+      console.log(`  Forked session ${opts.fork.slice(0, 8)} -> ${session.id.slice(0, 8)}`);
+    } else if (opts.resume) {
+      session = sessionManager.resume(opts.resume);
+      if (!session) { console.error(`  Session '${opts.resume}' not found.`); process.exit(1); }
+      console.log(`  Resumed session ${session.id.slice(0, 8)} (${session.messageCount} messages)`);
+    } else if (opts.continue) {
+      session = sessionManager.resumeLatest(projectPath);
+      if (!session) { session = sessionManager.start(projectPath); }
+      else { console.log(`  Continued session ${session.id.slice(0, 8)} (${session.messageCount} messages)`); }
+    } else {
+      session = sessionManager.start(projectPath);
+    }
+
     const systemPrompt = buildSystemPrompt(projectPath);
 
     const localCount = registry.models.filter((m) => m.isLocal).length;

--- a/packages/core/src/session/manager.ts
+++ b/packages/core/src/session/manager.ts
@@ -1,8 +1,6 @@
 import { SessionRepository, MessageRepository } from '@brainstorm/db';
 import type { Session } from '@brainstorm/shared';
 
-// We store conversation as simple {role, content} objects
-// and convert to ModelMessage format when needed by the AI SDK
 export interface ConversationMessage {
   role: 'user' | 'assistant' | 'system';
   content: string;
@@ -14,7 +12,7 @@ export class SessionManager {
   private currentSession: Session | null = null;
   private conversationHistory: ConversationMessage[] = [];
 
-  constructor(db: any) {
+  constructor(private db: any) {
     this.sessions = new SessionRepository(db);
     this.messages = new MessageRepository(db);
   }
@@ -39,6 +37,42 @@ export class SessionManager {
       }));
 
     return session;
+  }
+
+  /** Resume the most recent session for the given project path. */
+  resumeLatest(projectPath?: string): Session | null {
+    const recent = this.sessions.listRecent(1);
+    if (recent.length === 0) return null;
+    const target = projectPath
+      ? recent.find((s) => s.projectPath === projectPath)
+      : recent[0];
+    if (!target) return null;
+    return this.resume(target.id);
+  }
+
+  /** Fork a session: create a new session with a copy of the conversation history. */
+  fork(sessionId: string): Session | null {
+    const original = this.sessions.get(sessionId);
+    if (!original) return null;
+
+    const forked = this.sessions.create(original.projectPath);
+    const msgs = this.messages.listBySession(sessionId);
+
+    // Copy all messages to the new session
+    for (const m of msgs) {
+      this.messages.create(forked.id, m.role, m.content, m.modelId, m.tokenCount);
+    }
+
+    // Set as current session
+    this.currentSession = forked;
+    this.conversationHistory = msgs
+      .filter((m) => m.role !== 'tool')
+      .map((m) => ({
+        role: m.role as 'user' | 'assistant' | 'system',
+        content: m.content,
+      }));
+
+    return forked;
   }
 
   addUserMessage(content: string): void {


### PR DESCRIPTION
## Summary
- `storm sessions` lists recent sessions with message count, cost, and age
- `storm chat --continue` resumes the most recent session
- `storm chat --resume <id>` resumes a specific session
- `storm chat --fork <id>` copies history to a new session
- `SessionManager.resumeLatest()` and `fork()` methods

## PR #6 of 20

Enables iterative work across sessions. "Continue where I left off" and "branch from this point."

## Test plan
- [ ] `storm sessions` shows recent sessions with correct data
- [ ] `storm chat --continue` loads previous conversation
- [ ] `storm chat --fork <id>` creates new session with copied history

Generated with [Claude Code](https://claude.ai/code)