### PR TITLE
feat: @brainstorm/gateway — typed BrainstormRouter API client

### DIFF
--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@brainstorm/gateway",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@brainstorm/shared": "*"
+  },
+  "devDependencies": {
+    "tsup": "^8",
+    "typescript": "^5.7"
+  }
+}

--- a/packages/gateway/src/client.ts
+++ b/packages/gateway/src/client.ts
@@ -1,0 +1,240 @@
+import { createLogger } from '@brainstorm/shared';
+import type {
+  GatewaySelf, GatewayDiscovery, GatewayModel, ModelLeaderboardEntry,
+  ApiKey, CreateKeyOptions, UsageSummary, DailyInsights, WasteInsights,
+  BudgetForecast, GovernanceSummary, AuditEntry, MemoryEntry,
+  GatewayAgentProfile,
+} from './types.js';
+
+const log = createLogger('gateway');
+
+/**
+ * BrainstormRouter gateway client.
+ * Typed wrapper around the BR REST API for brainstorm-specific operations.
+ */
+export class BrainstormGateway {
+  private baseUrl: string;
+  private apiKey: string;
+  private adminKey?: string;
+
+  constructor(options: { apiKey: string; adminKey?: string; baseUrl?: string }) {
+    this.apiKey = options.apiKey;
+    this.adminKey = options.adminKey;
+    this.baseUrl = options.baseUrl ?? 'https://api.brainstormrouter.com';
+  }
+
+  // ── Discovery ───────────────────────────────────────────────────────
+
+  async getSelf(): Promise<GatewaySelf> {
+    return this.get('/v1/self');
+  }
+
+  async getDiscovery(): Promise<GatewayDiscovery> {
+    return this.get('/v1/discovery');
+  }
+
+  async getHealth(): Promise<{ status: string }> {
+    return this.get('/health');
+  }
+
+  // ── Models ──────────────────────────────────────────────────────────
+
+  async listModels(): Promise<GatewayModel[]> {
+    const data = await this.get('/v1/models');
+    return data.data ?? data.models ?? data;
+  }
+
+  async getRunnableModels(): Promise<GatewayModel[]> {
+    const data = await this.get('/v1/catalog/runnable');
+    return data.data ?? data.models ?? data;
+  }
+
+  async getLeaderboard(): Promise<ModelLeaderboardEntry[]> {
+    const data = await this.get('/v1/models/leaderboard');
+    return data.data ?? data.rankings ?? data;
+  }
+
+  async setAlias(alias: string, modelId: string): Promise<void> {
+    await this.put(`/v1/config/aliases/${alias}`, { model: modelId });
+  }
+
+  // ── API Keys ────────────────────────────────────────────────────────
+
+  async listKeys(): Promise<ApiKey[]> {
+    const data = await this.get('/v1/api-keys', true);
+    return Array.isArray(data) ? data : data.keys ?? data.data ?? [];
+  }
+
+  async createKey(opts: CreateKeyOptions): Promise<ApiKey & { key: string }> {
+    return this.post('/v1/api-keys', {
+      name: opts.name,
+      prefix: 'br_live_',
+      scopes: opts.scopes ?? ['developer'],
+      allowed_models: opts.allowedModels,
+      rate_limit_rpm: opts.rateLimitRpm ?? 100,
+      budget_limit_usd: opts.budgetLimitUsd ?? 50,
+      budget_period: opts.budgetPeriod ?? 'monthly',
+    }, true);
+  }
+
+  // ── Config ──────────────────────────────────────────────────────────
+
+  async getConfig(key: string): Promise<any> {
+    const data = await this.get(`/v1/config/${key}`, true);
+    return data.data ?? data;
+  }
+
+  async setConfig(key: string, value: any): Promise<void> {
+    await this.put(`/v1/config/${key}`, value, true);
+  }
+
+  // ── Usage & Insights ────────────────────────────────────────────────
+
+  async getUsageSummary(period?: string): Promise<UsageSummary> {
+    const params = period ? `?period=${period}` : '';
+    return this.get(`/v1/usage/summary${params}`);
+  }
+
+  async getDailyInsights(): Promise<DailyInsights[]> {
+    const data = await this.get('/v1/insights/daily');
+    return data.data ?? data.insights ?? data;
+  }
+
+  async getWasteInsights(): Promise<WasteInsights> {
+    return this.get('/v1/insights/waste');
+  }
+
+  async getForecast(): Promise<BudgetForecast> {
+    return this.get('/v1/insights/forecast');
+  }
+
+  // ── Agents ──────────────────────────────────────────────────────────
+
+  async listAgentProfiles(): Promise<GatewayAgentProfile[]> {
+    const data = await this.get('/v1/agent/profiles');
+    return data.data ?? data.profiles ?? data;
+  }
+
+  // ── Memory ──────────────────────────────────────────────────────────
+
+  async storeMemory(block: string, content: string): Promise<void> {
+    await this.post('/v1/memory/entries', { block, content });
+  }
+
+  async queryMemory(query: string): Promise<MemoryEntry[]> {
+    const data = await this.post('/v1/memory/query', { query });
+    return data.results ?? data.entries ?? data;
+  }
+
+  async listMemory(): Promise<MemoryEntry[]> {
+    const data = await this.get('/v1/memory/entries');
+    return data.data ?? data.entries ?? data;
+  }
+
+  // ── Governance ──────────────────────────────────────────────────────
+
+  async getGovernanceSummary(): Promise<GovernanceSummary> {
+    return this.get('/v1/governance/summary');
+  }
+
+  async getCompletionAudit(since?: string): Promise<AuditEntry[]> {
+    const params = since ? `?since=${since}` : '';
+    const data = await this.get(`/v1/governance/completion-audit${params}`);
+    return data.data ?? data.entries ?? data;
+  }
+
+  // ── Capability Sync ─────────────────────────────────────────────────
+
+  async pushCapabilityScores(modelId: string, scores: Record<string, number>): Promise<any> {
+    return this.post(`/v1/models/${encodeURIComponent(modelId)}/capabilities`, {
+      source: 'brainstorm-eval',
+      version: '0.1.0',
+      evaluated_at: new Date().toISOString(),
+      scores,
+    });
+  }
+
+  // ── Outcome Feedback ────────────────────────────────────────────────
+
+  async reportOutcome(requestId: string, outcome: {
+    success: boolean;
+    codeCompiled?: boolean;
+    testsPassed?: boolean;
+    error?: string;
+    taskType?: string;
+    modelUsed?: string;
+    cost?: number;
+    toolCalls?: string[];
+  }): Promise<any> {
+    return this.post(`/v1/feedback/${requestId}`, {
+      outcome: outcome.success ? 'success' : 'failure',
+      signals: {
+        code_compiled: outcome.codeCompiled,
+        tests_passed: outcome.testsPassed,
+      },
+      error: outcome.error,
+      task_profile: outcome.taskType ? { type: outcome.taskType } : undefined,
+      model_used: outcome.modelUsed,
+      cost_actual: outcome.cost,
+      tool_calls: outcome.toolCalls,
+    });
+  }
+
+  // ── HTTP Helpers ────────────────────────────────────────────────────
+
+  private async get(path: string, useAdmin = false): Promise<any> {
+    return this.request('GET', path, undefined, useAdmin);
+  }
+
+  private async post(path: string, body: any, useAdmin = false): Promise<any> {
+    return this.request('POST', path, body, useAdmin);
+  }
+
+  private async put(path: string, body: any, useAdmin = false): Promise<any> {
+    return this.request('PUT', path, body, useAdmin);
+  }
+
+  private async request(method: string, path: string, body?: any, useAdmin = false): Promise<any> {
+    const key = useAdmin && this.adminKey ? this.adminKey : this.apiKey;
+    const url = `${this.baseUrl}${path}`;
+
+    try {
+      const response = await fetch(url, {
+        method,
+        headers: {
+          'Authorization': `Bearer ${key}`,
+          ...(body ? { 'Content-Type': 'application/json' } : {}),
+        },
+        ...(body ? { body: JSON.stringify(body) } : {}),
+      });
+
+      const data = await response.json() as any;
+
+      if (!response.ok) {
+        const msg = data?.error?.message ?? `HTTP ${response.status}`;
+        log.warn({ method, path, status: response.status, error: msg }, 'Gateway request failed');
+        throw new Error(`Gateway ${method} ${path}: ${msg}`);
+      }
+
+      return data;
+    } catch (error: any) {
+      if (error.message?.startsWith('Gateway ')) throw error;
+      log.warn({ method, path, err: error }, 'Gateway request error');
+      throw new Error(`Gateway ${method} ${path}: ${error.message}`);
+    }
+  }
+}
+
+/**
+ * Create a gateway client from environment variables.
+ */
+export function createGatewayClient(): BrainstormGateway | null {
+  const apiKey = process.env.BRAINSTORM_API_KEY;
+  if (!apiKey) return null;
+
+  return new BrainstormGateway({
+    apiKey,
+    adminKey: process.env.BRAINSTORM_ADMIN_KEY,
+    baseUrl: process.env.BRAINSTORM_GATEWAY_URL,
+  });
+}

--- a/packages/gateway/src/headers.ts
+++ b/packages/gateway/src/headers.ts
@@ -1,0 +1,48 @@
+import type { GatewayFeedback } from './types.js';
+
+/**
+ * Parse BrainstormRouter response headers into structured feedback.
+ * These headers are returned on every completion request.
+ */
+export function parseGatewayHeaders(headers: Record<string, string>): GatewayFeedback {
+  const feedback: GatewayFeedback = {};
+
+  const budgetRemaining = headers['x-budget-remaining'] ?? headers['x-br-budget-remaining'];
+  if (budgetRemaining) feedback.budgetRemaining = parseFloat(budgetRemaining);
+
+  const guardianStatus = headers['x-br-guardian-status'] ?? headers['x-br-guardrail-status'];
+  if (guardianStatus) feedback.guardianStatus = guardianStatus;
+
+  const estimatedCost = headers['x-br-estimated-cost'];
+  if (estimatedCost) feedback.actualCost = parseFloat(estimatedCost);
+
+  const requestId = headers['x-request-id'];
+  if (requestId) feedback.requestId = requestId;
+
+  const selectedModel = headers['x-br-model-selected'];
+  if (selectedModel) feedback.selectedModel = selectedModel;
+
+  return feedback;
+}
+
+/**
+ * Format gateway feedback for display in the CLI.
+ */
+export function formatGatewayFeedback(feedback: GatewayFeedback): string {
+  const parts: string[] = [];
+
+  if (feedback.budgetRemaining !== undefined) {
+    parts.push(`Budget: $${feedback.budgetRemaining.toFixed(2)}`);
+  }
+  if (feedback.guardianStatus) {
+    parts.push(`Guardian: ${feedback.guardianStatus}`);
+  }
+  if (feedback.actualCost !== undefined) {
+    parts.push(`Cost: $${feedback.actualCost.toFixed(4)}`);
+  }
+  if (feedback.selectedModel) {
+    parts.push(`Model: ${feedback.selectedModel}`);
+  }
+
+  return parts.length > 0 ? parts.join(' | ') : '';
+}

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -1,0 +1,3 @@
+export { BrainstormGateway, createGatewayClient } from './client.js';
+export { parseGatewayHeaders, formatGatewayFeedback } from './headers.js';
+export * from './types.js';

--- a/packages/gateway/src/types.ts
+++ b/packages/gateway/src/types.ts
@@ -1,0 +1,151 @@
+// ── Gateway Identity ─────────────────────────────────────────────────
+
+export interface GatewaySelf {
+  identity: {
+    tenant_id: string;
+    auth_method: string;
+    key_id: string;
+    agent_id: string | null;
+    roles: string[];
+    scopes: string[];
+  };
+  capabilities: {
+    granted: string[];
+  };
+}
+
+// ── Models ───────────────────────────────────────────────────────────
+
+export interface GatewayModel {
+  id: string;
+  name: string;
+  provider: string;
+  pricing?: { input: number; output: number };
+  context_window?: number;
+  capabilities?: string[];
+}
+
+export interface ModelLeaderboardEntry {
+  model: string;
+  provider: string;
+  quality_rank: number;
+  speed_rank: number;
+  value_rank: number;
+  request_count: number;
+  avg_latency_ms: number;
+}
+
+// ── API Keys ─────────────────────────────────────────────────────────
+
+export interface ApiKey {
+  id: string;
+  name: string;
+  prefix: string;
+  scopes: string[];
+  allowedModels: string[] | null;
+  rateLimitRpm: number;
+  budgetLimitUsd: number;
+  budgetPeriod: string;
+  expiresAt: string | null;
+  createdAt: string;
+}
+
+export interface CreateKeyOptions {
+  name: string;
+  scopes?: string[];
+  allowedModels?: string[];
+  rateLimitRpm?: number;
+  budgetLimitUsd?: number;
+  budgetPeriod?: string;
+}
+
+// ── Usage & Insights ─────────────────────────────────────────────────
+
+export interface UsageSummary {
+  period: string;
+  total_requests: number;
+  total_cost_usd: number;
+  total_input_tokens: number;
+  total_output_tokens: number;
+  by_model: Array<{ model: string; requests: number; cost_usd: number }>;
+}
+
+export interface DailyInsights {
+  date: string;
+  cost_usd: number;
+  request_count: number;
+  avg_latency_ms: number;
+  top_models: Array<{ model: string; cost_usd: number }>;
+}
+
+export interface WasteInsights {
+  total_waste_usd: number;
+  suggestions: Array<{ description: string; savings_usd: number; action: string }>;
+}
+
+export interface BudgetForecast {
+  current_spend_usd: number;
+  budget_limit_usd: number;
+  projected_end_of_period_usd: number;
+  will_exceed: boolean;
+  days_remaining: number;
+}
+
+// ── Governance ───────────────────────────────────────────────────────
+
+export interface GovernanceSummary {
+  memory_health: { total_entries: number; compliance_status: string };
+  audit_stats: { total_requests: number; flagged: number };
+  anomaly_score: number;
+}
+
+export interface AuditEntry {
+  request_id: string;
+  timestamp: string;
+  model: string;
+  cost_usd: number;
+  latency_ms: number;
+  guardian_status: string;
+}
+
+// ── Memory ───────────────────────────────────────────────────────────
+
+export interface MemoryEntry {
+  id: string;
+  block: string;
+  content: string;
+  created_at: string;
+}
+
+// ── Agent Profiles ───────────────────────────────────────────────────
+
+export interface GatewayAgentProfile {
+  id: string;
+  name: string;
+  role: string;
+  model: string;
+  status: string;
+  budget_remaining: number;
+}
+
+// ── Response Headers ─────────────────────────────────────────────────
+
+export interface GatewayFeedback {
+  budgetRemaining?: number;
+  guardianStatus?: string;
+  routingDecision?: string;
+  actualCost?: number;
+  cacheHit?: boolean;
+  complexityScore?: number;
+  selectedModel?: string;
+  requestId?: string;
+}
+
+// ── Discovery ────────────────────────────────────────────────────────
+
+export interface GatewayDiscovery {
+  health: string;
+  budget: { remaining_usd: number; limit_usd: number; period: string };
+  models: { available: number; runnable: number };
+  capabilities: string[];
+}

--- a/packages/gateway/tsconfig.json
+++ b/packages/gateway/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/gateway/tsup.config.ts
+++ b/packages/gateway/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+});


### PR DESCRIPTION
## Summary

New `@brainstorm/gateway` package — 14th in the monorepo. Typed wrapper around BR's REST API.

Verified live against api.brainstormrouter.com:
- 304 models listed
- 7 API keys retrieved
- Health: ok (db + redis up)
- Memory: 1 entry accessible

Foundation for: CLI router commands, response header extraction, cost reconciliation, capability score push, outcome feedback loop.

## Test plan

- [x] 14 packages build clean
- [x] Live test against BR gateway

🤖 Generated with [Claude Code](https://claude.ai/code)