### PR TITLE
fix: vault integration — eager key resolution + all commands wired

### DIFF
--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -18,20 +18,35 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { ResolvedKeys } from '@brainstorm/providers';
 
-/** Create a KeyResolver backed by the vault, with lazy password prompt. */
-function createKeyResolverForCli(): { resolver: KeyResolver; asResolvedKeys: ResolvedKeys } {
-  const vaultPath = join(homedir(), '.brainstorm', 'vault.enc');
-  const vault = new BrainstormVault(vaultPath);
+/** Known API key names that providers need at startup. */
+const PROVIDER_KEY_NAMES = [
+  'BRAINSTORM_API_KEY',
+  'ANTHROPIC_API_KEY',
+  'OPENAI_API_KEY',
+  'GOOGLE_GENERATIVE_AI_API_KEY',
+  'DEEPSEEK_API_KEY',
+  'BRAINSTORM_ADMIN_KEY',
+];
+
+/**
+ * Eagerly resolve all provider keys through the vault/1Password/env chain.
+ * Triggers the lazy vault password prompt if a vault exists and keys are needed.
+ * Returns a sync ResolvedKeys map for createProviderRegistry.
+ */
+async function resolveProviderKeys(): Promise<ResolvedKeys> {
+  const vault = new BrainstormVault(VAULT_PATH);
   const resolver = new KeyResolver(
     vault.exists() ? vault : null,
     () => promptPassword('  Vault password: '),
   );
-  // Adapter: KeyResolver.get is async, but ResolvedKeys.get is sync.
-  // Pre-resolve keys before passing to createProviderRegistry.
-  return {
-    resolver,
-    asResolvedKeys: { get: (name: string) => vault.isOpen() ? vault.get(name) : null },
-  };
+
+  const resolved = new Map<string, string>();
+  for (const name of PROVIDER_KEY_NAMES) {
+    const value = await resolver.get(name);
+    if (value) resolved.set(name, value);
+  }
+
+  return { get: (name: string) => resolved.get(name) ?? null };
 }
 
 /**
@@ -254,7 +269,7 @@ program
   .description('List available models and their status')
   .action(async () => {
     const config = loadConfig();
-    const registry = await createProviderRegistry(config);
+    const registry = await createProviderRegistry(config, await resolveProviderKeys());
 
     console.log('\n🧠 Brainstorm — Available Models\n');
 
@@ -493,7 +508,7 @@ workflowCmd
 
     const config = loadConfig();
     const db = getDb();
-    const registry = await createProviderRegistry(config);
+    const registry = await createProviderRegistry(config, await resolveProviderKeys());
     const costTracker = new CostTracker(db, config.budget);
     const projectPath = process.cwd();
     const { frontmatter } = buildSystemPrompt(projectPath);
@@ -579,7 +594,7 @@ program
   .action(async (prompt: string, opts: { json?: boolean; pipe?: boolean; model?: string; tools?: boolean; maxSteps?: string }) => {
     const config = loadConfig();
     const db = getDb();
-    const registry = await createProviderRegistry(config);
+    const registry = await createProviderRegistry(config, await resolveProviderKeys());
     const costTracker = new CostTracker(db, config.budget);
     const tools = createDefaultToolRegistry();
     await connectGatewayMCP(tools);
@@ -935,8 +950,8 @@ program
   .action(async (opts: { simple?: boolean; continue?: boolean; resume?: string; fork?: string }) => {
     const config = loadConfig();
     const db = getDb();
-    const { asResolvedKeys } = createKeyResolverForCli();
-    const registry = await createProviderRegistry(config, asResolvedKeys);
+    const resolvedKeys = await resolveProviderKeys();
+    const registry = await createProviderRegistry(config, resolvedKeys);
     const costTracker = new CostTracker(db, config.budget);
     const tools = createDefaultToolRegistry();
     await connectGatewayMCP(tools);


### PR DESCRIPTION
## Summary
Fixes both issues from the [code review](https://github.com/justinjilg/brainstorm/pull/54#issuecomment-4119854958):

- **Vault keys always null**: Replaced broken sync adapter with `resolveProviderKeys()` that eagerly calls `await resolver.get()` for all provider key names before registry creation. This triggers the lazy vault password prompt and builds a sync `Map<string, string>` of resolved values.
- **Partial wiring**: All 4 `createProviderRegistry` call sites (`models`, `run`, `workflow run`, `chat`) now receive `await resolveProviderKeys()`.

## Test plan
- [ ] With vault containing ANTHROPIC_API_KEY: `brainstorm models` shows Anthropic models
- [ ] `brainstorm run "hello"` uses vault key (prompts for password once)
- [ ] `brainstorm chat` still works with vault keys
- [ ] Without vault: falls through to env vars silently (no prompt)
- [ ] Build passes: `npx turbo run build --force` (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)