### PR TITLE
feat: eval → routing feedback loop (PR #19)

### DIFF
--- a/packages/eval/src/cli.ts
+++ b/packages/eval/src/cli.ts
@@ -2,6 +2,7 @@ import { loadProbes, loadProbesByCapability } from './loader.js';
 import { runAllProbes } from './runner.js';
 import { saveEvalRun, buildScorecard, loadEvalRuns } from './storage.js';
 import { formatScorecard, formatComparison } from './scorecard.js';
+import { exportCapabilityScores } from './export.js';
 import type { CapabilityDimension } from './types.js';
 
 export interface EvalCliOptions {
@@ -54,8 +55,10 @@ export async function runEvalCli(options: EvalCliOptions): Promise<void> {
     defaultTimeout: options.timeout ?? 30000,
   });
 
-  // Save and display
+  // Save, export capability scores, and display
   const run = saveEvalRun(modelId, results);
+  const exportedScores = exportCapabilityScores(run);
+  console.log(`  Capability scores exported for ${modelId} (routing will use these next session)\n`);
   const scorecard = buildScorecard(run);
   console.log(formatScorecard(scorecard));
 

--- a/packages/providers/src/registry.ts
+++ b/packages/providers/src/registry.ts
@@ -1,5 +1,8 @@
 import type { BrainstormConfig } from '@brainstorm/config';
-import type { ModelEntry } from '@brainstorm/shared';
+import type { ModelEntry, CapabilityScores } from '@brainstorm/shared';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
 import { createOllamaProvider } from './local/ollama.js';
 import { createLMStudioProvider, createLlamaCppProvider } from './local/openai-compat.js';
 import { discoverLocalModels } from './local/discovery.js';
@@ -103,6 +106,15 @@ export async function createProviderRegistry(config: BrainstormConfig): Promise<
     }
   }
 
+  // Overlay eval-derived capability scores (from `brainstorm eval`)
+  const evalScores = loadEvalCapabilityScores();
+  for (const [modelId, entry] of Object.entries(evalScores)) {
+    const model = allModels.find((m) => m.id === modelId);
+    if (model) {
+      model.capabilities.capabilityScores = entry.scores;
+    }
+  }
+
   const registry: ProviderRegistry = {
     models: allModels,
     hasBrainstormSaaS,
@@ -146,4 +158,19 @@ export async function createProviderRegistry(config: BrainstormConfig): Promise<
   };
 
   return registry;
+}
+
+/**
+ * Load eval-derived capability scores from ~/.brainstorm/eval/capability-scores.json.
+ * These are written by `brainstorm eval` via @brainstorm/eval's exportCapabilityScores().
+ * Reading directly avoids a circular dependency (eval → providers → eval).
+ */
+function loadEvalCapabilityScores(): Record<string, { scores: CapabilityScores; evaluatedAt: number }> {
+  const scoresPath = join(homedir(), '.brainstorm', 'eval', 'capability-scores.json');
+  if (!existsSync(scoresPath)) return {};
+  try {
+    return JSON.parse(readFileSync(scoresPath, 'utf-8'));
+  } catch {
+    return {};
+  }
 }


### PR DESCRIPTION
## Summary

- Eval CLI auto-exports capability scores after each run
- Provider registry loads eval scores on startup, overlaying baselines
- Completes the eval → routing → improvement loop

## Test plan

- [x] 13 packages build clean

🤖 Generated with [Claude Code](https://claude.ai/code)