### PR TITLE
feat: orchestrator agent role — completes 5-agent DAG (PR #20)

### DIFF
--- a/packages/agents/src/prompts.ts
+++ b/packages/agents/src/prompts.ts
@@ -11,6 +11,8 @@ const ROLE_PROMPTS: Record<string, string> = {
   debugger: `You are a debugging specialist. Your job is to identify the root cause of bugs. Read error messages, trace execution paths, and isolate the issue. Provide a clear diagnosis and recommended fix.`,
 
   analyst: `You are a technical analyst. Your job is to explain code, architecture, and technical concepts clearly. Provide insightful explanations that help the developer understand the codebase better.`,
+
+  orchestrator: `You are a workflow orchestrator. Your job is to coordinate multi-agent workflows: decide which agent runs next, check budget constraints, handle review rejections, manage retry loops, and ensure the workflow completes successfully. You do NOT write code yourself — you delegate to specialized agents and manage the process.`,
 };
 
 export function buildAgentSystemPrompt(agent: AgentProfile, stepDescription?: string): string {

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -85,7 +85,7 @@ const agentGuardrailsSchema = z.object({
 const agentConfigSchema = z.object({
   id: z.string(),
   displayName: z.string().optional(),
-  role: z.enum(['architect', 'coder', 'reviewer', 'debugger', 'analyst', 'custom']).default('custom'),
+  role: z.enum(['architect', 'coder', 'reviewer', 'debugger', 'analyst', 'orchestrator', 'custom']).default('custom'),
   description: z.string().default(''),
   model: z.string(),
   systemPrompt: z.string().optional(),
@@ -102,7 +102,7 @@ const agentConfigSchema = z.object({
 
 const workflowStepConfigSchema = z.object({
   id: z.string(),
-  agentRole: z.enum(['architect', 'coder', 'reviewer', 'debugger', 'analyst', 'custom']),
+  agentRole: z.enum(['architect', 'coder', 'reviewer', 'debugger', 'analyst', 'orchestrator', 'custom']),
   agentId: z.string().optional(),
   description: z.string().default(''),
   inputArtifacts: z.array(z.string()).default([]),

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -168,7 +168,7 @@ export interface ToolDefinition {
 
 // ── Agent Profiles ──────────────────────────────────────────────────
 
-export type AgentRole = 'architect' | 'coder' | 'reviewer' | 'debugger' | 'analyst' | 'custom';
+export type AgentRole = 'architect' | 'coder' | 'reviewer' | 'debugger' | 'analyst' | 'orchestrator' | 'custom';
 export type AgentLifecycle = 'active' | 'suspended';
 
 export interface AgentGuardrails {


### PR DESCRIPTION
## Summary
- Orchestrator role added to complete the 5-agent DAG
- System prompt for workflow coordination
- Config schema updated

## PR #20 of 20 — THE FINAL PR

🧠 Brainstorm CLI v0.1.0 is complete.

**What we built:**
- 12 packages in a Turborepo monorepo
- 16 built-in tools (filesystem, shell, git, web)
- 5 agent roles (architect, coder, reviewer, debugger, orchestrator)
- 4 routing strategies (cost-first, quality-first, rule-based, combined)
- Multi-agent workflow engine with handoff/shared modes
- BrainstormRouter SaaS + direct provider + local Ollama support
- Permission model, checkpoints, context compaction, sessions
- Hooks, MCP, subagents, skills, memory, plan mode, CI/CD mode
- Security: credential scanner, .brainstormignore, path traversal guard
- Discovery caching, multimodal support, streaming markdown

Generated with [Claude Code](https://claude.ai/code)