### PR TITLE
feat: interrupt handling with AbortController

### DIFF
--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -1019,6 +1019,20 @@ program
       console.log(`  Strategy: ${config.general.defaultStrategy} | Models: ${localCount} local, ${cloudCount} cloud`);
       console.log(`  Type your message. /quit to exit.\n`);
 
+      let simpleAbortController: AbortController | null = null;
+
+      // First Ctrl-C aborts current operation, second exits
+      process.on('SIGINT', () => {
+        if (simpleAbortController) {
+          simpleAbortController.abort();
+          simpleAbortController = null;
+          process.stdout.write('\n  [interrupted]\n\n');
+        } else {
+          rl.close();
+          process.exit(0);
+        }
+      });
+
       while (true) {
         const input = await rl.question('you > ');
         if (!input.trim()) continue;
@@ -1027,18 +1041,22 @@ program
         sessionManager.addUserMessage(input);
         let fullResponse = '';
         process.stdout.write('\nbrainstorm > ');
+        simpleAbortController = new AbortController();
 
         for await (const event of runAgentLoop(sessionManager.getHistory(), {
           config, registry, router, costTracker, tools,
           sessionId: session.id, projectPath, systemPrompt,
           compaction: buildCompactionCallbacks(sessionManager),
+          signal: simpleAbortController.signal,
         })) {
           if (event.type === 'routing') process.stderr.write(`[${event.decision.strategy} -> ${event.decision.model.name}] `);
           if (event.type === 'text-delta') { fullResponse += event.delta; process.stdout.write(event.delta); }
           if (event.type === 'gateway-feedback') { const gw = formatGatewayFeedback(event.feedback); if (gw) process.stderr.write(`\n  ${gw}`); }
+          if (event.type === 'interrupted') process.stdout.write('\n  [interrupted]\n\n');
           if (event.type === 'done') process.stdout.write(`\n  [$${event.totalCost.toFixed(4)}]\n\n`);
           if (event.type === 'error') process.stdout.write(`\n  Error: ${event.error.message}\n\n`);
         }
+        simpleAbortController = null;
         if (fullResponse) sessionManager.addAssistantMessage(fullResponse);
       }
       rl.close();
@@ -1050,12 +1068,16 @@ program
     const React = await import('react');
     const { ChatApp } = await import('../components/ChatApp.js');
 
+    let currentAbortController: AbortController | null = null;
+
     function handleSendMessage(text: string) {
       sessionManager.addUserMessage(text);
+      currentAbortController = new AbortController();
       const gen = runAgentLoop(sessionManager.getHistory(), {
         config, registry, router, costTracker, tools,
         sessionId: session.id, projectPath, systemPrompt,
         compaction: buildCompactionCallbacks(sessionManager),
+        signal: currentAbortController.signal,
       });
       // Wrap to capture assistant message after completion
       return (async function* () {
@@ -1065,7 +1087,15 @@ program
           yield event;
         }
         if (fullResponse) sessionManager.addAssistantMessage(fullResponse);
+        currentAbortController = null;
       })();
+    }
+
+    function handleAbort() {
+      if (currentAbortController) {
+        currentAbortController.abort();
+        currentAbortController = null;
+      }
     }
 
     render(
@@ -1073,6 +1103,7 @@ program
         strategy: config.general.defaultStrategy,
         modelCount: { local: localCount, cloud: cloudCount },
         onSendMessage: handleSendMessage,
+        onAbort: handleAbort,
       }),
     );
   });

--- a/packages/cli/src/components/ChatApp.tsx
+++ b/packages/cli/src/components/ChatApp.tsx
@@ -10,9 +10,10 @@ interface ChatAppProps {
   strategy: string;
   modelCount: { local: number; cloud: number };
   onSendMessage: (text: string) => AsyncGenerator<AgentEvent>;
+  onAbort?: () => void;
 }
 
-export function ChatApp({ strategy, modelCount, onSendMessage }: ChatAppProps) {
+export function ChatApp({ strategy, modelCount, onSendMessage, onAbort }: ChatAppProps) {
   const { exit } = useApp();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
@@ -21,6 +22,13 @@ export function ChatApp({ strategy, modelCount, onSendMessage }: ChatAppProps) {
   const [sessionCost, setSessionCost] = useState(0);
   const [isProcessing, setIsProcessing] = useState(false);
   const [tasks, setTasks] = useState<AgentTask[]>([]);
+
+  // Escape key aborts current operation
+  useInput((_input, key) => {
+    if (key.escape && isProcessing && onAbort) {
+      onAbort();
+    }
+  });
 
   const handleSubmit = useCallback(async (text: string) => {
     if (!text.trim() || isProcessing) return;
@@ -75,6 +83,12 @@ export function ChatApp({ strategy, modelCount, onSendMessage }: ChatAppProps) {
             setTasks((prev) =>
               prev.map((t) => (t.id === event.task.id ? event.task : t)),
             );
+            break;
+          case 'interrupted':
+            setMessages((prev) => [
+              ...prev,
+              { role: 'routing', content: 'interrupted' },
+            ]);
             break;
           case 'done':
             cost = event.totalCost;

--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -41,6 +41,8 @@ export interface AgentLoopOptions {
   maxSteps?: number;
   /** Context compaction support. If provided, compaction is checked before each LLM call. */
   compaction?: CompactionCallbacks;
+  /** AbortSignal to cancel in-flight LLM calls and tool executions. */
+  signal?: AbortSignal;
 }
 
 // Task types that should NOT get tools (pure text generation)
@@ -109,6 +111,7 @@ export async function* runAgentLoop(
       messages: messages as any,
       ...(shouldUseTools ? { tools: tools.toAISDKTools() } : {}),
       ...(metadataHeader ? { headers: { 'x-br-metadata': metadataHeader } } : {}),
+      ...(options.signal ? { abortSignal: options.signal } : {}),
       stopWhen: stepCountIs(shouldUseTools ? (options.maxSteps ?? config.general.maxSteps) : 1),
       onStepFinish: async ({ usage }: any) => {
         if (usage) {
@@ -142,6 +145,11 @@ export async function* runAgentLoop(
         while (taskEventQueue.length > 0) {
           yield taskEventQueue.shift()!;
         }
+        // Check for abort between tool executions
+        if (options.signal?.aborted) {
+          yield { type: 'interrupted' };
+          return;
+        }
       }
     }
 
@@ -169,8 +177,13 @@ export async function* runAgentLoop(
 
     yield { type: 'done', totalCost: costTracker.getSessionCost() };
   } catch (error: any) {
-    router.recordFailure(decision.model.id, error.message);
-    yield { type: 'error', error };
+    // AbortError means the user cancelled — yield interrupted, not error
+    if (error.name === 'AbortError' || options.signal?.aborted) {
+      yield { type: 'interrupted' };
+    } else {
+      router.recordFailure(decision.model.id, error.message);
+      yield { type: 'error', error };
+    }
   } finally {
     setTaskEventHandler(null);
   }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -194,6 +194,7 @@ export type AgentEvent =
   | { type: 'tool-output-partial'; toolName: string; chunk: string }
   | { type: 'task-created'; task: AgentTask }
   | { type: 'task-updated'; task: AgentTask }
+  | { type: 'interrupted' }
   | { type: 'error'; error: Error }
   | { type: 'done'; totalCost: number };
 


### PR DESCRIPTION
## Summary

- Add `signal?: AbortSignal` to `AgentLoopOptions`, passed to `streamText({ abortSignal })`
- Check `signal.aborted` between tool executions for graceful early exit
- `AbortError` yields `{ type: 'interrupted' }` instead of `{ type: 'error' }` — session continues normally
- TUI (Ink): Escape key triggers abort via `onAbort` callback, shows `[interrupted]` message
- Readline mode: First Ctrl-C aborts current operation, second Ctrl-C exits the process
- Add `interrupted` event type to `AgentEvent` union

## Packages touched

| Package | Change |
|---------|--------|
| shared | Add `{ type: 'interrupted' }` to `AgentEvent` |
| core | Accept `signal` in loop options, pass to `streamText`, check between tools |
| cli | Wire `AbortController` per message, Escape/Ctrl-C handlers |

## Test plan

- [ ] `npx turbo run build --force` — 15/15 pass
- [ ] TUI: Press Escape during LLM generation → stream stops, `[interrupted]` shown, next message works
- [ ] Readline: First Ctrl-C during generation → aborts, second Ctrl-C → exits
- [ ] Verify session history is preserved after interruption

🤖 Generated with [Claude Code](https://claude.ai/code)