### PR TITLE
feat: hooks system for lifecycle automation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -283,6 +283,10 @@
       "resolved": "packages/db",
       "link": true
     },
+    "node_modules/@brainstorm/hooks": {
+      "resolved": "packages/hooks",
+      "link": true
+    },
     "node_modules/@brainstorm/providers": {
       "resolved": "packages/providers",
       "link": true
@@ -4667,6 +4671,17 @@
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7",
+        "tsup": "^8",
+        "typescript": "^5.7"
+      }
+    },
+    "packages/hooks": {
+      "name": "@brainstorm/hooks",
+      "version": "0.1.0",
+      "dependencies": {
+        "@brainstorm/shared": "*"
+      },
+      "devDependencies": {
         "tsup": "^8",
         "typescript": "^5.7"
       }

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@brainstorm/hooks",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@brainstorm/shared": "*"
+  },
+  "devDependencies": {
+    "tsup": "^8",
+    "typescript": "^5.7"
+  }
+}

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,0 +1,2 @@
+export { HookManager } from './manager.js';
+export type { HookDefinition, HookEvent, HookResult, HookType } from './types.js';

--- a/packages/hooks/src/manager.ts
+++ b/packages/hooks/src/manager.ts
@@ -1,0 +1,104 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { HookDefinition, HookEvent, HookResult } from './types.js';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * HookManager — registers and fires hooks at lifecycle events.
+ *
+ * Hooks are deterministic automation: they always run when their event fires,
+ * unlike LLM decisions which are probabilistic. This is the extensibility
+ * foundation for Brainstorm CLI.
+ */
+export class HookManager {
+  private hooks: HookDefinition[] = [];
+  private nextId = 0;
+
+  /** Register a hook. Returns a hook ID for removal. */
+  register(hook: HookDefinition): string {
+    const id = `hook-${this.nextId++}`;
+    this.hooks.push(hook);
+    return id;
+  }
+
+  /** Register multiple hooks (e.g., from TOML config). */
+  registerAll(hooks: HookDefinition[]): void {
+    for (const h of hooks) this.register(h);
+  }
+
+  /** Get all registered hooks. */
+  list(): HookDefinition[] {
+    return [...this.hooks];
+  }
+
+  /**
+   * Fire all hooks matching an event.
+   *
+   * For PreToolUse: if any blocking hook fails, returns blocked=true.
+   * For PostToolUse: runs all hooks, failures are logged but don't block.
+   */
+  async fire(
+    event: HookEvent,
+    context?: { toolName?: string; filePath?: string; [key: string]: unknown },
+  ): Promise<HookResult[]> {
+    const matching = this.hooks.filter((h) => {
+      if (h.event !== event) return false;
+      if (h.matcher && context?.toolName) {
+        try {
+          return new RegExp(h.matcher).test(context.toolName);
+        } catch { return false; }
+      }
+      return true;
+    });
+
+    const results: HookResult[] = [];
+
+    for (const hook of matching) {
+      const start = Date.now();
+      const hookId = `${hook.event}:${hook.command.slice(0, 30)}`;
+
+      if (hook.type === 'command') {
+        try {
+          // Expand variables in command
+          let cmd = hook.command;
+          if (context?.filePath) cmd = cmd.replace(/\$FILE/g, context.filePath);
+          if (context?.toolName) cmd = cmd.replace(/\$TOOL/g, context.toolName);
+
+          const { stdout, stderr } = await execFileAsync('/bin/sh', ['-c', cmd], {
+            timeout: 10_000,
+            cwd: process.cwd(),
+          });
+
+          results.push({
+            hookId,
+            event,
+            success: true,
+            output: stdout.trim(),
+            durationMs: Date.now() - start,
+          });
+        } catch (err: any) {
+          const blocked = hook.blocking && event === 'PreToolUse';
+          results.push({
+            hookId,
+            event,
+            success: false,
+            error: err.stderr || err.message,
+            durationMs: Date.now() - start,
+            blocked,
+          });
+
+          if (blocked) break; // Stop processing further hooks
+        }
+      }
+      // 'prompt' type hooks would invoke an LLM — deferred to future PR
+    }
+
+    return results;
+  }
+
+  /** Check if any PreToolUse hook blocked the operation. */
+  isBlocked(results: HookResult[]): boolean {
+    return results.some((r) => r.blocked);
+  }
+}

--- a/packages/hooks/src/types.ts
+++ b/packages/hooks/src/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Hook events fired during the agent lifecycle.
+ * Mirrors Claude Code's hook event model for compatibility.
+ */
+export type HookEvent =
+  | 'PreToolUse'      // Before a tool executes — can block or modify
+  | 'PostToolUse'     // After a tool succeeds — for side effects (format, lint)
+  | 'SessionStart'    // When a session begins or resumes
+  | 'SessionEnd'      // When a session ends
+  | 'Stop'            // When the agent finishes responding
+  | 'PreCompact'      // Before context compaction
+  | 'PreCommit';      // Before a git commit
+
+export type HookType = 'command' | 'prompt';
+
+/**
+ * Hook definition — matches a lifecycle event and runs an action.
+ */
+export interface HookDefinition {
+  /** Which event triggers this hook. */
+  event: HookEvent;
+  /** Optional matcher: only fire for specific tool names (regex for PreToolUse/PostToolUse). */
+  matcher?: string;
+  /** Hook type: 'command' runs a shell command, 'prompt' asks an LLM. */
+  type: HookType;
+  /** The command to run or prompt to evaluate. */
+  command: string;
+  /** If true, a failing hook blocks the operation (PreToolUse only). */
+  blocking?: boolean;
+  /** Human-readable description. */
+  description?: string;
+}
+
+export interface HookResult {
+  hookId: string;
+  event: HookEvent;
+  success: boolean;
+  output?: string;
+  error?: string;
+  durationMs: number;
+  blocked?: boolean;
+}

--- a/packages/hooks/tsconfig.json
+++ b/packages/hooks/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/hooks/tsup.config.ts
+++ b/packages/hooks/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+});


### PR DESCRIPTION
## Summary
- New `@brainstorm/hooks` package with `HookManager`
- 7 lifecycle events: PreToolUse, PostToolUse, SessionStart, SessionEnd, Stop, PreCompact, PreCommit
- Shell command hooks with variable expansion ($FILE, $TOOL)
- Blocking hooks can prevent tool execution (PreToolUse)
- Regex matcher for tool-specific hooks

## PR #8 of 20

The extensibility foundation. Add a hook in TOML to run `prettier` after every file_write, or block dangerous shell commands.

## Test plan
- [ ] HookManager.register() + fire('PostToolUse') executes command
- [ ] Blocking PreToolUse hook prevents tool execution
- [ ] $FILE variable expanded in hook command

Generated with [Claude Code](https://claude.ai/code)