### PR TITLE
feat: brainstorm eval CLI command + scorecard (PR #5)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,6 +23,7 @@
     "@brainstorm/tools": "*",
     "@brainstorm/agents": "*",
     "@brainstorm/workflow": "*",
+    "@brainstorm/eval": "*",
     "commander": "^13",
     "ink": "^5",
     "ink-text-input": "^6",

--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -9,6 +9,7 @@ import { AgentManager, parseAgentNL } from '@brainstorm/agents';
 import { runWorkflow, getPresetWorkflow, autoSelectPreset, PRESET_WORKFLOWS } from '@brainstorm/workflow';
 import { renderMarkdownToString } from '../components/MarkdownRenderer.js';
 import { runInit } from '../init/index.js';
+import { runEvalCli } from '@brainstorm/eval';
 
 const program = new Command();
 
@@ -24,6 +25,22 @@ program
   .option('--force', 'Overwrite existing files')
   .action(async (opts: { yes?: boolean; force?: boolean }) => {
     await runInit(process.cwd(), opts);
+  });
+
+program
+  .command('eval')
+  .description('Run capability evaluation probes against a model')
+  .option('--model <id>', 'Model to evaluate (e.g., anthropic/claude-sonnet-4-6)')
+  .option('--capability <dim>', 'Run only probes for this dimension')
+  .option('--compare', 'Compare results across all previously evaluated models')
+  .option('--timeout <ms>', 'Timeout per probe in milliseconds', '30000')
+  .action(async (opts: { model?: string; capability?: string; compare?: boolean; timeout?: string }) => {
+    await runEvalCli({
+      model: opts.model,
+      capability: opts.capability,
+      compare: opts.compare,
+      timeout: parseInt(opts.timeout ?? '30000'),
+    });
   });
 
 program

--- a/packages/eval/src/cli.ts
+++ b/packages/eval/src/cli.ts
@@ -1,0 +1,73 @@
+import { loadProbes, loadProbesByCapability } from './loader.js';
+import { runAllProbes } from './runner.js';
+import { saveEvalRun, buildScorecard, loadEvalRuns } from './storage.js';
+import { formatScorecard, formatComparison } from './scorecard.js';
+import type { CapabilityDimension } from './types.js';
+
+export interface EvalCliOptions {
+  model?: string;
+  capability?: string;
+  compare?: boolean;
+  timeout?: number;
+}
+
+/**
+ * Run the eval CLI command.
+ * Called from packages/cli/src/bin/brainstorm.ts.
+ */
+export async function runEvalCli(options: EvalCliOptions): Promise<void> {
+  // Compare mode: show existing results
+  if (options.compare) {
+    const runs = loadEvalRuns();
+    if (runs.length === 0) {
+      console.log('\n  No eval results found. Run `brainstorm eval` first.\n');
+      return;
+    }
+
+    // Get latest run per model
+    const latestByModel = new Map<string, typeof runs[0]>();
+    for (const run of runs) {
+      latestByModel.set(run.modelId, run);
+    }
+
+    const scorecards = [...latestByModel.values()].map(buildScorecard);
+    console.log(formatComparison(scorecards));
+    return;
+  }
+
+  // Load probes
+  let probes = options.capability
+    ? loadProbesByCapability(options.capability as CapabilityDimension)
+    : loadProbes();
+
+  if (probes.length === 0) {
+    console.log('\n  No probes found. Check packages/eval/probes/ directory.\n');
+    return;
+  }
+
+  const modelId = options.model ?? 'default';
+  console.log(`\n  Running ${probes.length} probes${modelId !== 'default' ? ` on ${modelId}` : ''}...\n`);
+
+  // Run probes
+  const results = await runAllProbes(probes, {
+    modelId,
+    defaultTimeout: options.timeout ?? 30000,
+  });
+
+  // Save and display
+  const run = saveEvalRun(modelId, results);
+  const scorecard = buildScorecard(run);
+  console.log(formatScorecard(scorecard));
+
+  // Show individual failures
+  const failures = results.filter((r) => !r.passed);
+  if (failures.length > 0) {
+    console.log(`  Failed probes (${failures.length}):\n`);
+    for (const f of failures) {
+      const failedChecks = f.checks.filter((c) => !c.passed);
+      console.log(`    ${f.probeId}: ${failedChecks.map((c) => c.detail ?? c.check).join('; ')}`);
+      if (f.error) console.log(`      Error: ${f.error}`);
+    }
+    console.log();
+  }
+}

--- a/packages/eval/src/index.ts
+++ b/packages/eval/src/index.ts
@@ -5,3 +5,5 @@ export { saveEvalRun, buildScorecard, loadEvalRuns, getLatestScorecard, EVAL_DIR
 export { loadProbes, loadProbesByCapability } from './loader.js';
 export { verifyTypeScriptCompiles } from './verifiers/typescript.js';
 export { runTestFile } from './verifiers/test-runner.js';
+export { formatScorecard, formatComparison } from './scorecard.js';
+export { runEvalCli, type EvalCliOptions } from './cli.js';

--- a/packages/eval/src/scorecard.ts
+++ b/packages/eval/src/scorecard.ts
@@ -1,0 +1,95 @@
+import type { CapabilityScorecard, CapabilityDimension } from './types.js';
+
+const DIMENSION_LABELS: Record<CapabilityDimension, string> = {
+  'tool-selection': 'Tool Selection',
+  'tool-sequencing': 'Tool Sequencing',
+  'code-correctness': 'Code Correctness',
+  'multi-step': 'Multi-Step',
+  'instruction-adherence': 'Instruction Adherence',
+  'context-utilization': 'Context Utilization',
+  'self-correction': 'Self-Correction',
+};
+
+/**
+ * Format a capability scorecard for terminal display.
+ */
+export function formatScorecard(scorecard: CapabilityScorecard): string {
+  const lines: string[] = [];
+  const modelName = scorecard.modelId;
+
+  lines.push('');
+  lines.push(`  Capability Scorecard: ${modelName}`);
+  lines.push('  ' + '─'.repeat(45));
+
+  const dimensions: CapabilityDimension[] = [
+    'tool-selection', 'tool-sequencing', 'code-correctness',
+    'multi-step', 'instruction-adherence', 'context-utilization', 'self-correction',
+  ];
+
+  for (const dim of dimensions) {
+    const data = scorecard.dimensions[dim];
+    if (!data || data.total === 0) continue;
+
+    const label = DIMENSION_LABELS[dim].padEnd(24);
+    const pct = Math.round(data.score * 100);
+    const bar = renderBar(data.score);
+    lines.push(`  ${label} ${data.passed}/${data.total} (${pct}%) ${bar}`);
+  }
+
+  lines.push('  ' + '─'.repeat(45));
+
+  const { overall } = scorecard;
+  const overallPct = Math.round(overall.score * 100);
+  lines.push(`  ${'Overall'.padEnd(24)} ${overall.passed}/${overall.total} (${overallPct}%)`);
+  lines.push(`  ${'Cost'.padEnd(24)} $${overall.cost.toFixed(4)}`);
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+/**
+ * Format a comparison table of multiple scorecards.
+ */
+export function formatComparison(scorecards: CapabilityScorecard[]): string {
+  if (scorecards.length === 0) return '  No eval results found.\n';
+
+  const lines: string[] = [];
+  const dimensions: CapabilityDimension[] = [
+    'tool-selection', 'tool-sequencing', 'code-correctness',
+    'multi-step', 'instruction-adherence', 'context-utilization', 'self-correction',
+  ];
+
+  // Header
+  const modelNames = scorecards.map((s) => s.modelId.split('/').pop() ?? s.modelId);
+  const colWidth = Math.max(12, ...modelNames.map((n) => n.length + 2));
+
+  lines.push('');
+  lines.push('  ' + ''.padEnd(24) + modelNames.map((n) => n.padStart(colWidth)).join(''));
+  lines.push('  ' + '─'.repeat(24 + colWidth * scorecards.length));
+
+  for (const dim of dimensions) {
+    const label = DIMENSION_LABELS[dim].padEnd(24);
+    const values = scorecards.map((sc) => {
+      const d = sc.dimensions[dim];
+      if (!d || d.total === 0) return '—'.padStart(colWidth);
+      return `${Math.round(d.score * 100)}%`.padStart(colWidth);
+    });
+    lines.push(`  ${label}${values.join('')}`);
+  }
+
+  lines.push('  ' + '─'.repeat(24 + colWidth * scorecards.length));
+
+  const overalls = scorecards.map((sc) => `${Math.round(sc.overall.score * 100)}%`.padStart(colWidth));
+  lines.push(`  ${'Overall'.padEnd(24)}${overalls.join('')}`);
+
+  const costs = scorecards.map((sc) => `$${sc.overall.cost.toFixed(3)}`.padStart(colWidth));
+  lines.push(`  ${'Cost'.padEnd(24)}${costs.join('')}`);
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+function renderBar(score: number): string {
+  const filled = Math.round(score * 10);
+  return '█'.repeat(filled) + '░'.repeat(10 - filled);
+}


### PR DESCRIPTION
## Summary

- `brainstorm eval --model <id>` runs 70 probes, outputs scored capability matrix
- `brainstorm eval --capability <dim>` runs probes for one dimension only
- `brainstorm eval --compare` shows comparison table across all evaluated models
- Terminal-formatted scorecard with per-dimension bar charts
- Displays individual failure details for debugging

Completes the eval harness (PRs 1-5).

## Test plan

- [x] 13 packages build clean
- [x] `brainstorm eval --help` shows correct usage

🤖 Generated with [Claude Code](https://claude.ai/code)