### PR TITLE
feat: user-configurable MCP servers (Infra PR #4)

### DIFF
--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -50,30 +50,51 @@ async function resolveProviderKeys(): Promise<ResolvedKeys> {
 }
 
 /**
- * Auto-connect to BrainstormRouter MCP server when API key is set.
- * Registers gateway tools (budget, memory, config, etc.) into the tool registry.
+ * Connect to MCP servers from config + BrainstormRouter gateway.
+ * Loads user-configured servers from config.mcp.servers (populated from
+ * config.toml and .brainstorm/mcp.json), plus the built-in gateway server.
  */
-async function connectGatewayMCP(tools: ReturnType<typeof createDefaultToolRegistry>): Promise<void> {
-  if (!process.env.BRAINSTORM_API_KEY) return;
-
+async function connectMCPServers(
+  tools: ReturnType<typeof createDefaultToolRegistry>,
+  config: ReturnType<typeof loadConfig>,
+): Promise<void> {
   const mcp = new MCPClientManager();
-  mcp.addServers([{
-    name: 'brainstormrouter',
-    transport: 'stdio',
-    url: 'brainstormrouter-mcp',
-    command: 'npx',
-    args: ['brainstormrouter-mcp'],
-    env: { BRAINSTORM_API_KEY: process.env.BRAINSTORM_API_KEY },
-    toolFilter: [
-      'br_get_ops_status', 'br_list_models', 'br_get_budget',
-      'br_get_memory', 'br_store_memory', 'br_query_memory',
-      'br_get_config', 'br_set_config', 'br_get_insights',
-    ],
-  }]);
+
+  // User-configured MCP servers from config.toml / .brainstorm/mcp.json
+  if (config.mcp.servers.length > 0) {
+    mcp.addServers(config.mcp.servers.map((s) => ({
+      name: s.name,
+      transport: s.transport,
+      url: s.url ?? '',
+      command: s.command,
+      args: s.args,
+      env: s.env,
+      enabled: s.enabled,
+      toolFilter: s.toolFilter,
+    })));
+  }
+
+  // Built-in BrainstormRouter gateway MCP (if API key available)
+  const brKey = process.env.BRAINSTORM_API_KEY;
+  if (brKey) {
+    mcp.addServers([{
+      name: 'brainstormrouter',
+      transport: 'stdio',
+      url: 'brainstormrouter-mcp',
+      command: 'npx',
+      args: ['brainstormrouter-mcp'],
+      env: { BRAINSTORM_API_KEY: brKey },
+      toolFilter: [
+        'br_get_ops_status', 'br_list_models', 'br_get_budget',
+        'br_get_memory', 'br_store_memory', 'br_query_memory',
+        'br_get_config', 'br_set_config', 'br_get_insights',
+      ],
+    }]);
+  }
 
   const { connected, errors } = await mcp.connectAll(tools);
   if (connected.length > 0) {
-    process.stderr.write(`[mcp] Connected to BrainstormRouter (${connected.length} servers)\n`);
+    process.stderr.write(`[mcp] Connected: ${connected.join(', ')}\n`);
   }
   for (const err of errors) {
     process.stderr.write(`[mcp] ${err.name}: ${err.error}\n`);
@@ -597,7 +618,7 @@ program
     const registry = await createProviderRegistry(config, await resolveProviderKeys());
     const costTracker = new CostTracker(db, config.budget);
     const tools = createDefaultToolRegistry();
-    await connectGatewayMCP(tools);
+    await connectMCPServers(tools, config);
     const sessionManager = new SessionManager(db);
     const projectPath = process.cwd();
     const { prompt: systemPrompt, frontmatter } = buildSystemPrompt(projectPath);
@@ -954,7 +975,7 @@ program
     const registry = await createProviderRegistry(config, resolvedKeys);
     const costTracker = new CostTracker(db, config.budget);
     const tools = createDefaultToolRegistry();
-    await connectGatewayMCP(tools);
+    await connectMCPServers(tools, config);
     const sessionManager = new SessionManager(db);
     const projectPath = process.cwd();
     const { prompt: systemPrompt, frontmatter } = buildSystemPrompt(projectPath);

--- a/packages/config/src/loader.ts
+++ b/packages/config/src/loader.ts
@@ -45,6 +45,33 @@ function applyEnvOverrides(config: Record<string, unknown>): Record<string, unkn
   return result;
 }
 
+function readJsonSafe(path: string): Record<string, unknown> {
+  if (!existsSync(path)) return {};
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8'));
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Load MCP server configs from .brainstorm/mcp.json files.
+ * Project-level servers override global by name.
+ */
+function loadMCPServers(projectDir: string): Array<Record<string, unknown>> {
+  const globalMcp = readJsonSafe(join(GLOBAL_CONFIG_DIR, 'mcp.json'));
+  const projectMcp = readJsonSafe(join(projectDir, '.brainstorm', 'mcp.json'));
+
+  const globalServers = Array.isArray(globalMcp.servers) ? globalMcp.servers : [];
+  const projectServers = Array.isArray(projectMcp.servers) ? projectMcp.servers : [];
+
+  // Project servers override global by name
+  const byName = new Map<string, Record<string, unknown>>();
+  for (const s of globalServers) byName.set((s as any).name, s as Record<string, unknown>);
+  for (const s of projectServers) byName.set((s as any).name, s as Record<string, unknown>);
+  return Array.from(byName.values());
+}
+
 export function loadConfig(projectDir: string = process.cwd()): BrainstormConfig {
   // Layer 1: Global config
   const global = readToml(GLOBAL_CONFIG_FILE);
@@ -54,6 +81,14 @@ export function loadConfig(projectDir: string = process.cwd()): BrainstormConfig
   let merged = deepMerge(global, project);
   // Layer 3: Environment variables
   merged = applyEnvOverrides(merged);
+  // Layer 4: MCP servers from mcp.json files
+  const mcpServers = loadMCPServers(projectDir);
+  if (mcpServers.length > 0) {
+    const mcp = (merged.mcp ?? {}) as Record<string, unknown>;
+    const existing = Array.isArray(mcp.servers) ? mcp.servers : [];
+    mcp.servers = [...existing, ...mcpServers];
+    merged.mcp = mcp;
+  }
   // Validate and apply defaults
   return brainstormConfigSchema.parse(merged);
 }

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -122,6 +122,25 @@ const workflowConfigSchema = z.object({
   steps: z.array(workflowStepConfigSchema).default([]),
 });
 
+// ── MCP Config ──────────────────────────────────────────────────────
+
+const mcpServerSchema = z.object({
+  name: z.string(),
+  transport: z.enum(['sse', 'http', 'stdio']),
+  url: z.string().optional(),
+  command: z.string().optional(),
+  args: z.array(z.string()).optional(),
+  env: z.record(z.string()).optional(),
+  enabled: z.boolean().default(true),
+  toolFilter: z.array(z.string()).optional(),
+});
+
+const mcpSchema = z.object({
+  servers: z.array(mcpServerSchema).default([]),
+});
+
+// ── Full Config ─────────────────────────────────────────────────────
+
 export const brainstormConfigSchema = z.object({
   general: generalSchema.default({}),
   budget: budgetSchema.default({}),
@@ -132,6 +151,7 @@ export const brainstormConfigSchema = z.object({
   models: z.array(modelOverrideSchema).default([]),
   agents: z.array(agentConfigSchema).default([]),
   workflows: z.array(workflowConfigSchema).default([]),
+  mcp: mcpSchema.default({}),
 });
 
 export type BrainstormConfig = z.infer<typeof brainstormConfigSchema>;
@@ -142,3 +162,4 @@ export type GeneralConfig = z.infer<typeof generalSchema>;
 export type AgentConfig = z.infer<typeof agentConfigSchema>;
 export type WorkflowConfig = z.infer<typeof workflowConfigSchema>;
 export type WorkflowStepConfig = z.infer<typeof workflowStepConfigSchema>;
+export type MCPServerConfigSchema = z.infer<typeof mcpServerSchema>;


### PR DESCRIPTION
## Summary
- MCP servers configurable via config.toml `[mcp]` section or `.brainstorm/mcp.json` files
- Global (`~/.brainstorm/mcp.json`) + project-level (`.brainstorm/mcp.json`) with name-based override
- Refactored `connectGatewayMCP` → `connectMCPServers` loading from config + gateway
- All CLI commands (`run`, `chat`) use the unified MCP connection
- BrainstormRouter gateway still auto-connects when API key is set

From plan: `spicy-roaming-sonnet.md` — Close Infrastructure Gaps

## Test plan
- [ ] Create `~/.brainstorm/mcp.json` with a server → verify tools appear in chat
- [ ] Create `.brainstorm/mcp.json` in project → verify project servers override global
- [ ] `"enabled": false` → server skipped
- [ ] No mcp.json files → only gateway connects (if API key set)
- [ ] Build: `npx turbo run build --force` (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)