### PR TITLE
feat: input history with up/down navigation

### DIFF
--- a/packages/cli/src/components/ChatApp.tsx
+++ b/packages/cli/src/components/ChatApp.tsx
@@ -6,6 +6,7 @@ import { MessageList, type ChatMessage } from './MessageList.js';
 import { TaskList } from './TaskList.js';
 import { isSlashCommand, executeSlashCommand, type SlashContext } from '../commands/slash.js';
 import { resolveKeyAction } from '../keybindings.js';
+import { InputHistory } from '../input-history.js';
 import type { AgentEvent, AgentTask, RoutingDecision } from '@brainstorm/shared';
 
 interface ChatAppProps {
@@ -25,9 +26,22 @@ export function ChatApp({ strategy, modelCount, onSendMessage, onAbort }: ChatAp
   const [isProcessing, setIsProcessing] = useState(false);
   const [tasks, setTasks] = useState<AgentTask[]>([]);
   const [tokenCount, setTokenCount] = useState<{ input: number; output: number }>({ input: 0, output: 0 });
+  const [history] = useState(() => new InputHistory());
 
-  // Keybinding handler
+  // Keybinding handler + input history navigation
   useInput((inputChar, key) => {
+    // Up/Down arrow for input history
+    if (key.upArrow && !isProcessing) {
+      const prev = history.up(input);
+      if (prev !== null) setInput(prev);
+      return;
+    }
+    if (key.downArrow && !isProcessing) {
+      const next = history.down();
+      if (next !== null) setInput(next);
+      return;
+    }
+
     const action = resolveKeyAction(inputChar, key as any);
     if (!action) return;
 
@@ -63,6 +77,7 @@ export function ChatApp({ strategy, modelCount, onSendMessage, onAbort }: ChatAp
 
   const handleSubmit = useCallback(async (text: string) => {
     if (!text.trim() || isProcessing) return;
+    history.push(text.trim());
 
     // Handle slash commands
     if (isSlashCommand(text)) {

--- a/packages/cli/src/input-history.ts
+++ b/packages/cli/src/input-history.ts
@@ -1,0 +1,142 @@
+/**
+ * Input history with persistence.
+ *
+ * Keeps the last N inputs in memory and persists to disk.
+ * Up/Down arrow navigation cycles through previous inputs.
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+const HISTORY_DIR = join(homedir(), '.brainstorm');
+const HISTORY_FILE = join(HISTORY_DIR, 'input-history.json');
+const MAX_MEMORY = 100;
+const MAX_PERSIST = 500;
+
+export class InputHistory {
+  private entries: string[] = [];
+  private cursor = -1;
+  private draft = '';
+
+  constructor() {
+    this.load();
+  }
+
+  /**
+   * Add an input to history. Deduplicates consecutive identical entries.
+   */
+  push(input: string): void {
+    const trimmed = input.trim();
+    if (!trimmed) return;
+
+    // Don't add if identical to most recent
+    if (this.entries.length > 0 && this.entries[this.entries.length - 1] === trimmed) {
+      this.resetCursor();
+      return;
+    }
+
+    this.entries.push(trimmed);
+
+    // Trim memory buffer
+    if (this.entries.length > MAX_MEMORY) {
+      this.entries = this.entries.slice(-MAX_MEMORY);
+    }
+
+    this.resetCursor();
+    this.save();
+  }
+
+  /**
+   * Navigate up (older). Returns the entry to display, or null if at the end.
+   */
+  up(currentInput: string): string | null {
+    if (this.entries.length === 0) return null;
+
+    // Save current input as draft on first up
+    if (this.cursor === -1) {
+      this.draft = currentInput;
+    }
+
+    const nextCursor = this.cursor === -1 ? this.entries.length - 1 : this.cursor - 1;
+    if (nextCursor < 0) return null;
+
+    this.cursor = nextCursor;
+    return this.entries[this.cursor];
+  }
+
+  /**
+   * Navigate down (newer). Returns the entry to display, or the draft if at bottom.
+   */
+  down(): string | null {
+    if (this.cursor === -1) return null;
+
+    this.cursor += 1;
+
+    if (this.cursor >= this.entries.length) {
+      this.cursor = -1;
+      return this.draft;
+    }
+
+    return this.entries[this.cursor];
+  }
+
+  /**
+   * Reset cursor position (called after submitting input).
+   */
+  resetCursor(): void {
+    this.cursor = -1;
+    this.draft = '';
+  }
+
+  /**
+   * Get all entries (for debugging/export).
+   */
+  getAll(): string[] {
+    return [...this.entries];
+  }
+
+  private load(): void {
+    try {
+      if (existsSync(HISTORY_FILE)) {
+        const data = JSON.parse(readFileSync(HISTORY_FILE, 'utf-8'));
+        if (Array.isArray(data)) {
+          this.entries = data.slice(-MAX_MEMORY);
+        }
+      }
+    } catch {
+      // Corrupt file — start fresh
+      this.entries = [];
+    }
+  }
+
+  private save(): void {
+    try {
+      if (!existsSync(HISTORY_DIR)) mkdirSync(HISTORY_DIR, { recursive: true });
+
+      // Load full history from disk, append new entries, trim
+      let fullHistory: string[] = [];
+      try {
+        if (existsSync(HISTORY_FILE)) {
+          const data = JSON.parse(readFileSync(HISTORY_FILE, 'utf-8'));
+          if (Array.isArray(data)) fullHistory = data;
+        }
+      } catch {
+        // Start fresh
+      }
+
+      // Merge: disk history + memory entries (deduped at tail)
+      const merged = [...fullHistory];
+      for (const entry of this.entries) {
+        if (merged[merged.length - 1] !== entry) {
+          merged.push(entry);
+        }
+      }
+
+      const trimmed = merged.slice(-MAX_PERSIST);
+      writeFileSync(HISTORY_FILE, JSON.stringify(trimmed), 'utf-8');
+    } catch {
+      // Non-fatal — history is a convenience feature
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- **InputHistory class**: in-memory buffer (100) + disk persistence (500 entries)
- **Up/Down arrows**: cycle through previous inputs in ChatApp
- **Persistence**: saves to `~/.brainstorm/input-history.json`
- **Deduplication**: skips consecutive identical entries
- **Draft preservation**: current input saved as draft when navigating up

## Test plan
- [ ] Build: `npx turbo run build --filter=@brainstorm/cli`
- [ ] Verify Up arrow recalls previous input
- [ ] Verify Down arrow returns to current draft
- [ ] Verify history persists across sessions
- [ ] Verify slash commands are also saved to history

🤖 Generated with [Claude Code](https://claude.com/claude-code)