### PR TITLE
feat: key resolver + backends — vault/1Password/env chain (Vault PR #3)

### DIFF
--- a/packages/vault/src/backends/env.ts
+++ b/packages/vault/src/backends/env.ts
@@ -1,0 +1,4 @@
+/** Read a key from environment variables. */
+export function envRead(keyName: string): string | null {
+  return process.env[keyName] ?? null;
+}

--- a/packages/vault/src/backends/op-cli.ts
+++ b/packages/vault/src/backends/op-cli.ts
@@ -1,0 +1,35 @@
+import { execFileSync } from 'node:child_process';
+
+/** Default 1Password vault name for key lookups. */
+const OP_VAULT = 'Dev Keys';
+
+/** Check if `op` CLI is available and authenticated. */
+export function isOpAvailable(): boolean {
+  if (!process.env.OP_SERVICE_ACCOUNT_TOKEN) return false;
+  try {
+    execFileSync('op', ['--version'], { timeout: 3000, stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read a credential from 1Password via `op read`.
+ * Maps key names to 1Password item paths:
+ *   BRAINSTORM_API_KEY → op://Dev Keys/BRAINSTORM_API_KEY/credential
+ */
+export function opRead(keyName: string): string | null {
+  if (!isOpAvailable()) return null;
+  try {
+    const ref = `op://${OP_VAULT}/${keyName}/credential`;
+    const value = execFileSync('op', ['read', ref], {
+      timeout: 10000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env },
+    }).toString().trim();
+    return value || null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/vault/src/index.ts
+++ b/packages/vault/src/index.ts
@@ -1,3 +1,6 @@
 export { deriveKey, generateSalt, encrypt, decrypt, KDF_PARAMS } from './crypto.js';
 export { BrainstormVault } from './vault.js';
+export { KeyResolver, type PasswordPrompt } from './resolver.js';
+export { isOpAvailable, opRead } from './backends/op-cli.js';
+export { envRead } from './backends/env.js';
 export type { VaultFile, VaultPayload, VaultConfig, EncryptResult } from './types.js';

--- a/packages/vault/src/resolver.ts
+++ b/packages/vault/src/resolver.ts
@@ -1,0 +1,79 @@
+import type { BrainstormVault } from './vault.js';
+import { opRead, isOpAvailable } from './backends/op-cli.js';
+import { envRead } from './backends/env.js';
+
+export type PasswordPrompt = () => Promise<string>;
+
+/**
+ * Key resolver — tries vault → 1Password → env vars in order.
+ * Lazy unlock: prompts for vault password on first access, not at startup.
+ */
+export class KeyResolver {
+  private vault: BrainstormVault | null;
+  private promptPassword: PasswordPrompt | null;
+  private unlockAttempted = false;
+
+  constructor(vault: BrainstormVault | null, promptPassword?: PasswordPrompt) {
+    this.vault = vault;
+    this.promptPassword = promptPassword ?? null;
+  }
+
+  /**
+   * Get a key by name. Tries each backend in priority order:
+   * 1. Local encrypted vault (lazy unlock on first access)
+   * 2. 1Password CLI (if op available)
+   * 3. Environment variables
+   */
+  async get(name: string): Promise<string | null> {
+    // 1. Vault — lazy unlock
+    if (this.vault?.exists()) {
+      if (!this.vault.isOpen() && !this.unlockAttempted && this.promptPassword) {
+        this.unlockAttempted = true;
+        try {
+          const password = await this.promptPassword();
+          this.vault.open(password);
+        } catch {
+          // Wrong password or user cancelled — fall through to other backends
+        }
+      }
+      if (this.vault.isOpen()) {
+        const value = this.vault.get(name);
+        if (value) return value;
+      }
+    }
+
+    // 2. 1Password CLI
+    if (isOpAvailable()) {
+      const value = opRead(name);
+      if (value) return value;
+    }
+
+    // 3. Environment variables
+    return envRead(name);
+  }
+
+  /** Get a key or throw if not found in any backend. */
+  async getRequired(name: string): Promise<string> {
+    const value = await this.get(name);
+    if (!value) {
+      const sources = ['vault', isOpAvailable() ? '1Password' : null, 'environment'].filter(Boolean).join(', ');
+      throw new Error(`Key "${name}" not found in ${sources}`);
+    }
+    return value;
+  }
+
+  /** Report which backends are available. */
+  status(): { vault: string; op: string; env: string } {
+    const vaultStatus = !this.vault?.exists()
+      ? 'not initialized'
+      : this.vault.isOpen()
+        ? `unlocked (${this.vault.list().length} keys)`
+        : 'locked';
+
+    return {
+      vault: vaultStatus,
+      op: isOpAvailable() ? 'available' : 'not available',
+      env: 'always available',
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- `KeyResolver`: tries vault → 1Password → env vars in priority order
- `backends/op-cli.ts`: 1Password bridge via `op read` (auto-detects availability)
- `backends/env.ts`: environment variable fallback
- Lazy unlock: vault password prompted on first key access, not at startup
- `resolver.status()` reports backend availability for CLI display

## Test plan
- [ ] With vault + 1Password + env: vault key wins
- [ ] With vault locked + 1Password: 1Password key wins
- [ ] With no vault + no 1Password: env var returned
- [ ] `resolver.status()` shows correct state for each backend
- [ ] Build passes: `npx turbo run build --filter=@brainstorm/vault`

🤖 Generated with [Claude Code](https://claude.com/claude-code)