### PR TITLE
feat: specialized subagent types with tool filtering

### DIFF
--- a/packages/core/src/agent/subagent.ts
+++ b/packages/core/src/agent/subagent.ts
@@ -5,6 +5,73 @@ import { BrainstormRouter, CostTracker } from '@brainstorm/router';
 import type { ToolRegistry } from '@brainstorm/tools';
 import { serializeRoutingMetadata } from '@brainstorm/shared';
 
+// ── Subagent Types ──────────────────────────────────────────────────
+
+export type SubagentType = 'explore' | 'plan' | 'code' | 'review' | 'general';
+
+interface SubagentTypeConfig {
+  /** Tools this subagent type is allowed to use */
+  allowedTools: string[] | 'all';
+  /** System prompt prefix for behavioral instructions */
+  systemPrompt: string;
+  /** Default max steps (keep focused subagents short) */
+  defaultMaxSteps: number;
+  /** Model complexity hint: 'cheap' routes to cost-first, 'capable' to quality-first */
+  modelHint: 'cheap' | 'capable';
+}
+
+const SUBAGENT_TYPES: Record<SubagentType, SubagentTypeConfig> = {
+  explore: {
+    allowedTools: ['file_read', 'glob', 'grep', 'list_dir', 'git_status', 'git_diff', 'git_log'],
+    systemPrompt:
+      'You are an exploration subagent. Your job is to find information in the codebase quickly and return what you found. You have read-only tools — you cannot modify files. Be thorough but concise.',
+    defaultMaxSteps: 5,
+    modelHint: 'cheap',
+  },
+  plan: {
+    allowedTools: ['file_read', 'glob', 'grep', 'list_dir', 'git_status', 'git_diff', 'git_log', 'task_create', 'task_update', 'task_list'],
+    systemPrompt:
+      'You are a planning subagent. Analyze the codebase and design an implementation approach. Create tasks to track the plan. You have read-only file tools plus task management. Return a structured plan.',
+    defaultMaxSteps: 8,
+    modelHint: 'capable',
+  },
+  code: {
+    allowedTools: 'all',
+    systemPrompt:
+      'You are a coding subagent. Implement the requested changes, verify they compile, and return a summary of what you changed. Follow existing patterns in the codebase.',
+    defaultMaxSteps: 10,
+    modelHint: 'capable',
+  },
+  review: {
+    allowedTools: ['file_read', 'glob', 'grep', 'list_dir', 'git_status', 'git_diff', 'git_log', 'git_commit'],
+    systemPrompt:
+      'You are a code review subagent. Review the changes for bugs, style issues, and correctness. Be specific — cite file paths and line numbers. Focus on real issues, not nitpicks.',
+    defaultMaxSteps: 5,
+    modelHint: 'capable',
+  },
+  general: {
+    allowedTools: 'all',
+    systemPrompt:
+      'You are a focused subagent. Complete the given task concisely and return the result. Do not ask questions — make your best judgment.',
+    defaultMaxSteps: 5,
+    modelHint: 'cheap',
+  },
+};
+
+/**
+ * Get the configuration for a subagent type.
+ */
+export function getSubagentTypeConfig(type: SubagentType): SubagentTypeConfig {
+  return SUBAGENT_TYPES[type];
+}
+
+/**
+ * All valid subagent type names.
+ */
+export const SUBAGENT_TYPE_NAMES: SubagentType[] = ['explore', 'plan', 'code', 'review', 'general'];
+
+// ── Subagent Execution ──────────────────────────────────────────────
+
 export interface SubagentOptions {
   config: BrainstormConfig;
   registry: ProviderRegistry;
@@ -12,9 +79,11 @@ export interface SubagentOptions {
   costTracker: CostTracker;
   tools: ToolRegistry;
   projectPath: string;
-  /** System prompt override for the subagent. */
+  /** Subagent type — determines tool access, system prompt, and model hint. */
+  type?: SubagentType;
+  /** System prompt override (overrides type's default). */
   systemPrompt?: string;
-  /** Max steps for the subagent (default: 5, keeps it focused). */
+  /** Max steps override (overrides type's default). */
   maxSteps?: number;
 }
 
@@ -23,6 +92,7 @@ export interface SubagentResult {
   cost: number;
   modelUsed: string;
   toolCalls: string[];
+  type: SubagentType;
 }
 
 /**
@@ -30,35 +100,49 @@ export interface SubagentResult {
  *
  * Subagents get their own context — they don't see the parent conversation.
  * This prevents context bloat while enabling parallel work.
- * BrainstormRouter routes subagents to cheaper models (they're simpler tasks).
+ *
+ * The subagent type determines:
+ * - Which tools are available (explore = read-only, code = all)
+ * - System prompt behavior (review = bug-focused, plan = structured output)
+ * - Model selection hint (explore → cheap, code → capable)
  */
 export async function spawnSubagent(
   task: string,
   options: SubagentOptions,
 ): Promise<SubagentResult> {
   const { router, costTracker, tools, config, registry, projectPath } = options;
+  const type = options.type ?? 'general';
+  const typeConfig = SUBAGENT_TYPES[type];
 
   const taskProfile = router.classify(task);
-  const decision = router.route(taskProfile);
+
+  // Apply model hint: override routing strategy for this subagent
+  const decision = router.route(taskProfile, {
+    preferCheap: typeConfig.modelHint === 'cheap',
+  });
 
   const modelId = registry.getProvider(decision.model.id);
-  const systemPrompt = options.systemPrompt ??
-    'You are a focused subagent. Complete the given task concisely and return the result. Do not ask questions — make your best judgment.';
+  const systemPrompt = options.systemPrompt ?? typeConfig.systemPrompt;
+  const maxSteps = options.maxSteps ?? typeConfig.defaultMaxSteps;
+
+  // Filter tools based on subagent type
+  const filteredTools = typeConfig.allowedTools === 'all'
+    ? tools.toAISDKTools()
+    : tools.toAISDKToolsFiltered(typeConfig.allowedTools);
 
   const costBefore = costTracker.getSessionCost();
   const toolCallNames: string[] = [];
   let fullText = '';
 
-  // Serialize task context for gateway telemetry (x-br-metadata header)
   const metadataHeader = serializeRoutingMetadata(taskProfile, decision);
 
   const result = streamText({
     model: modelId,
     system: systemPrompt,
     messages: [{ role: 'user' as const, content: task }],
-    tools: tools.toAISDKTools(),
+    tools: filteredTools,
     ...(metadataHeader ? { headers: { 'x-br-metadata': metadataHeader } } : {}),
-    stopWhen: stepCountIs(options.maxSteps ?? 5),
+    stopWhen: stepCountIs(maxSteps),
     onStepFinish: async ({ usage }: any) => {
       if (usage) {
         costTracker.record({
@@ -88,5 +172,20 @@ export async function spawnSubagent(
     cost: costTracker.getSessionCost() - costBefore,
     modelUsed: decision.model.name,
     toolCalls: toolCallNames,
+    type,
   };
+}
+
+/**
+ * Spawn multiple subagents in parallel.
+ */
+export async function spawnParallel(
+  specs: Array<{ task: string; type?: SubagentType }>,
+  options: SubagentOptions,
+): Promise<SubagentResult[]> {
+  return Promise.all(
+    specs.map((spec) =>
+      spawnSubagent(spec.task, { ...options, type: spec.type }),
+    ),
+  );
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@ export { buildSystemPrompt, parseAtMentions } from './agent/context.js';
 export { SessionManager } from './session/manager.js';
 export { PermissionManager } from './permissions/manager.js';
 export { compactContext, estimateTokenCount, needsCompaction } from './session/compaction.js';
-export { spawnSubagent, type SubagentOptions, type SubagentResult } from './agent/subagent.js';
+export { spawnSubagent, spawnParallel, getSubagentTypeConfig, SUBAGENT_TYPE_NAMES, type SubagentOptions, type SubagentResult, type SubagentType } from './agent/subagent.js';
 export { loadSkills, findSkill, type SkillDefinition } from './skills/loader.js';
 export { MemoryManager, type MemoryEntry } from './memory/manager.js';
 export { getPlanModeTools, getPlanModePrompt } from './plan/mode.js';

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -45,12 +45,22 @@ export class BrainstormRouter {
     return classifyTask(message, context, this.projectHints);
   }
 
-  route(task: TaskProfile, conversationTokens?: number): RoutingDecision {
+  route(task: TaskProfile, optionsOrTokens?: number | { conversationTokens?: number; preferCheap?: boolean }): RoutingDecision {
     // Check budget before routing
     this.costTracker.checkBudget();
 
+    const opts = typeof optionsOrTokens === 'number'
+      ? { conversationTokens: optionsOrTokens, preferCheap: false }
+      : { conversationTokens: optionsOrTokens?.conversationTokens, preferCheap: optionsOrTokens?.preferCheap ?? false };
+
     const candidates = this.getEligibleModels(task);
-    const context = this.buildRoutingContext(conversationTokens);
+    const context = this.buildRoutingContext(opts.conversationTokens);
+
+    // If preferCheap, try cost-first strategy first
+    if (opts.preferCheap && this.strategies['cost-first']) {
+      const cheapDecision = this.strategies['cost-first'].select(task, candidates, context);
+      if (cheapDecision) return cheapDecision;
+    }
 
     // Try active strategy
     const decision = this.strategies[this.activeStrategy].select(task, candidates, context);

--- a/packages/tools/src/registry.ts
+++ b/packages/tools/src/registry.ts
@@ -28,6 +28,21 @@ export class ToolRegistry {
     return result;
   }
 
+  /**
+   * Return AI SDK tools filtered to only the named tools.
+   * Used by subagent types to restrict tool access.
+   */
+  toAISDKToolsFiltered(allowedNames: string[]): Record<string, ReturnType<BrainstormToolDef['toAISDKTool']>> {
+    const allowed = new Set(allowedNames);
+    const result: Record<string, any> = {};
+    for (const [name, tool] of this.tools) {
+      if (allowed.has(name)) {
+        result[name] = tool.toAISDKTool();
+      }
+    }
+    return result;
+  }
+
   getPermitted(overrides?: Record<string, ToolPermission>): Record<string, any> {
     const result: Record<string, any> = {};
     for (const [name, tool] of this.tools) {


### PR DESCRIPTION
## Summary
- **5 subagent types**: explore (read-only, cheap), plan (read + tasks, capable), code (all tools, capable), review (read + git, capable), general (all tools, cheap)
- **Tool filtering**: `toAISDKToolsFiltered()` on ToolRegistry restricts tool access per type
- **Model hints**: `preferCheap` option in router tries cost-first strategy for exploration tasks
- **Parallel execution**: `spawnParallel()` runs multiple subagents concurrently via Promise.all

## Test plan
- [ ] Build: `npx turbo run build`
- [ ] Verify explore subagent only has read tools
- [ ] Verify code subagent has full tool access
- [ ] Verify preferCheap routes to cheaper model

🤖 Generated with [Claude Code](https://claude.com/claude-code)