### PR TITLE
feat: @file references in chat input

### DIFF
--- a/packages/core/src/agent/context.ts
+++ b/packages/core/src/agent/context.ts
@@ -1,7 +1,7 @@
 import { loadProjectContext } from '@brainstorm/config';
 import { execFileSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 
 const DEFAULT_SYSTEM_PROMPT = `You are Brainstorm, an AI coding assistant. You help users with software engineering tasks including writing code, debugging, refactoring, explaining code, and more.
 
@@ -60,4 +60,46 @@ function getGitContext(projectPath: string): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Parse @file references from user input and inject file contents.
+ *
+ * Patterns: @path/to/file.ts, @./relative/path.js, @src/App.tsx
+ *
+ * Returns cleaned message (@ prefix stripped) and file content messages.
+ */
+export function parseAtMentions(
+  input: string,
+  projectPath: string,
+): { cleanedInput: string; fileContexts: Array<{ role: 'user'; content: string }> } {
+  const atPattern = /@(\.?[\w./-]+\.\w{1,10})/g;
+  const fileContexts: Array<{ role: 'user'; content: string }> = [];
+  const seen = new Set<string>();
+
+  let match;
+  while ((match = atPattern.exec(input)) !== null) {
+    const ref = match[1];
+    const filePath = resolve(projectPath, ref);
+
+    if (seen.has(filePath)) continue;
+    seen.add(filePath);
+
+    if (existsSync(filePath)) {
+      try {
+        const content = readFileSync(filePath, 'utf-8');
+        const lines = content.split('\n');
+        const truncated = lines.length > 500
+          ? lines.slice(0, 500).join('\n') + `\n... (${lines.length - 500} more lines)`
+          : content;
+        fileContexts.push({
+          role: 'user',
+          content: `[File: ${ref}]\n\`\`\`\n${truncated}\n\`\`\``,
+        });
+      } catch { /* skip unreadable files */ }
+    }
+  }
+
+  const cleanedInput = input.replace(atPattern, '$1').trim();
+  return { cleanedInput, fileContexts };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 export { runAgentLoop, type AgentLoopOptions } from './agent/loop.js';
-export { buildSystemPrompt } from './agent/context.js';
+export { buildSystemPrompt, parseAtMentions } from './agent/context.js';
 export { SessionManager } from './session/manager.js';
 export { PermissionManager } from './permissions/manager.js';
 export { compactContext, estimateTokenCount, needsCompaction } from './session/compaction.js';


### PR DESCRIPTION
## Summary
- `parseAtMentions()` extracts `@path/to/file.ts` from user input
- Reads file, truncates at 500 lines, injects as context
- Deduplicates, strips @ prefix for clean prompt text

## PR #7 of 20

Type `@src/auth.ts explain this` and the file is automatically injected into context.

## Test plan
- [x] `parseAtMentions("explain @package.json", cwd)` → finds and reads file
- [x] Multiple @refs deduplicated
- [x] Non-existent files silently skipped

Generated with [Claude Code](https://claude.ai/code)