### PR TITLE
feat: insight system — teach as you work (PR #12)

### DIFF
--- a/packages/core/src/agent/context.ts
+++ b/packages/core/src/agent/context.ts
@@ -2,6 +2,7 @@ import { loadStormFile, type StormFrontmatter } from '@brainstorm/config';
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
+import { INSIGHT_PROMPT_SECTION } from './insights.js';
 
 const DEFAULT_SYSTEM_PROMPT = `You are Brainstorm, an AI coding assistant with intelligent model routing. You help users with software engineering tasks: writing code, debugging, refactoring, reviewing, and explaining code.
 
@@ -60,9 +61,7 @@ Only report failure to the user after 2 unsuccessful alternative approaches.
 - Ask before destructive operations: deleting files, dropping tables, force-pushing.
 - When uncertain about the impact of a change, explain the risk and ask.
 
-# Teaching
-
-After completing a significant action (fixing a bug, making an architecture decision), briefly share ONE non-obvious insight about your choice. Keep it to 2-3 sentences. Skip this for trivial actions.`;
+${INSIGHT_PROMPT_SECTION}`;
 
 export interface SystemPromptResult {
   prompt: string;

--- a/packages/core/src/agent/insights.ts
+++ b/packages/core/src/agent/insights.ts
@@ -1,0 +1,34 @@
+/**
+ * Insight system — normalizes the model's teaching annotations into
+ * a consistent format for TUI rendering.
+ *
+ * The model is instructed to emit insights via the system prompt.
+ * This module provides the prompt section and a lightweight post-processor
+ * that ensures consistent formatting (★ Insight: prefix).
+ */
+
+/** The system prompt section that instructs the model to teach as it works. */
+export const INSIGHT_PROMPT_SECTION = `# Teaching
+
+After completing a significant action (fixing a bug, making an architecture decision, choosing between approaches), briefly share ONE non-obvious insight about your choice. Format as:
+
+★ Insight: [your observation in 2-3 sentences]
+
+Guidelines:
+- Only for non-obvious choices — skip trivial actions like reading a file or running a command.
+- Focus on WHY you made a choice, not WHAT you did.
+- One insight per significant action, not per response.
+- Keep it genuinely useful — not filler like "TypeScript is great for type safety."`;
+
+/**
+ * Normalize insight markers in streamed text.
+ * Catches common model variations and standardizes to "★ Insight:".
+ */
+export function normalizeInsightMarkers(text: string): string {
+  // Standardize common variations the model might produce
+  return text
+    .replace(/\*\*Insight\*\*:/g, '★ Insight:')
+    .replace(/💡\s*Insight:/g, '★ Insight:')
+    .replace(/🔍\s*Insight:/g, '★ Insight:')
+    .replace(/\*\*★ Insight:\*\*/g, '★ Insight:');
+}

--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -8,6 +8,7 @@ import { setTaskEventHandler } from '@brainstorm/tools';
 import type { AgentEvent, AgentTask, GatewayFeedbackData } from '@brainstorm/shared';
 import { serializeRoutingMetadata } from '@brainstorm/shared';
 import { createStreamFilter } from './response-filter.js';
+import { normalizeInsightMarkers } from './insights.js';
 import { parseGatewayHeaders } from '@brainstorm/gateway';
 
 // Suppress AI SDK warnings in non-debug mode
@@ -97,7 +98,7 @@ export async function* runAgentLoop(
       if (part.type === 'text-delta') {
         const raw = (part as any).text ?? (part as any).delta ?? '';
         const filtered = streamFilter.filter(raw);
-        if (filtered) yield { type: 'text-delta', delta: filtered };
+        if (filtered) yield { type: 'text-delta', delta: normalizeInsightMarkers(filtered) };
       } else if (part.type === 'tool-call') {
         yield { type: 'tool-call-start', toolName: part.toolName, args: (part as any).input ?? (part as any).args };
       } else if (part.type === 'tool-result') {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,3 +12,4 @@ export { loadIgnorePatterns, isIgnored } from './security/ignore.js';
 export { scanForCredentials, redactCredentials, type ScanResult } from './security/secret-scanner.js';
 export { resolveSafe, isWithinWorkspace, PathTraversalError } from './security/path-guard.js';
 export { filterResponse, createStreamFilter, type StreamFilter } from './agent/response-filter.js';
+export { normalizeInsightMarkers, INSIGHT_PROMPT_SECTION } from './agent/insights.js';


### PR DESCRIPTION
## Summary
- New `insights.ts` module with centralized `INSIGHT_PROMPT_SECTION` and `normalizeInsightMarkers`
- System prompt now instructs ★ Insight: format with WHY-focused guidelines
- Post-processor normalizes model variations (bold, emoji) to consistent ★ prefix
- Wired into the stream pipeline and exported from @brainstorm/core

Phase 2 plan item: PR #12 — Teach as you work (insight system)

## Test plan
- [ ] Complete a multi-step task, observe 1-2 ★ Insight annotations in output
- [ ] Verify insights focus on WHY not WHAT
- [ ] Verify no insights on trivial actions (file reads, simple commands)
- [ ] Build passes: `npx turbo run build --force` (14/14 packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)