### PR TITLE
feat: brainstorm probe + enhanced run for autonomous testing

### DIFF
--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -367,7 +367,10 @@ program
   .argument('<prompt>', 'The prompt to send')
   .option('--json', 'Output structured JSON (for CI/CD pipelines)')
   .option('--pipe', 'Read from stdin if no prompt given')
-  .action(async (prompt: string, opts: { json?: boolean; pipe?: boolean }) => {
+  .option('--model <id>', 'Target a specific model (bypass routing)')
+  .option('--tools', 'Enable tool use (default: disabled)')
+  .option('--max-steps <n>', 'Maximum agentic steps (default: 1)', '1')
+  .action(async (prompt: string, opts: { json?: boolean; pipe?: boolean; model?: string; tools?: boolean; maxSteps?: string }) => {
     const config = loadConfig();
     const db = getDb();
     const registry = await createProviderRegistry(config);
@@ -387,7 +390,9 @@ program
     for await (const event of runAgentLoop(sessionManager.getHistory(), {
       config, registry, router, costTracker, tools,
       sessionId: session.id, projectPath, systemPrompt,
-      disableTools: true,
+      disableTools: !opts.tools,
+      ...(opts.model ? { preferredModelId: opts.model } : {}),
+      maxSteps: parseInt(opts.maxSteps ?? '1'),
     })) {
       switch (event.type) {
         case 'routing':
@@ -427,6 +432,93 @@ program
     if (fullResponse) {
       sessionManager.addAssistantMessage(fullResponse);
     }
+  });
+
+// ── Probe Command ─────────────────────────────────────────────────
+
+program
+  .command('probe')
+  .description('Run an ad-hoc eval probe with verification (for autonomous testing)')
+  .argument('<prompt>', 'The prompt to test')
+  .option('--model <id>', 'Target a specific model')
+  .option('--expect-tools <tools>', 'Comma-separated tool names that must be called')
+  .option('--expect-contains <strings>', 'Comma-separated strings that must appear in output')
+  .option('--expect-excludes <strings>', 'Comma-separated strings that must NOT appear')
+  .option('--min-steps <n>', 'Minimum number of agentic steps')
+  .option('--max-steps <n>', 'Maximum number of agentic steps', '10')
+  .option('--timeout <ms>', 'Timeout in milliseconds', '30000')
+  .option('--json', 'Output full ProbeResult as JSON')
+  .option('--setup-file <pairs...>', 'Setup files as path=content pairs')
+  .action(async (prompt: string, opts: any) => {
+    const { runProbe } = await import('@brainstorm/eval');
+
+    // Build Probe from CLI args
+    const probe: any = {
+      id: `adhoc-${Date.now().toString(36)}`,
+      capability: 'multi-step' as const,
+      prompt,
+      verify: {},
+      timeout_ms: parseInt(opts.timeout),
+    };
+
+    if (opts.expectTools) {
+      probe.verify.tool_calls_include = opts.expectTools.split(',').map((s: string) => s.trim());
+    }
+    if (opts.expectContains) {
+      probe.verify.answer_contains = opts.expectContains.split(',').map((s: string) => s.trim());
+    }
+    if (opts.expectExcludes) {
+      probe.verify.answer_excludes = opts.expectExcludes.split(',').map((s: string) => s.trim());
+    }
+    if (opts.minSteps) {
+      probe.verify.min_steps = parseInt(opts.minSteps);
+    }
+    if (opts.maxSteps) {
+      probe.verify.max_steps = parseInt(opts.maxSteps);
+    }
+
+    // Parse setup files: --setup-file "path=content" --setup-file "path2=content2"
+    if (opts.setupFile) {
+      probe.setup = { files: {} as Record<string, string> };
+      for (const pair of opts.setupFile) {
+        const eqIdx = pair.indexOf('=');
+        if (eqIdx > 0) {
+          probe.setup.files[pair.slice(0, eqIdx)] = pair.slice(eqIdx + 1);
+        }
+      }
+    }
+
+    const result = await runProbe(probe, {
+      modelId: opts.model,
+      maxSteps: parseInt(opts.maxSteps),
+      defaultTimeout: parseInt(opts.timeout),
+    });
+
+    if (opts.json) {
+      process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    } else {
+      const status = result.passed ? 'PASSED' : 'FAILED';
+      console.log(`\n  Probe: ${status}`);
+      console.log(`  Model: ${result.modelId}`);
+      console.log(`  Steps: ${result.steps}`);
+      console.log(`  Cost:  $${result.cost.toFixed(4)}`);
+      console.log(`  Time:  ${result.durationMs}ms`);
+      if (result.toolCalls.length > 0) {
+        console.log(`  Tools: ${result.toolCalls.map((t) => t.name).join(', ')}`);
+      }
+      if (!result.passed) {
+        const failures = result.checks.filter((c) => !c.passed);
+        console.log(`  Failures:`);
+        for (const f of failures) {
+          console.log(`    - ${f.check}: ${f.detail ?? 'failed'}`);
+        }
+      }
+      if (result.error) console.log(`  Error: ${result.error}`);
+      console.log(`  Output: ${result.output.slice(0, 200)}${result.output.length > 200 ? '...' : ''}`);
+      console.log();
+    }
+
+    process.exit(result.passed ? 0 : 1);
   });
 
 // ── Sessions Command ───────────────────────────────────────────────

--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -25,6 +25,8 @@ export interface AgentLoopOptions {
   disableTools?: boolean;
   /** Override model selection — bypass the router. Used by cross-model workflows. */
   preferredModelId?: string;
+  /** Override max agentic steps (default: config.general.maxSteps). */
+  maxSteps?: number;
 }
 
 // Task types that should NOT get tools (pure text generation)
@@ -63,7 +65,7 @@ export async function* runAgentLoop(
       messages: messages as any,
       ...(shouldUseTools ? { tools: tools.toAISDKTools() } : {}),
       ...(metadataHeader ? { headers: { 'x-br-metadata': metadataHeader } } : {}),
-      stopWhen: stepCountIs(shouldUseTools ? config.general.maxSteps : 1),
+      stopWhen: stepCountIs(shouldUseTools ? (options.maxSteps ?? config.general.maxSteps) : 1),
       onStepFinish: async ({ usage }: any) => {
         if (usage) {
           costTracker.record({

--- a/packages/eval/src/runner.ts
+++ b/packages/eval/src/runner.ts
@@ -20,6 +20,8 @@ export interface RunnerOptions {
   projectDir?: string;
   /** Timeout per probe in ms (default: 30000) */
   defaultTimeout?: number;
+  /** Override max agentic steps per probe */
+  maxSteps?: number;
 }
 
 /**
@@ -65,6 +67,8 @@ export async function runProbe(probe: Probe, options: RunnerOptions = {}): Promi
       for await (const event of runAgentLoop(sessionManager.getHistory(), {
         config, registry, router, costTracker, tools,
         sessionId: session.id, projectPath: projectDir, systemPrompt,
+        ...(options.modelId && options.modelId !== 'default' ? { preferredModelId: options.modelId } : {}),
+        ...(options.maxSteps ? { maxSteps: options.maxSteps } : {}),
       })) {
         switch (event.type) {
           case 'text-delta':


### PR DESCRIPTION
## Summary

- `brainstorm probe "prompt" --expect-tools X --json` — ad-hoc eval probe with verification
- `brainstorm run` enhanced: `--model`, `--tools`, `--max-steps` flags
- `AgentLoopOptions.maxSteps` for per-invocation step control
- Eval runner wires `preferredModelId` and `maxSteps` to agent loop

Enables Claude Code to autonomously drive brainstorm, test tool usage, compare models, and find regressions.

## Test plan

- [x] 13 packages build clean
- [x] `brainstorm probe --help` shows all options
- [x] `brainstorm run --help` shows new flags

🤖 Generated with [Claude Code](https://claude.ai/code)