### PR TITLE
feat: vault crypto primitives — AES-256-GCM + Argon2id (Vault PR #1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -361,6 +361,10 @@
       "resolved": "packages/tools",
       "link": true
     },
+    "node_modules/@brainstorm/vault": {
+      "resolved": "packages/vault",
+      "link": true
+    },
     "node_modules/@brainstorm/workflow": {
       "resolved": "packages/workflow",
       "link": true
@@ -850,6 +854,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -4167,6 +4183,7 @@
         "@brainstorm/db": "*",
         "@brainstorm/eval": "*",
         "@brainstorm/gateway": "*",
+        "@brainstorm/mcp": "*",
         "@brainstorm/providers": "*",
         "@brainstorm/router": "*",
         "@brainstorm/shared": "*",
@@ -4209,6 +4226,7 @@
       "dependencies": {
         "@brainstorm/config": "*",
         "@brainstorm/db": "*",
+        "@brainstorm/gateway": "*",
         "@brainstorm/providers": "*",
         "@brainstorm/router": "*",
         "@brainstorm/shared": "*",
@@ -4240,6 +4258,7 @@
         "@brainstorm/config": "*",
         "@brainstorm/core": "*",
         "@brainstorm/db": "*",
+        "@brainstorm/gateway": "*",
         "@brainstorm/providers": "*",
         "@brainstorm/router": "*",
         "@brainstorm/shared": "*",
@@ -4337,6 +4356,17 @@
         "ai": "^6",
         "fast-glob": "^3",
         "zod": "^3"
+      },
+      "devDependencies": {
+        "tsup": "^8",
+        "typescript": "^5.7"
+      }
+    },
+    "packages/vault": {
+      "name": "@brainstorm/vault",
+      "version": "0.1.0",
+      "dependencies": {
+        "@noble/hashes": "^1"
       },
       "devDependencies": {
         "tsup": "^8",

--- a/packages/vault/package.json
+++ b/packages/vault/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@brainstorm/vault",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@noble/hashes": "^1"
+  },
+  "devDependencies": {
+    "tsup": "^8",
+    "typescript": "^5.7"
+  }
+}

--- a/packages/vault/src/crypto.ts
+++ b/packages/vault/src/crypto.ts
@@ -1,0 +1,43 @@
+import { argon2id } from '@noble/hashes/argon2';
+import { randomBytes, createCipheriv, createDecipheriv } from 'node:crypto';
+import type { EncryptResult } from './types.js';
+
+/** Default Argon2id parameters — OWASP recommended for interactive login. */
+export const KDF_PARAMS = {
+  memory: 65536,    // 64 MB
+  iterations: 3,
+  parallelism: 4,
+  keyLength: 32,    // 256 bits for AES-256
+} as const;
+
+/** Derive a 256-bit key from a password using Argon2id. */
+export function deriveKey(password: string, salt: Uint8Array): Buffer {
+  const derived = argon2id(new TextEncoder().encode(password), salt, {
+    m: KDF_PARAMS.memory,
+    t: KDF_PARAMS.iterations,
+    p: KDF_PARAMS.parallelism,
+    dkLen: KDF_PARAMS.keyLength,
+  });
+  return Buffer.from(derived);
+}
+
+/** Generate a cryptographically random salt (32 bytes). */
+export function generateSalt(): Buffer {
+  return randomBytes(32);
+}
+
+/** Encrypt plaintext with AES-256-GCM. */
+export function encrypt(key: Buffer, plaintext: Buffer): EncryptResult {
+  const nonce = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', key, nonce);
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return { nonce, ciphertext, tag };
+}
+
+/** Decrypt ciphertext with AES-256-GCM. Throws on tampered data. */
+export function decrypt(key: Buffer, nonce: Buffer, ciphertext: Buffer, tag: Buffer): Buffer {
+  const decipher = createDecipheriv('aes-256-gcm', key, nonce);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+}

--- a/packages/vault/src/index.ts
+++ b/packages/vault/src/index.ts
@@ -1,0 +1,2 @@
+export { deriveKey, generateSalt, encrypt, decrypt, KDF_PARAMS } from './crypto.js';
+export type { VaultFile, VaultPayload, VaultConfig, EncryptResult } from './types.js';

--- a/packages/vault/src/types.ts
+++ b/packages/vault/src/types.ts
@@ -1,0 +1,37 @@
+/** On-disk vault file format (JSON). */
+export interface VaultFile {
+  version: 1;
+  kdf: 'argon2id';
+  kdf_params: {
+    memory: number;   // KiB (65536 = 64 MB)
+    iterations: number;
+    parallelism: number;
+  };
+  salt: string;       // base64, 32 bytes
+  nonce: string;      // base64, 12 bytes
+  ciphertext: string; // base64, encrypted JSON payload
+  tag: string;        // base64, 16 bytes (GCM auth tag)
+}
+
+/** Decrypted vault payload. */
+export interface VaultPayload {
+  keys: Record<string, string>;
+  metadata: {
+    created_at: string;
+    last_accessed: string;
+    key_count: number;
+  };
+}
+
+/** Vault configuration from config.toml. */
+export interface VaultConfig {
+  path: string;                // default: ~/.brainstorm/vault.enc
+  auto_lock_minutes: number;   // default: 30, 0 = disabled
+}
+
+/** Result of an encrypt operation. */
+export interface EncryptResult {
+  nonce: Buffer;
+  ciphertext: Buffer;
+  tag: Buffer;
+}

--- a/packages/vault/tsconfig.json
+++ b/packages/vault/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/vault/tsup.config.ts
+++ b/packages/vault/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+});


### PR DESCRIPTION
## Summary
- New `@brainstorm/vault` package (14th in the monorepo)
- AES-256-GCM encrypt/decrypt + Argon2id KDF via `@noble/hashes` (pure JS, audited, zero native deps)
- Typed vault file format (`VaultFile`, `VaultPayload`) — versioned for future ML-KEM upgrade
- OWASP-recommended params: 64MB memory, 3 iterations, 4 parallelism lanes

From plan: `synchronous-tickling-blossom.md` — Encrypted Key Manager for Brainstorm CLI

## Test plan
- [ ] `npx turbo run build --filter=@brainstorm/vault` passes
- [ ] `deriveKey()` produces consistent 32-byte output for same password+salt
- [ ] `encrypt()` → `decrypt()` round-trips correctly
- [ ] Tampered ciphertext throws on `decrypt()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)