### PR TITLE
feat: decision authority from STORM.md — stronger constraints (PR #10)

### DIFF
--- a/packages/core/src/agent/context.ts
+++ b/packages/core/src/agent/context.ts
@@ -87,12 +87,32 @@ export function buildSystemPrompt(projectPath: string): SystemPromptResult {
 
     const protectedAreas = extractSection(storm.body, "Don't touch");
     if (protectedAreas) {
-      parts.push(`\n## Protected Areas\n\nDo NOT modify these files without asking the user first:\n${protectedAreas}`);
+      parts.push(`\n## Protected Areas\n\nThese files are off-limits. Do NOT modify them without explicit user approval:\n${protectedAreas}\nIf a task requires changes to a protected file, explain WHY and ask before proceeding.`);
     }
 
     const conventions = extractSection(storm.body, 'Conventions');
     if (conventions) {
-      parts.push(`\n## Code Patterns\n\nAlways follow these patterns when writing code in this project:\n${conventions}`);
+      const codeExamples = extractCodeBlocks(conventions);
+      parts.push(`\n## Code Patterns (MANDATORY)\n\nAlways follow these patterns when writing code in this project:\n${conventions}`);
+      if (codeExamples.length > 0) {
+        parts.push(`\nReference examples — match this style exactly:\n${codeExamples.join('\n')}`);
+      }
+    }
+
+    // Additional decision-relevant sections
+    const architecture = extractSection(storm.body, 'Architecture');
+    if (architecture) {
+      parts.push(`\n## Architecture Constraints\n\nRespect these architectural decisions when making changes:\n${architecture}`);
+    }
+
+    const stack = extractSection(storm.body, 'Stack');
+    if (stack) {
+      parts.push(`\n## Stack\n\n${stack}`);
+    }
+
+    const dependencies = extractSection(storm.body, 'Dependencies');
+    if (dependencies) {
+      parts.push(`\n## Dependency Rules\n\nFollow these dependency guidelines:\n${dependencies}`);
     }
   }
 
@@ -133,6 +153,23 @@ function extractSection(body: string, heading: string): string | null {
   // Skip sections that only contain placeholder comments
   if (!trimmed || trimmed.startsWith('<!--') && trimmed.endsWith('-->')) return null;
   return trimmed;
+}
+
+/**
+ * Extract fenced code blocks from a markdown section.
+ * These become explicit "match this style" examples in the system prompt.
+ */
+function extractCodeBlocks(section: string): string[] {
+  const blocks: string[] = [];
+  const pattern = /```[\w]*\n([\s\S]*?)```/g;
+  let match;
+  while ((match = pattern.exec(section)) !== null) {
+    const block = match[0].trim();
+    if (block.length > 10 && block.length < 2000) {
+      blocks.push(block);
+    }
+  }
+  return blocks;
 }
 
 function getGitContext(projectPath: string): string | null {


### PR DESCRIPTION
## Summary
- Protected Areas section now requires explicit user approval with justification before modifications
- Conventions section extracts fenced code blocks as mandatory "match this style" examples
- New section extraction: Architecture, Stack, Dependencies — all injected as system prompt constraints
- Code patterns section marked MANDATORY (not just guidance)

Phase 2 plan item: PR #10 — Decision authority from STORM.md

## Test plan
- [ ] Create a STORM.md with "Don't touch" section listing files → verify model asks before editing them
- [ ] Add a Conventions section with code examples → verify model matches the pattern
- [ ] Add Architecture section → verify it appears in the system prompt
- [ ] Build passes: `npx turbo run build --filter=@brainstorm/core --force`

🤖 Generated with [Claude Code](https://claude.com/claude-code)