### PR TITLE
fix: address 5 code review findings from Phase 2 PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Turborepo monorepo with 12 TypeScript packages:
 - `packages/db` — better-sqlite3 persistence (sessions, messages, cost_records, agent_profiles, workflow_runs), auto-migrations
 - `packages/providers` — AI Gateway + BrainstormRouter SaaS (cloud) + Ollama/LM Studio/llama.cpp (local), auto-discovery with caching
 - `packages/router` — BrainstormRouter: heuristic task classifier, 4 routing strategies, CostTracker, fallback chain
-- `packages/tools` — 16 built-in tools (filesystem 7, shell 3, git 4, web 2) with permission levels + checkpoint system
+- `packages/tools` — 19 built-in tools (filesystem 7, shell 3, git 4, web 2, tasks 3) with permission levels + checkpoint system
 - `packages/core` — Agentic loop, SessionManager, PermissionManager, context compaction, @-mentions, skills, memory, plan mode, multimodal, security (path guard, credential scanner, .brainstormignore)
 - `packages/agents` — Agent profiles, NL parser, role prompts, Zod output schemas, TOML+SQLite merge
 - `packages/workflow` — Workflow engine state machine, context filtering, confidence/escalation, 4 preset workflows

--- a/packages/cli/src/components/ChatApp.tsx
+++ b/packages/cli/src/components/ChatApp.tsx
@@ -35,6 +35,7 @@ export function ChatApp({ strategy, modelCount, onSendMessage }: ChatAppProps) {
     setMessages((prev) => [...prev, { role: 'user', content: text.trim() }]);
     setIsProcessing(true);
     setStreamingText('');
+    setTasks([]);
 
     let fullResponse = '';
     let model: string | undefined;

--- a/packages/core/src/agent/context.ts
+++ b/packages/core/src/agent/context.ts
@@ -91,11 +91,7 @@ export function buildSystemPrompt(projectPath: string): SystemPromptResult {
 
     const conventions = extractSection(storm.body, 'Conventions');
     if (conventions) {
-      const codeExamples = extractCodeBlocks(conventions);
-      parts.push(`\n## Code Patterns (MANDATORY)\n\nAlways follow these patterns when writing code in this project:\n${conventions}`);
-      if (codeExamples.length > 0) {
-        parts.push(`\nReference examples — match this style exactly:\n${codeExamples.join('\n')}`);
-      }
+      parts.push(`\n## Code Patterns (MANDATORY)\n\nAlways follow these patterns when writing code in this project. Any code blocks below are reference examples — match this style exactly:\n${conventions}`);
     }
 
     // Additional decision-relevant sections
@@ -152,23 +148,6 @@ function extractSection(body: string, heading: string): string | null {
   // Skip sections that only contain placeholder comments
   if (!trimmed || trimmed.startsWith('<!--') && trimmed.endsWith('-->')) return null;
   return trimmed;
-}
-
-/**
- * Extract fenced code blocks from a markdown section.
- * These become explicit "match this style" examples in the system prompt.
- */
-function extractCodeBlocks(section: string): string[] {
-  const blocks: string[] = [];
-  const pattern = /```[\w]*\n([\s\S]*?)```/g;
-  let match;
-  while ((match = pattern.exec(section)) !== null) {
-    const block = match[0].trim();
-    if (block.length > 10 && block.length < 2000) {
-      blocks.push(block);
-    }
-  }
-  return blocks;
 }
 
 function getGitContext(projectPath: string): string | null {

--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -4,8 +4,8 @@ import type { BrainstormConfig } from '@brainstorm/config';
 import type { ProviderRegistry } from '@brainstorm/providers';
 import { BrainstormRouter, CostTracker } from '@brainstorm/router';
 import type { ToolRegistry } from '@brainstorm/tools';
-import { setTaskEventHandler } from '@brainstorm/tools';
-import type { AgentEvent, AgentTask, GatewayFeedbackData } from '@brainstorm/shared';
+import { setTaskEventHandler, clearTasks } from '@brainstorm/tools';
+import type { AgentEvent, GatewayFeedbackData } from '@brainstorm/shared';
 import { serializeRoutingMetadata } from '@brainstorm/shared';
 import { createStreamFilter } from './response-filter.js';
 import { normalizeInsightMarkers } from './insights.js';
@@ -41,7 +41,8 @@ export async function* runAgentLoop(
 ): AsyncGenerator<AgentEvent> {
   const { router, costTracker, tools, config, sessionId, systemPrompt } = options;
 
-  // Wire task event handler so task_create/task_update yield events to the TUI
+  // Reset task state and wire event handler for this invocation
+  clearTasks();
   const taskEventQueue: AgentEvent[] = [];
   setTaskEventHandler((type, task) => {
     taskEventQueue.push({ type, task } as AgentEvent);
@@ -112,7 +113,7 @@ export async function* runAgentLoop(
 
     // Flush any remaining buffered content (critical for short responses < 80 chars)
     const remaining = streamFilter.flush();
-    if (remaining) yield { type: 'text-delta', delta: remaining };
+    if (remaining) yield { type: 'text-delta', delta: normalizeInsightMarkers(remaining) };
 
     // Extract gateway response headers (X-BR-*) for cost reconciliation and telemetry
     try {
@@ -136,5 +137,7 @@ export async function* runAgentLoop(
   } catch (error: any) {
     router.recordFailure(decision.model.id, error.message);
     yield { type: 'error', error };
+  } finally {
+    setTaskEventHandler(null);
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,4 +12,4 @@ export { loadIgnorePatterns, isIgnored } from './security/ignore.js';
 export { scanForCredentials, redactCredentials, type ScanResult } from './security/secret-scanner.js';
 export { resolveSafe, isWithinWorkspace, PathTraversalError } from './security/path-guard.js';
 export { filterResponse, createStreamFilter, type StreamFilter } from './agent/response-filter.js';
-export { normalizeInsightMarkers, INSIGHT_PROMPT_SECTION } from './agent/insights.js';
+export { normalizeInsightMarkers } from './agent/insights.js';


### PR DESCRIPTION
## Summary
Fixes all 5 issues flagged in the [code review](https://github.com/justinjilg/brainstorm/pull/45#issuecomment-4119532906) of PRs #44-47:

- **clearTasks() never called**: Now called at start of each `runAgentLoop`; handler nulled in `finally` block
- **Tasks state not reset in ChatApp**: Added `setTasks([])` at start of `handleSubmit`, matching existing `setStreamingText('')` pattern
- **normalizeInsightMarkers skipped on flush()**: Applied to both stream and flush paths
- **Duplicate code blocks in system prompt**: Removed `extractCodeBlocks` — conventions text already contains them
- **CLAUDE.md tool count stale**: Updated 16 → 19 (tasks 3)

Also removed unused `INSIGHT_PROMPT_SECTION` from public API (internal-only).

Net: -17 lines (removed dead code, fixed bugs, no new features).

## Test plan
- [ ] Multi-turn chat: verify tasks from turn 1 don't appear in turn 2
- [ ] Ctrl-C during stream: verify no stale handler errors on next message
- [ ] Short response with insight: verify ★ Insight: format is normalized
- [ ] STORM.md with Conventions code blocks: verify they appear once, not twice
- [ ] Build passes: `npx turbo run build --force` (14/14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)