### PR TITLE
feat: security hardening — .brainstormignore + credential scanner

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,3 +8,5 @@ export { loadSkills, findSkill, type SkillDefinition } from './skills/loader.js'
 export { MemoryManager, type MemoryEntry } from './memory/manager.js';
 export { getPlanModeTools, getPlanModePrompt } from './plan/mode.js';
 export { readMultimodalFile, isImageFile, isPdfFile, requiresVisionModel, type MultimodalContent } from './multimodal/reader.js';
+export { loadIgnorePatterns, isIgnored } from './security/ignore.js';
+export { scanForCredentials, redactCredentials, type ScanResult } from './security/secret-scanner.js';

--- a/packages/core/src/security/ignore.ts
+++ b/packages/core/src/security/ignore.ts
@@ -1,0 +1,74 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+/**
+ * Default patterns for .brainstormignore — files that should never be
+ * read or sent to LLM providers.
+ */
+const DEFAULT_IGNORE_PATTERNS = [
+  // Secrets and credentials
+  '.env', '.env.*', '.env.local', '.env.production',
+  '*.pem', '*.key', '*.p12', '*.pfx', '*.jks',
+  'credentials.json', 'service-account.json',
+  '.npmrc', '.pypirc',
+
+  // SSH and auth
+  '.ssh/', '.gnupg/', '.aws/', '.gcloud/',
+
+  // Build artifacts and dependencies
+  'node_modules/', 'dist/', 'build/', '.next/', '.turbo/',
+  '__pycache__/', '*.pyc', '.venv/', 'venv/',
+  'target/', '.gradle/',
+
+  // Binary files
+  '*.exe', '*.dll', '*.so', '*.dylib',
+  '*.zip', '*.tar', '*.gz', '*.rar',
+  '*.jpg', '*.jpeg', '*.png', '*.gif', '*.mp4', '*.mp3',
+  '*.woff', '*.woff2', '*.ttf', '*.eot',
+
+  // IDE and OS
+  '.idea/', '.vscode/settings.json',
+  '.DS_Store', 'Thumbs.db',
+
+  // Lock files (large, not useful for context)
+  'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml',
+  'Cargo.lock', 'poetry.lock', 'Gemfile.lock',
+];
+
+/**
+ * Load ignore patterns from .brainstormignore + defaults.
+ */
+export function loadIgnorePatterns(projectPath: string): string[] {
+  const patterns = [...DEFAULT_IGNORE_PATTERNS];
+
+  const ignoreFile = join(projectPath, '.brainstormignore');
+  if (existsSync(ignoreFile)) {
+    const custom = readFileSync(ignoreFile, 'utf-8')
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l && !l.startsWith('#'));
+    patterns.push(...custom);
+  }
+
+  return patterns;
+}
+
+/**
+ * Check if a file path matches any ignore pattern.
+ */
+export function isIgnored(filePath: string, projectPath: string, patterns: string[]): boolean {
+  const rel = relative(projectPath, filePath);
+  for (const pattern of patterns) {
+    if (pattern.endsWith('/')) {
+      // Directory pattern
+      if (rel.startsWith(pattern) || rel.includes('/' + pattern)) return true;
+    } else if (pattern.startsWith('*.')) {
+      // Extension pattern
+      if (rel.endsWith(pattern.slice(1))) return true;
+    } else {
+      // Exact match or contains
+      if (rel === pattern || rel.endsWith('/' + pattern) || rel.includes(pattern)) return true;
+    }
+  }
+  return false;
+}

--- a/packages/core/src/security/secret-scanner.ts
+++ b/packages/core/src/security/secret-scanner.ts
@@ -1,0 +1,58 @@
+/**
+ * Scans text for credential patterns and redacts them before sending to LLM providers.
+ * 13 regex patterns matching common credential formats.
+ */
+
+const CREDENTIAL_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
+  { name: 'AWS Access Key', pattern: /AKIA[0-9A-Z]{16}/g },
+  { name: 'AWS Credential', pattern: /(?:aws_secret_access_key|secret_key)\s*[:=]\s*['"]?([A-Za-z0-9/+=]{40})['"]?/gi },
+  { name: 'GitHub Token', pattern: /gh[ps]_[A-Za-z0-9_]{36,}/g },
+  { name: 'GitHub OAuth', pattern: /gho_[A-Za-z0-9_]{36,}/g },
+  { name: 'OpenAI Key', pattern: /sk-[A-Za-z0-9]{20,}/g },
+  { name: 'Anthropic Key', pattern: /sk-ant-[A-Za-z0-9-]{20,}/g },
+  { name: 'Stripe Key', pattern: /(?:sk|pk)_(?:live|test)_[A-Za-z0-9]{20,}/g },
+  { name: 'Google API Key', pattern: /AIza[A-Za-z0-9_-]{35}/g },
+  { name: 'PEM Private Key', pattern: /-----BEGIN (?:RSA |EC )?PRIVATE KEY-----/g },
+  { name: 'Basic Auth URL', pattern: /https?:\/\/[^:]+:[^@]+@/g },
+  { name: 'Generic Credential', pattern: /(?:password|token|api_key|apikey)\s*[:=]\s*['"]([^'"]{8,})['"/]/gi },
+  { name: 'JWT', pattern: /eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/g },
+  { name: 'BR API Key', pattern: /br_(?:live|test)_[A-Za-z0-9]{20,}/g },
+];
+
+export interface ScanResult {
+  hasFindings: boolean;
+  findings: Array<{ name: string; position: number; preview: string }>;
+}
+
+/**
+ * Scan text for credential patterns.
+ */
+export function scanForCredentials(text: string): ScanResult {
+  const findings: ScanResult['findings'] = [];
+
+  for (const { name, pattern } of CREDENTIAL_PATTERNS) {
+    pattern.lastIndex = 0;
+    let match;
+    while ((match = pattern.exec(text)) !== null) {
+      findings.push({
+        name,
+        position: match.index,
+        preview: match[0].slice(0, 6) + '...[REDACTED]',
+      });
+    }
+  }
+
+  return { hasFindings: findings.length > 0, findings };
+}
+
+/**
+ * Redact all detected credentials in text.
+ */
+export function redactCredentials(text: string): string {
+  let result = text;
+  for (const { pattern } of CREDENTIAL_PATTERNS) {
+    pattern.lastIndex = 0;
+    result = result.replace(pattern, '[REDACTED]');
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- `.brainstormignore` with 30+ default patterns
- 13-pattern credential scanner with redaction
- Prevents credentials from being sent to LLM providers

## PR #17 of 20

Generated with [Claude Code](https://claude.ai/code)