### PR TITLE
feat: cross-model workflow execution (PR #16)

### DIFF
--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -23,6 +23,8 @@ export interface AgentLoopOptions {
   projectPath: string;
   systemPrompt: string;
   disableTools?: boolean;
+  /** Override model selection — bypass the router. Used by cross-model workflows. */
+  preferredModelId?: string;
 }
 
 // Task types that should NOT get tools (pure text generation)
@@ -39,7 +41,9 @@ export async function* runAgentLoop(
   const userText = lastUserMsg?.content ?? '';
 
   const task = router.classify(userText);
-  const decision = router.route(task);
+  const decision = options.preferredModelId
+    ? { ...router.route(task), model: options.registry.getModel(options.preferredModelId) ?? router.route(task).model, reason: `Cross-model workflow override: ${options.preferredModelId}` }
+    : router.route(task);
 
   yield { type: 'routing', decision };
 

--- a/packages/workflow/src/engine.ts
+++ b/packages/workflow/src/engine.ts
@@ -20,6 +20,8 @@ export interface WorkflowEngineOptions {
   costTracker: CostTracker;
   agentManager: AgentManager;
   projectPath: string;
+  /** Per-step model overrides: stepId → modelId. Used for cross-model workflows. */
+  stepModelOverrides?: Record<string, string>;
 }
 
 export async function* runWorkflow(
@@ -118,6 +120,9 @@ export async function* runWorkflow(
       const sessionId = run.id;
       const systemPrompt = ctx.systemPrompt;
 
+      // Per-step model override for cross-model workflows
+      const stepModelId = options.stepModelOverrides?.[stepDef.id];
+
       for await (const event of runAgentLoop(ctx.messages, {
         config,
         registry,
@@ -128,6 +133,7 @@ export async function* runWorkflow(
         projectPath,
         systemPrompt,
         disableTools: !shouldUseTools(stepDef, agent),
+        ...(stepModelId ? { preferredModelId: stepModelId } : {}),
       })) {
         // Forward agent events as step progress
         yield { type: 'step-progress', stepId: stepDef.id, event };


### PR DESCRIPTION
## Summary

- `preferredModelId` in AgentLoopOptions bypasses router for specific model
- `stepModelOverrides` in WorkflowEngineOptions maps steps → models
- Each workflow step can use a different model independently

## Test plan

- [x] 13 packages build clean

🤖 Generated with [Claude Code](https://claude.ai/code)