### PR TITLE
feat: activate context management

### DIFF
--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -4,7 +4,7 @@ import { getDb } from '@brainstorm/db';
 import { createProviderRegistry } from '@brainstorm/providers';
 import { BrainstormRouter, CostTracker } from '@brainstorm/router';
 import { createDefaultToolRegistry } from '@brainstorm/tools';
-import { runAgentLoop, buildSystemPrompt, SessionManager } from '@brainstorm/core';
+import { runAgentLoop, buildSystemPrompt, SessionManager, type CompactionCallbacks } from '@brainstorm/core';
 import { AgentManager, parseAgentNL } from '@brainstorm/agents';
 import { runWorkflow, getPresetWorkflow, autoSelectPreset, PRESET_WORKFLOWS } from '@brainstorm/workflow';
 import { renderMarkdownToString } from '../components/MarkdownRenderer.js';
@@ -47,6 +47,13 @@ async function resolveProviderKeys(): Promise<ResolvedKeys> {
   }
 
   return { get: (name: string) => resolved.get(name) ?? null };
+}
+
+function buildCompactionCallbacks(sessionManager: SessionManager): CompactionCallbacks {
+  return {
+    getTokenEstimate: () => sessionManager.getTokenEstimate(),
+    compact: (opts) => sessionManager.compact(opts),
+  };
 }
 
 /**
@@ -636,6 +643,7 @@ program
       disableTools: !opts.tools,
       ...(opts.model ? { preferredModelId: opts.model } : {}),
       maxSteps: parseInt(opts.maxSteps ?? '1'),
+      compaction: buildCompactionCallbacks(sessionManager),
     })) {
       switch (event.type) {
         case 'routing':
@@ -1023,6 +1031,7 @@ program
         for await (const event of runAgentLoop(sessionManager.getHistory(), {
           config, registry, router, costTracker, tools,
           sessionId: session.id, projectPath, systemPrompt,
+          compaction: buildCompactionCallbacks(sessionManager),
         })) {
           if (event.type === 'routing') process.stderr.write(`[${event.decision.strategy} -> ${event.decision.model.name}] `);
           if (event.type === 'text-delta') { fullResponse += event.delta; process.stdout.write(event.delta); }
@@ -1046,6 +1055,7 @@ program
       const gen = runAgentLoop(sessionManager.getHistory(), {
         config, registry, router, costTracker, tools,
         sessionId: session.id, projectPath, systemPrompt,
+        compaction: buildCompactionCallbacks(sessionManager),
       });
       // Wrap to capture assistant message after completion
       return (async function* () {

--- a/packages/cli/src/components/ChatApp.tsx
+++ b/packages/cli/src/components/ChatApp.tsx
@@ -62,6 +62,12 @@ export function ChatApp({ strategy, modelCount, onSendMessage }: ChatAppProps) {
               { role: 'routing', content: `tool: ${event.toolName}` },
             ]);
             break;
+          case 'compaction':
+            setMessages((prev) => [
+              ...prev,
+              { role: 'routing', content: `context compacted — ${event.removed} messages summarized (${event.tokensBefore.toLocaleString()} → ${event.tokensAfter.toLocaleString()} tokens)` },
+            ]);
+            break;
           case 'task-created':
             setTasks((prev) => [...prev, event.task]);
             break;

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -21,6 +21,15 @@ const providersSchema = z.object({
   llamacpp: localProviderSchema.default({ baseUrl: 'http://localhost:8080', enabled: false }),
 });
 
+// ── Compaction Config ────────────────────────────────────────────────
+
+const compactionSchema = z.object({
+  enabled: z.boolean().default(true),
+  threshold: z.number().min(0.1).max(1.0).default(0.8),
+  keepRecent: z.number().min(1).default(5),
+  summarizeModel: z.string().optional(),
+});
+
 // ── Budget Config ────────────────────────────────────────────────────
 
 const budgetSchema = z.object({
@@ -143,6 +152,7 @@ const mcpSchema = z.object({
 
 export const brainstormConfigSchema = z.object({
   general: generalSchema.default({}),
+  compaction: compactionSchema.default({}),
   budget: budgetSchema.default({}),
   providers: providersSchema.default({}),
   routing: z.object({
@@ -163,3 +173,4 @@ export type AgentConfig = z.infer<typeof agentConfigSchema>;
 export type WorkflowConfig = z.infer<typeof workflowConfigSchema>;
 export type WorkflowStepConfig = z.infer<typeof workflowStepConfigSchema>;
 export type MCPServerConfigSchema = z.infer<typeof mcpServerSchema>;
+export type CompactionConfig = z.infer<typeof compactionSchema>;

--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -16,6 +16,15 @@ if (!process.env.BRAINSTORM_LOG_LEVEL) {
   (globalThis as any).AI_SDK_LOG_WARNINGS = false;
 }
 
+export interface CompactionCallbacks {
+  /** Current estimated token count of conversation history. */
+  getTokenEstimate: () => number;
+  /** Run compaction on the conversation. Returns compaction result. */
+  compact: (options: { contextWindow: number; keepRecent?: number; summarizeModel?: any }) => Promise<{
+    compacted: boolean; removed: number; tokensBefore: number; tokensAfter: number; summaryCost: number;
+  }>;
+}
+
 export interface AgentLoopOptions {
   config: BrainstormConfig;
   registry: ProviderRegistry;
@@ -30,6 +39,8 @@ export interface AgentLoopOptions {
   preferredModelId?: string;
   /** Override max agentic steps (default: config.general.maxSteps). */
   maxSteps?: number;
+  /** Context compaction support. If provided, compaction is checked before each LLM call. */
+  compaction?: CompactionCallbacks;
 }
 
 // Task types that should NOT get tools (pure text generation)
@@ -53,11 +64,34 @@ export async function* runAgentLoop(
   const userText = lastUserMsg?.content ?? '';
 
   const task = router.classify(userText);
+  const conversationTokens = options.compaction?.getTokenEstimate() ?? 0;
   const decision = options.preferredModelId
-    ? { ...router.route(task), model: options.registry.getModel(options.preferredModelId) ?? router.route(task).model, reason: `Cross-model workflow override: ${options.preferredModelId}` }
-    : router.route(task);
+    ? { ...router.route(task, conversationTokens), model: options.registry.getModel(options.preferredModelId) ?? router.route(task, conversationTokens).model, reason: `Cross-model workflow override: ${options.preferredModelId}` }
+    : router.route(task, conversationTokens);
 
   yield { type: 'routing', decision };
+
+  // Check if context compaction is needed before the LLM call
+  if (options.compaction && config.compaction?.enabled !== false) {
+    const contextWindow = decision.model.limits.contextWindow || 128_000;
+    const threshold = config.compaction?.threshold ?? 0.8;
+    const tokenEstimate = options.compaction.getTokenEstimate();
+
+    if (tokenEstimate > contextWindow * threshold) {
+      const compactionResult = await options.compaction.compact({
+        contextWindow,
+        keepRecent: config.compaction?.keepRecent ?? 5,
+      });
+      if (compactionResult.compacted) {
+        yield {
+          type: 'compaction',
+          removed: compactionResult.removed,
+          tokensBefore: compactionResult.tokensBefore,
+          tokensAfter: compactionResult.tokensAfter,
+        };
+      }
+    }
+  }
 
   // Always resolve through the provider registry — it handles local, cloud, and SaaS models
   const modelId = options.registry.getProvider(decision.model.id);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-export { runAgentLoop, type AgentLoopOptions } from './agent/loop.js';
+export { runAgentLoop, type AgentLoopOptions, type CompactionCallbacks } from './agent/loop.js';
 export { buildSystemPrompt, parseAtMentions } from './agent/context.js';
 export { SessionManager } from './session/manager.js';
 export { PermissionManager } from './permissions/manager.js';

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -79,9 +79,20 @@ export async function compactContext(
       let summaryText = '';
       for await (const part of result.fullStream) {
         if (part.type === 'text-delta') {
-          summaryText += (part as any).text ?? '';
+          summaryText += (part as any).text ?? (part as any).delta ?? '';
         }
       }
+
+      // Capture summarization cost from usage
+      try {
+        const usage = await result.usage;
+        if (usage) {
+          const inputTokens = (usage as any).inputTokens ?? 0;
+          const outputTokens = (usage as any).outputTokens ?? 0;
+          summaryCost = (inputTokens + outputTokens) * 0.000001; // rough estimate
+        }
+      } catch { /* usage not available — non-fatal */ }
+
       summary = summaryText || fallbackSummary(oldMessages);
     } catch {
       summary = fallbackSummary(oldMessages);

--- a/packages/core/src/session/manager.ts
+++ b/packages/core/src/session/manager.ts
@@ -1,5 +1,6 @@
 import { SessionRepository, MessageRepository } from '@brainstorm/db';
 import type { Session } from '@brainstorm/shared';
+import { estimateTokenCount, needsCompaction, compactContext } from './compaction.js';
 
 export interface ConversationMessage {
   role: 'user' | 'assistant' | 'system';
@@ -99,5 +100,31 @@ export class SessionManager {
 
   listRecent(limit = 10): Session[] {
     return this.sessions.listRecent(limit);
+  }
+
+  getTokenEstimate(): number {
+    return estimateTokenCount(this.conversationHistory);
+  }
+
+  needsCompaction(contextWindow: number): boolean {
+    return needsCompaction(this.conversationHistory, contextWindow);
+  }
+
+  async compact(options: {
+    contextWindow: number;
+    keepRecent?: number;
+    summarizeModel?: any;
+  }): Promise<{ compacted: boolean; removed: number; tokensBefore: number; tokensAfter: number; summaryCost: number }> {
+    const tokensBefore = estimateTokenCount(this.conversationHistory);
+    const result = await compactContext(this.conversationHistory, options);
+
+    if (result.compacted) {
+      const removed = this.conversationHistory.length - result.messages.length;
+      this.conversationHistory = result.messages;
+      const tokensAfter = estimateTokenCount(this.conversationHistory);
+      return { compacted: true, removed, tokensBefore, tokensAfter, summaryCost: result.summaryCost };
+    }
+
+    return { compacted: false, removed: 0, tokensBefore, tokensAfter: tokensBefore, summaryCost: 0 };
   }
 }

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -45,12 +45,12 @@ export class BrainstormRouter {
     return classifyTask(message, context, this.projectHints);
   }
 
-  route(task: TaskProfile): RoutingDecision {
+  route(task: TaskProfile, conversationTokens?: number): RoutingDecision {
     // Check budget before routing
     this.costTracker.checkBudget();
 
     const candidates = this.getEligibleModels(task);
-    const context = this.buildRoutingContext();
+    const context = this.buildRoutingContext(conversationTokens);
 
     // Try active strategy
     const decision = this.strategies[this.activeStrategy].select(task, candidates, context);
@@ -110,12 +110,12 @@ export class BrainstormRouter {
     });
   }
 
-  private buildRoutingContext(): RoutingContext {
+  private buildRoutingContext(conversationTokens?: number): RoutingContext {
     const budget = this.costTracker.getBudgetState();
     return {
       budget,
       sessionCost: this.costTracker.getSessionCost(),
-      conversationTokens: 0, // TODO: track from session
+      conversationTokens: conversationTokens ?? 0,
       userPreferences: {
         preferLocal: false,
         preferredProvider: undefined,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -190,6 +190,7 @@ export type AgentEvent =
   | { type: 'tool-call-result'; toolName: string; result: unknown }
   | { type: 'step-complete'; text: string; toolCalls: unknown[] }
   | { type: 'gateway-feedback'; feedback: GatewayFeedbackData }
+  | { type: 'compaction'; removed: number; tokensBefore: number; tokensAfter: number }
   | { type: 'task-created'; task: AgentTask }
   | { type: 'task-updated'; task: AgentTask }
   | { type: 'error'; error: Error }


### PR DESCRIPTION
## Summary

- Wires the existing dead compaction code (`compactContext`, `estimateTokenCount`, `needsCompaction`) into the active chat loop
- Adds `compaction` config section to schema (enabled, threshold 0.8, keepRecent 5, summarizeModel)
- Introduces `CompactionCallbacks` interface to decouple agent loop from SessionManager
- Before each LLM call, checks token count against `contextWindow * threshold` and compacts if needed
- Feeds real `conversationTokens` to the router (was hardcoded `0 // TODO`)
- Fixes AI SDK v6 text-delta consumption in compaction summarizer (`text ?? delta`)
- Captures `summaryCost` from summarization usage
- Shows compaction event in CLI TUI: "context compacted — N messages summarized (X → Y tokens)"

## Packages touched

| Package | Change |
|---------|--------|
| shared | Add `compaction` event to `AgentEvent` union |
| config | Add `compactionSchema` with defaults |
| core | Wire `SessionManager.compact()`, add compaction check in agent loop |
| router | Accept `conversationTokens` parameter in `route()` |
| cli | Wire `CompactionCallbacks`, handle compaction event in TUI |

## Test plan

- [ ] `npx turbo run build --force` — 15/15 pass
- [ ] Start `brainstorm chat`, send 20+ messages — observe `[context compacted]` event when approaching context window
- [ ] Verify router receives non-zero `conversationTokens` in routing context
- [ ] Config: set `compaction.enabled = false` in config.toml — verify no compaction fires

🤖 Generated with [Claude Code](https://claude.ai/code)