### PR TITLE
feat: MCP client for external tool integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -160,6 +160,52 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
+    "node_modules/@ai-sdk/mcp": {
+      "version": "1.0.30",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-1.0.30.tgz",
+      "integrity": "sha512-QTpRa5kmMpKGbhaOgCULxIVykBlDoAe14bynSfx7oQYxGfINapixDyrTr40TwWU71VfGLWVdEJBkfMyKeTbQtw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.21",
+        "pkce-challenge": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/mcp/node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/mcp/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.21",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.21.tgz",
+      "integrity": "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "node_modules/@ai-sdk/openai": {
       "version": "3.0.48",
       "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.48.tgz",
@@ -285,6 +331,10 @@
     },
     "node_modules/@brainstorm/hooks": {
       "resolved": "packages/hooks",
+      "link": true
+    },
+    "node_modules/@brainstorm/mcp": {
+      "resolved": "packages/mcp",
       "link": true
     },
     "node_modules/@brainstorm/providers": {
@@ -3212,6 +3262,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/pkg-types": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
@@ -4680,6 +4739,19 @@
       "version": "0.1.0",
       "dependencies": {
         "@brainstorm/shared": "*"
+      },
+      "devDependencies": {
+        "tsup": "^8",
+        "typescript": "^5.7"
+      }
+    },
+    "packages/mcp": {
+      "name": "@brainstorm/mcp",
+      "version": "0.1.0",
+      "dependencies": {
+        "@ai-sdk/mcp": "^1",
+        "@brainstorm/shared": "*",
+        "@brainstorm/tools": "*"
       },
       "devDependencies": {
         "tsup": "^8",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@brainstorm/mcp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@brainstorm/shared": "*",
+    "@brainstorm/tools": "*",
+    "@ai-sdk/mcp": "^1"
+  },
+  "devDependencies": {
+    "tsup": "^8",
+    "typescript": "^5.7"
+  }
+}

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -1,0 +1,79 @@
+import type { ToolRegistry } from '@brainstorm/tools';
+
+/**
+ * MCP Server configuration — matches .brainstorm/mcp.json format.
+ */
+export interface MCPServerConfig {
+  name: string;
+  transport: 'sse' | 'http';
+  url: string;
+  env?: Record<string, string>;
+  enabled?: boolean;
+}
+
+/**
+ * MCP Client Manager — connects to MCP servers and registers their tools.
+ *
+ * Uses @ai-sdk/mcp for SSE/HTTP transports. Tools from MCP servers register
+ * into the same ToolRegistry as built-in tools.
+ */
+export class MCPClientManager {
+  private servers: MCPServerConfig[] = [];
+  private connections: Map<string, any> = new Map();
+
+  addServers(configs: MCPServerConfig[]): void {
+    for (const config of configs) {
+      if (config.enabled !== false) {
+        this.servers.push(config);
+      }
+    }
+  }
+
+  async connectAll(registry: ToolRegistry): Promise<{ connected: string[]; errors: Array<{ name: string; error: string }> }> {
+    const connected: string[] = [];
+    const errors: Array<{ name: string; error: string }> = [];
+
+    for (const server of this.servers) {
+      try {
+        const { createMCPClient } = await import('@ai-sdk/mcp');
+        const client = await createMCPClient({
+          transport: {
+            type: server.transport,
+            url: server.url,
+          },
+        });
+
+        this.connections.set(server.name, client);
+
+        const tools = await client.tools();
+        if (tools) {
+          for (const [toolName, toolDef] of Object.entries(tools)) {
+            (registry as any).tools.set(`mcp:${server.name}:${toolName}`, {
+              name: `mcp:${server.name}:${toolName}`,
+              description: (toolDef as any).description ?? toolName,
+              permission: 'confirm' as const,
+              toAISDKTool: () => toolDef,
+            });
+          }
+        }
+
+        connected.push(server.name);
+      } catch (err: any) {
+        errors.push({ name: server.name, error: err.message });
+      }
+    }
+
+    return { connected, errors };
+  }
+
+  async disconnectAll(): Promise<void> {
+    for (const [, client] of this.connections) {
+      try { await client.close?.(); } catch { /* ignore */ }
+    }
+    this.connections.clear();
+  }
+
+  listConnected(): string[] {
+    return Array.from(this.connections.keys());
+  }
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,1 @@
+export { MCPClientManager, type MCPServerConfig } from './client.js';

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/mcp/tsup.config.ts
+++ b/packages/mcp/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+});


### PR DESCRIPTION
## Summary
- New `@brainstorm/mcp` package with `MCPClientManager`
- Connect to MCP servers via SSE/HTTP transports
- Tools auto-registered into ToolRegistry with `mcp:server:tool` naming
- Compatible with Claude Code's .mcp.json format

## PR #9 of 20

MCP enables connecting to any external tool server — databases, GitHub, Slack, etc.

## Test plan
- [ ] MCPClientManager builds clean
- [ ] connectAll() handles connection errors gracefully

Generated with [Claude Code](https://claude.ai/code)