### PR TITLE
feat: branch management and stash tools

### DIFF
--- a/packages/tools/src/builtin/git-branch.ts
+++ b/packages/tools/src/builtin/git-branch.ts
@@ -1,0 +1,106 @@
+import { z } from 'zod';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { defineTool } from '../base.js';
+
+const execFileAsync = promisify(execFile);
+
+const PROTECTED_BRANCHES = new Set(['main', 'master', 'production', 'release']);
+
+export const gitBranchTool = defineTool({
+  name: 'git_branch',
+  description:
+    'Manage git branches — create, switch, delete, or list. Protects main/master from deletion. Warns about uncommitted changes before switching.',
+  permission: 'confirm',
+  inputSchema: z.object({
+    action: z.enum(['create', 'switch', 'delete', 'list']).describe('Branch action'),
+    name: z.string().optional().describe('Branch name (required for create/switch/delete)'),
+    startPoint: z.string().optional().describe('Starting point for new branch (default: HEAD)'),
+    cwd: z.string().optional().describe('Working directory'),
+  }),
+  async execute({ action, name, startPoint, cwd }) {
+    const opts = { cwd: cwd ?? process.cwd() };
+
+    try {
+      switch (action) {
+        case 'create':
+          return await createBranch(name, startPoint, opts);
+        case 'switch':
+          return await switchBranch(name, opts);
+        case 'delete':
+          return await deleteBranch(name, opts);
+        case 'list':
+          return await listBranches(opts);
+        default:
+          return { error: `Unknown action: ${action}` };
+      }
+    } catch (err: any) {
+      return { error: err.stderr || err.message };
+    }
+  },
+});
+
+async function createBranch(name: string | undefined, startPoint: string | undefined, opts: { cwd: string }) {
+  if (!name) return { error: 'name is required for "create" action' };
+
+  const args = ['checkout', '-b', name];
+  if (startPoint) args.push(startPoint);
+
+  const { stdout } = await execFileAsync('git', args, opts);
+  return { success: true, branch: name, output: stdout.trim() };
+}
+
+async function switchBranch(name: string | undefined, opts: { cwd: string }) {
+  if (!name) return { error: 'name is required for "switch" action' };
+
+  // Check for uncommitted changes
+  const { stdout: status } = await execFileAsync('git', ['status', '--porcelain'], opts);
+  if (status.trim()) {
+    return {
+      warning: 'Uncommitted changes detected. Consider stashing first with git_stash.',
+      uncommittedFiles: status.trim().split('\n').length,
+      status: status.trim(),
+      switchedAnyway: false,
+    };
+  }
+
+  const { stdout } = await execFileAsync('git', ['checkout', name], opts);
+  return { success: true, branch: name, output: stdout.trim() };
+}
+
+async function deleteBranch(name: string | undefined, opts: { cwd: string }) {
+  if (!name) return { error: 'name is required for "delete" action' };
+
+  if (PROTECTED_BRANCHES.has(name)) {
+    return { error: `Cannot delete protected branch "${name}". Protected branches: ${[...PROTECTED_BRANCHES].join(', ')}` };
+  }
+
+  // Use -d (safe delete — only if fully merged)
+  const { stdout } = await execFileAsync('git', ['branch', '-d', name], opts);
+  return { success: true, deleted: name, output: stdout.trim() };
+}
+
+async function listBranches(opts: { cwd: string }) {
+  const { stdout } = await execFileAsync(
+    'git',
+    ['branch', '-a', '--format=%(refname:short) %(objectname:short) %(upstream:short) %(HEAD)'],
+    opts,
+  );
+
+  const branches = stdout
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      const parts = line.trim().split(' ');
+      const isCurrent = parts[parts.length - 1] === '*';
+      return {
+        name: parts[0],
+        commit: parts[1],
+        upstream: parts[2] || null,
+        current: isCurrent,
+      };
+    });
+
+  return { branches };
+}

--- a/packages/tools/src/builtin/git-stash.ts
+++ b/packages/tools/src/builtin/git-stash.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { defineTool } from '../base.js';
+
+const execFileAsync = promisify(execFile);
+
+export const gitStashTool = defineTool({
+  name: 'git_stash',
+  description:
+    'Manage git stash — push changes to stash, pop/apply from stash, or list stashed entries. Useful before switching branches with uncommitted work.',
+  permission: 'confirm',
+  inputSchema: z.object({
+    action: z.enum(['push', 'pop', 'apply', 'list', 'drop']).describe('Stash action'),
+    message: z.string().optional().describe('Stash message (for "push")'),
+    index: z.number().optional().describe('Stash index (for pop/apply/drop, default: 0)'),
+    cwd: z.string().optional().describe('Working directory'),
+  }),
+  async execute({ action, message, index, cwd }) {
+    const opts = { cwd: cwd ?? process.cwd() };
+
+    try {
+      switch (action) {
+        case 'push': {
+          const args = ['stash', 'push'];
+          if (message) args.push('-m', message);
+          const { stdout } = await execFileAsync('git', args, opts);
+          return { success: true, output: stdout.trim() };
+        }
+        case 'pop': {
+          const ref = `stash@{${index ?? 0}}`;
+          const { stdout } = await execFileAsync('git', ['stash', 'pop', ref], opts);
+          return { success: true, output: stdout.trim() };
+        }
+        case 'apply': {
+          const ref = `stash@{${index ?? 0}}`;
+          const { stdout } = await execFileAsync('git', ['stash', 'apply', ref], opts);
+          return { success: true, output: stdout.trim() };
+        }
+        case 'list': {
+          const { stdout } = await execFileAsync('git', ['stash', 'list'], opts);
+          const entries = stdout
+            .trim()
+            .split('\n')
+            .filter(Boolean)
+            .map((line) => {
+              const match = line.match(/^(stash@\{\d+\}):\s*(.+)$/);
+              return match ? { ref: match[1], description: match[2] } : { ref: '', description: line };
+            });
+          return { entries, count: entries.length };
+        }
+        case 'drop': {
+          const ref = `stash@{${index ?? 0}}`;
+          const { stdout } = await execFileAsync('git', ['stash', 'drop', ref], opts);
+          return { success: true, output: stdout.trim() };
+        }
+        default:
+          return { error: `Unknown action: ${action}` };
+      }
+    } catch (err: any) {
+      return { error: err.stderr || err.message };
+    }
+  },
+});

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -14,6 +14,8 @@ export { gitCommitTool } from './builtin/git-commit.js';
 export { checkGitSafety, formatViolations, hasHardBlock, type GitSafetyViolation } from './builtin/git-safety.js';
 export { ghPrTool } from './builtin/gh-pr.js';
 export { ghIssueTool } from './builtin/gh-issue.js';
+export { gitBranchTool } from './builtin/git-branch.js';
+export { gitStashTool } from './builtin/git-stash.js';
 export { listDirTool } from './builtin/list-dir.js';
 export { multiEditTool } from './builtin/multi-edit.js';
 export { batchEditTool } from './builtin/batch-edit.js';
@@ -35,6 +37,8 @@ import { gitLogTool } from './builtin/git-log.js';
 import { gitCommitTool } from './builtin/git-commit.js';
 import { ghPrTool } from './builtin/gh-pr.js';
 import { ghIssueTool } from './builtin/gh-issue.js';
+import { gitBranchTool } from './builtin/git-branch.js';
+import { gitStashTool } from './builtin/git-stash.js';
 import { listDirTool } from './builtin/list-dir.js';
 import { multiEditTool } from './builtin/multi-edit.js';
 import { batchEditTool } from './builtin/batch-edit.js';
@@ -58,11 +62,13 @@ export function createDefaultToolRegistry(): ToolRegistry {
   registry.register(shellTool);
   registry.register(processSpawnTool);
   registry.register(processKillTool);
-  // Git (4)
+  // Git (6)
   registry.register(gitStatusTool);
   registry.register(gitDiffTool);
   registry.register(gitLogTool);
   registry.register(gitCommitTool);
+  registry.register(gitBranchTool);
+  registry.register(gitStashTool);
   // GitHub (2)
   registry.register(ghPrTool);
   registry.register(ghIssueTool);


### PR DESCRIPTION
## Summary
- **git_branch tool**: create, switch, delete, list branches with safety — protects main/master/production from deletion, warns about uncommitted changes before switch
- **git_stash tool**: push/pop/apply/list/drop with messages and index support
- Tool count: 22 → 24

## Test plan
- [ ] Build: `npx turbo run build --filter=@brainstorm/tools`
- [ ] Verify branch create: `git_branch create feat/test` — creates and switches
- [ ] Verify branch delete protection: `git_branch delete main` — blocked
- [ ] Verify switch warning: with dirty working tree, switch warns about uncommitted changes
- [ ] Verify stash push/pop cycle: stash changes, verify clean, pop, verify restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)