### PR TITLE
feat: output style modes (concise/detailed/learning)

### DIFF
--- a/packages/cli/src/commands/slash.ts
+++ b/packages/cli/src/commands/slash.ts
@@ -31,6 +31,10 @@ export interface SlashContext {
   compact?: () => Promise<void>;
   /** Exit the application */
   exit?: () => void;
+  /** Set output style */
+  setOutputStyle?: (style: string) => void;
+  /** Get current output style */
+  getOutputStyle?: () => string;
 }
 
 interface SlashCommand {
@@ -141,6 +145,23 @@ const commands: SlashCommand[] = [
       if (!ctx.compact) return 'Compaction not available.';
       await ctx.compact();
       return 'Context compacted.';
+    },
+  },
+  {
+    name: 'style',
+    aliases: [],
+    description: 'Switch output style',
+    usage: '/style [concise|detailed|learning]',
+    execute: (args, ctx) => {
+      const valid = ['concise', 'detailed', 'learning'];
+      if (!args) {
+        return `Current style: ${ctx.getOutputStyle?.() ?? 'concise'}. Options: ${valid.join(', ')}`;
+      }
+      if (!valid.includes(args)) {
+        return `Invalid style: ${args}. Options: ${valid.join(', ')}`;
+      }
+      ctx.setOutputStyle?.(args);
+      return `Output style: ${args}`;
     },
   },
   {

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -80,6 +80,7 @@ const generalSchema = z.object({
   defaultPermissionMode: z.enum(['auto', 'confirm', 'plan']).default('confirm'),
   theme: z.enum(['dark', 'light']).default('dark'),
   maxSteps: z.number().default(10),
+  outputStyle: z.enum(['concise', 'detailed', 'learning']).default('concise'),
 });
 
 // ── Full Config ──────────────────────────────────────────────────────

--- a/packages/core/src/agent/context.ts
+++ b/packages/core/src/agent/context.ts
@@ -3,6 +3,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { INSIGHT_PROMPT_SECTION } from './insights.js';
+import { getOutputStylePrompt, type OutputStyle } from './output-styles.js';
 
 const DEFAULT_SYSTEM_PROMPT = `You are Brainstorm, an AI coding assistant with intelligent model routing. You help users with software engineering tasks: writing code, debugging, refactoring, reviewing, and explaining code.
 
@@ -68,8 +69,13 @@ export interface SystemPromptResult {
   frontmatter: StormFrontmatter | null;
 }
 
-export function buildSystemPrompt(projectPath: string): SystemPromptResult {
+export function buildSystemPrompt(projectPath: string, outputStyle?: OutputStyle): SystemPromptResult {
   const parts = [DEFAULT_SYSTEM_PROMPT];
+
+  // Inject output style instructions
+  if (outputStyle) {
+    parts.push('\n' + getOutputStylePrompt(outputStyle));
+  }
   let frontmatter: StormFrontmatter | null = null;
 
   // Project context from STORM.md (or BRAINSTORM.md)

--- a/packages/core/src/agent/output-styles.ts
+++ b/packages/core/src/agent/output-styles.ts
@@ -1,0 +1,54 @@
+/**
+ * Output style modes control how verbose and educational the assistant's responses are.
+ *
+ * - concise: Default. Short answers, action-first, no extra explanations.
+ * - detailed: Longer explanations, reasoning shown, trade-offs discussed.
+ * - learning: Educational mode with ★ Insight annotations and trade-off analysis.
+ */
+
+export type OutputStyle = 'concise' | 'detailed' | 'learning';
+
+const STYLE_PROMPTS: Record<OutputStyle, string> = {
+  concise: `# Output Style: Concise
+
+Keep responses short and direct. Lead with the action or answer. Skip filler, preamble, and unnecessary transitions.
+- If you can say it in one sentence, don't use three.
+- Don't explain your reasoning unless asked.
+- No trailing summaries.
+- Focus on what changed and what to do next.`,
+
+  detailed: `# Output Style: Detailed
+
+Provide thorough explanations alongside your actions. Show your reasoning and discuss trade-offs.
+- Explain WHY you chose this approach over alternatives.
+- Mention relevant patterns, best practices, or gotchas.
+- Include brief notes on edge cases or potential issues.
+- Still lead with action, but follow with explanation.`,
+
+  learning: `# Output Style: Learning
+
+You are in teaching mode. Help the user learn from every interaction.
+- Before and after writing code, provide brief educational insights using this format:
+
+★ Insight ─────────────────────────────────────
+[2-3 key educational points about the implementation choice]
+─────────────────────────────────────────────────
+
+- Explain trade-offs between different approaches.
+- Point out patterns the user can reuse elsewhere.
+- Connect the current task to broader concepts.
+- Ask the user to implement small, meaningful pieces (5-10 lines) when there's a genuine design choice to make.
+- Focus insights on what's specific to this codebase, not general programming.`,
+};
+
+/**
+ * Get the system prompt segment for an output style.
+ */
+export function getOutputStylePrompt(style: OutputStyle): string {
+  return STYLE_PROMPTS[style] ?? STYLE_PROMPTS.concise;
+}
+
+/**
+ * All valid output style names.
+ */
+export const OUTPUT_STYLES: OutputStyle[] = ['concise', 'detailed', 'learning'];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,3 +13,4 @@ export { scanForCredentials, redactCredentials, type ScanResult } from './securi
 export { resolveSafe, isWithinWorkspace, PathTraversalError } from './security/path-guard.js';
 export { filterResponse, createStreamFilter, type StreamFilter } from './agent/response-filter.js';
 export { normalizeInsightMarkers } from './agent/insights.js';
+export { getOutputStylePrompt, OUTPUT_STYLES, type OutputStyle } from './agent/output-styles.js';


### PR DESCRIPTION
## Summary
- **3 output styles**: concise (default, terse), detailed (explains reasoning), learning (★ Insight annotations)
- **System prompt injection**: `getOutputStylePrompt()` returns style-specific instructions
- **Config support**: `general.outputStyle` in config schema
- **Slash command**: `/style [concise|detailed|learning]` to switch at runtime
- **buildSystemPrompt()** now accepts optional `outputStyle` parameter

## Test plan
- [ ] Build: `npx turbo run build`
- [ ] Verify `/style learning` changes response behavior
- [ ] Verify `/style` without args shows current style
- [ ] Verify config `outputStyle = "detailed"` is accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)