### PR TITLE
feat: spawn isolated subagents for parallel work

### DIFF
--- a/packages/core/src/agent/subagent.ts
+++ b/packages/core/src/agent/subagent.ts
@@ -1,0 +1,87 @@
+import { streamText, stepCountIs } from 'ai';
+import type { BrainstormConfig } from '@brainstorm/config';
+import type { ProviderRegistry } from '@brainstorm/providers';
+import { BrainstormRouter, CostTracker } from '@brainstorm/router';
+import type { ToolRegistry } from '@brainstorm/tools';
+
+export interface SubagentOptions {
+  config: BrainstormConfig;
+  registry: ProviderRegistry;
+  router: BrainstormRouter;
+  costTracker: CostTracker;
+  tools: ToolRegistry;
+  projectPath: string;
+  /** System prompt override for the subagent. */
+  systemPrompt?: string;
+  /** Max steps for the subagent (default: 5, keeps it focused). */
+  maxSteps?: number;
+}
+
+export interface SubagentResult {
+  text: string;
+  cost: number;
+  modelUsed: string;
+  toolCalls: string[];
+}
+
+/**
+ * Spawn an isolated subagent for a focused task.
+ *
+ * Subagents get their own context — they don't see the parent conversation.
+ * This prevents context bloat while enabling parallel work.
+ * BrainstormRouter routes subagents to cheaper models (they're simpler tasks).
+ */
+export async function spawnSubagent(
+  task: string,
+  options: SubagentOptions,
+): Promise<SubagentResult> {
+  const { router, costTracker, tools, config, registry, projectPath } = options;
+
+  const taskProfile = router.classify(task);
+  const decision = router.route(taskProfile);
+
+  const modelId = registry.getProvider(decision.model.id);
+  const systemPrompt = options.systemPrompt ??
+    'You are a focused subagent. Complete the given task concisely and return the result. Do not ask questions — make your best judgment.';
+
+  const costBefore = costTracker.getSessionCost();
+  const toolCallNames: string[] = [];
+  let fullText = '';
+
+  const result = streamText({
+    model: modelId,
+    system: systemPrompt,
+    messages: [{ role: 'user' as const, content: task }],
+    tools: tools.toAISDKTools(),
+    stopWhen: stepCountIs(options.maxSteps ?? 5),
+    onStepFinish: async ({ usage }: any) => {
+      if (usage) {
+        costTracker.record({
+          sessionId: 'subagent',
+          modelId: decision.model.id,
+          provider: decision.model.provider,
+          inputTokens: usage.inputTokens ?? 0,
+          outputTokens: usage.outputTokens ?? 0,
+          taskType: taskProfile.type,
+          projectPath,
+          pricing: decision.model.pricing,
+        });
+      }
+    },
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === 'text-delta') {
+      fullText += (part as any).text ?? '';
+    } else if (part.type === 'tool-call') {
+      toolCallNames.push(part.toolName);
+    }
+  }
+
+  return {
+    text: fullText,
+    cost: costTracker.getSessionCost() - costBefore,
+    modelUsed: decision.model.name,
+    toolCalls: toolCallNames,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,3 +3,4 @@ export { buildSystemPrompt, parseAtMentions } from './agent/context.js';
 export { SessionManager } from './session/manager.js';
 export { PermissionManager } from './permissions/manager.js';
 export { compactContext, estimateTokenCount, needsCompaction } from './session/compaction.js';
+export { spawnSubagent, type SubagentOptions, type SubagentResult } from './agent/subagent.js';


### PR DESCRIPTION
## Summary
- `spawnSubagent(task, options)` with isolated context
- BrainstormRouter auto-routes to cheaper models for subagent tasks
- Returns text, cost, model used, and tool calls
- 5-step default limit keeps subagents focused

## PR #10 of 20 — Completes Tier 2

Subagents enable parallel work: "explore this codebase" spawns a subagent that reads files and returns a summary without polluting the main conversation.

## Test plan
- [ ] spawnSubagent() builds clean
- [ ] Router selects appropriate model for subagent task

Generated with [Claude Code](https://claude.ai/code)