### PR TITLE
feat: enhanced TUI status bar with token counts

### DIFF
--- a/packages/cli/src/components/ChatApp.tsx
+++ b/packages/cli/src/components/ChatApp.tsx
@@ -23,6 +23,7 @@ export function ChatApp({ strategy, modelCount, onSendMessage, onAbort }: ChatAp
   const [sessionCost, setSessionCost] = useState(0);
   const [isProcessing, setIsProcessing] = useState(false);
   const [tasks, setTasks] = useState<AgentTask[]>([]);
+  const [tokenCount, setTokenCount] = useState<{ input: number; output: number }>({ input: 0, output: 0 });
 
   // Escape key aborts current operation
   useInput((_input, key) => {
@@ -106,6 +107,7 @@ export function ChatApp({ strategy, modelCount, onSendMessage, onAbort }: ChatAp
           case 'done':
             cost = event.totalCost;
             setSessionCost(event.totalCost);
+            if (event.totalTokens) setTokenCount(event.totalTokens);
             break;
           case 'error':
             setMessages((prev) => [
@@ -133,6 +135,7 @@ export function ChatApp({ strategy, modelCount, onSendMessage, onAbort }: ChatAp
         currentModel={currentModel}
         sessionCost={sessionCost}
         modelCount={modelCount}
+        tokenCount={tokenCount}
       />
       <MessageList messages={messages} streamingText={streamingText} />
       {tasks.length > 0 && <TaskList tasks={tasks} />}

--- a/packages/cli/src/components/StatusBar.tsx
+++ b/packages/cli/src/components/StatusBar.tsx
@@ -8,35 +8,57 @@ interface StatusBarProps {
   sessionCost: number;
   modelCount: { local: number; cloud: number };
   permissionMode?: PermissionMode;
+  tokenCount?: { input: number; output: number };
+  sessionId?: string;
 }
 
 const MODE_LABELS: Record<PermissionMode, { label: string; color: string }> = {
-  auto: { label: 'AUTO', color: 'green' },
-  confirm: { label: 'CONFIRM', color: 'yellow' },
-  plan: { label: 'PLAN', color: 'cyan' },
+  auto: { label: 'auto', color: 'green' },
+  confirm: { label: 'confirm', color: 'yellow' },
+  plan: { label: 'plan', color: 'cyan' },
 };
 
-export function StatusBar({ strategy, currentModel, sessionCost, modelCount, permissionMode = 'confirm' }: StatusBarProps) {
+function formatTokens(count: number): string {
+  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+  if (count >= 1_000) return `${(count / 1_000).toFixed(1)}k`;
+  return String(count);
+}
+
+export function StatusBar({
+  strategy,
+  currentModel,
+  sessionCost,
+  modelCount,
+  permissionMode = 'confirm',
+  tokenCount,
+  sessionId,
+}: StatusBarProps) {
   const mode = MODE_LABELS[permissionMode];
+  const totalTokens = tokenCount ? tokenCount.input + tokenCount.output : 0;
+
   return (
     <Box borderStyle="single" borderColor="gray" paddingX={1} flexDirection="row" justifyContent="space-between">
       <Text>
-        <Text color="cyan" bold>brainstorm</Text>
-        <Text color="gray"> | </Text>
-        <Text color="yellow">{strategy}</Text>
-        <Text color="gray"> | </Text>
-        <Text color={mode.color}>{mode.label}</Text>
-      </Text>
-      <Text>
-        {currentModel && (
+        <Text color={mode.color} bold>{mode.label}</Text>
+        <Text color="gray"> │ </Text>
+        <Text color="green">{currentModel ?? `${strategy} routing`}</Text>
+        {totalTokens > 0 && (
           <>
-            <Text color="green">{currentModel}</Text>
-            <Text color="gray"> | </Text>
+            <Text color="gray"> │ </Text>
+            <Text color="white">{formatTokens(totalTokens)} tokens</Text>
           </>
         )}
-        <Text color="gray">{modelCount.local} local, {modelCount.cloud} cloud</Text>
-        <Text color="gray"> | </Text>
-        <Text color={sessionCost > 0 ? 'yellow' : 'green'}>${sessionCost.toFixed(4)}</Text>
+        <Text color="gray"> │ </Text>
+        <Text color={sessionCost > 0.01 ? 'yellow' : 'green'}>${sessionCost.toFixed(4)}</Text>
+      </Text>
+      <Text>
+        <Text color="gray">{modelCount.local}L/{modelCount.cloud}C</Text>
+        {sessionId && (
+          <>
+            <Text color="gray"> │ </Text>
+            <Text color="gray">{sessionId.slice(0, 8)}</Text>
+          </>
+        )}
       </Text>
     </Box>
   );

--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -175,7 +175,7 @@ export async function* runAgentLoop(
       // Gateway headers not available (local models) — non-fatal
     }
 
-    yield { type: 'done', totalCost: costTracker.getSessionCost() };
+    yield { type: 'done', totalCost: costTracker.getSessionCost(), totalTokens: costTracker.getSessionTokens() };
   } catch (error: any) {
     // AbortError means the user cancelled — yield interrupted, not error
     if (error.name === 'AbortError' || options.signal?.aborted) {

--- a/packages/router/src/cost-tracker.ts
+++ b/packages/router/src/cost-tracker.ts
@@ -7,6 +7,8 @@ export class CostTracker {
   private repo: CostRepository;
   private budgetConfig: BudgetConfig;
   private sessionCost = 0;
+  private sessionInputTokens = 0;
+  private sessionOutputTokens = 0;
 
   constructor(db: any, budgetConfig: BudgetConfig) {
     this.repo = new CostRepository(db);
@@ -29,6 +31,8 @@ export class CostTracker {
       (params.outputTokens / 1_000_000) * params.pricing.outputPer1MTokens;
 
     this.sessionCost += cost;
+    this.sessionInputTokens += params.inputTokens;
+    this.sessionOutputTokens += params.outputTokens;
 
     return this.repo.record({
       timestamp: Math.floor(Date.now() / 1000),
@@ -72,6 +76,10 @@ export class CostTracker {
 
   getSessionCost(): number {
     return this.sessionCost;
+  }
+
+  getSessionTokens(): { input: number; output: number } {
+    return { input: this.sessionInputTokens, output: this.sessionOutputTokens };
   }
 
   getSummary() {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -196,7 +196,7 @@ export type AgentEvent =
   | { type: 'task-updated'; task: AgentTask }
   | { type: 'interrupted' }
   | { type: 'error'; error: Error }
-  | { type: 'done'; totalCost: number };
+  | { type: 'done'; totalCost: number; totalTokens?: { input: number; output: number } };
 
 // ── Tool System ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- **Redesigned status bar**: `confirm │ claude-sonnet-4.6 │ 12.4k tokens │ $0.03 │ 3L/5C`
- **Session token tracking**: CostTracker now tracks input/output tokens per session
- **Token display**: formatted as k/M with compact model count (L=local, C=cloud)
- **Done event**: now includes `totalTokens` alongside `totalCost`

## Test plan
- [ ] Build: `npx turbo run build`
- [ ] Verify status bar shows token count after first response
- [ ] Verify token count updates after each turn
- [ ] Verify cost display changes color above $0.01

🤖 Generated with [Claude Code](https://claude.com/claude-code)