### PR TITLE
feat: subagent tool for model-initiated parallel work

### DIFF
--- a/packages/cli/src/components/ChatApp.tsx
+++ b/packages/cli/src/components/ChatApp.tsx
@@ -124,6 +124,12 @@ export function ChatApp({ strategy, modelCount, onSendMessage, onAbort }: ChatAp
               { role: 'routing', content: `context compacted — ${event.removed} messages summarized (${event.tokensBefore.toLocaleString()} → ${event.tokensAfter.toLocaleString()} tokens)` },
             ]);
             break;
+          case 'subagent-result':
+            setMessages((prev) => [
+              ...prev,
+              { role: 'routing', content: `subagent [${event.subagentType}] → ${event.model} ($${event.cost.toFixed(4)}, ${event.toolCalls.length} tool calls)` },
+            ]);
+            break;
           case 'task-created':
             setTasks((prev) => [...prev, event.task]);
             break;

--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -140,7 +140,18 @@ export async function* runAgentLoop(
       } else if (part.type === 'tool-call') {
         yield { type: 'tool-call-start', toolName: part.toolName, args: (part as any).input ?? (part as any).args };
       } else if (part.type === 'tool-result') {
-        yield { type: 'tool-call-result', toolName: part.toolName, result: (part as any).output ?? (part as any).result };
+        const toolResult = (part as any).output ?? (part as any).result;
+        yield { type: 'tool-call-result', toolName: part.toolName, result: toolResult };
+        // Emit subagent-result events for TUI display
+        if (part.toolName === 'subagent' && toolResult && typeof toolResult === 'object') {
+          if (toolResult.mode === 'single') {
+            yield { type: 'subagent-result', subagentType: toolResult.type, model: toolResult.model, cost: toolResult.cost, toolCalls: toolResult.toolCalls };
+          } else if (toolResult.mode === 'parallel' && Array.isArray(toolResult.results)) {
+            for (const r of toolResult.results) {
+              yield { type: 'subagent-result', subagentType: r.type, model: r.model, cost: r.cost, toolCalls: r.toolCalls };
+            }
+          }
+        }
         // Drain any task events queued by task_create/task_update tool executions
         while (taskEventQueue.length > 0) {
           yield taskEventQueue.shift()!;

--- a/packages/core/src/agent/subagent-tool.ts
+++ b/packages/core/src/agent/subagent-tool.ts
@@ -1,0 +1,79 @@
+import { z } from 'zod';
+import { defineTool, type BrainstormToolDef } from '@brainstorm/tools';
+import { spawnSubagent, spawnParallel, SUBAGENT_TYPE_NAMES, type SubagentOptions, type SubagentType } from './subagent.js';
+
+/**
+ * Create the subagent tool with runtime context injected.
+ *
+ * This tool lives in @brainstorm/core (not @brainstorm/tools) because it
+ * depends on the subagent execution engine, which would create a circular
+ * dependency if placed in the tools package.
+ *
+ * The model can call this tool to spawn focused subagents for parallel work:
+ * - explore: fast codebase search (read-only, cheap model)
+ * - plan: design implementation approach (read + task tools)
+ * - code: implement changes (full tool access, capable model)
+ * - review: review code for bugs (read + git tools)
+ * - general: any focused task (all tools, cheap model)
+ */
+export function createSubagentTool(options: SubagentOptions): BrainstormToolDef {
+  return defineTool({
+    name: 'subagent',
+    description:
+      'Spawn a focused subagent to handle a task in isolation. ' +
+      'Subagents get their own conversation context and return results when done. ' +
+      'Use "explore" for codebase search, "plan" for design, "code" for implementation, ' +
+      '"review" for code review, or "general" for any focused task. ' +
+      'Pass multiple items to the "parallel" array to run several subagents concurrently.',
+    permission: 'auto',
+    inputSchema: z.object({
+      task: z.string().optional().describe('Task prompt for a single subagent. Use this OR parallel, not both.'),
+      type: z.enum(['explore', 'plan', 'code', 'review', 'general']).default('general')
+        .describe('Subagent type — determines available tools, system prompt, and model selection.'),
+      parallel: z.array(z.object({
+        task: z.string().describe('Task prompt for this subagent.'),
+        type: z.enum(['explore', 'plan', 'code', 'review', 'general']).default('general')
+          .describe('Subagent type for this task.'),
+      })).optional().describe('Run multiple subagents in parallel. Each gets its own context.'),
+    }),
+    execute: async (input) => {
+      // Parallel mode: multiple subagents at once
+      if (input.parallel && input.parallel.length > 0) {
+        const results = await spawnParallel(
+          input.parallel.map((spec) => ({ task: spec.task, type: spec.type as SubagentType })),
+          options,
+        );
+        return {
+          mode: 'parallel',
+          results: results.map((r) => ({
+            type: r.type,
+            model: r.modelUsed,
+            cost: r.cost,
+            toolCalls: r.toolCalls,
+            response: r.text,
+          })),
+          totalCost: results.reduce((sum, r) => sum + r.cost, 0),
+        };
+      }
+
+      // Single mode
+      if (!input.task) {
+        return { error: 'Provide either "task" for single subagent or "parallel" for multiple.' };
+      }
+
+      const result = await spawnSubagent(input.task, {
+        ...options,
+        type: input.type as SubagentType,
+      });
+
+      return {
+        mode: 'single',
+        type: result.type,
+        model: result.modelUsed,
+        cost: result.cost,
+        toolCalls: result.toolCalls,
+        response: result.text,
+      };
+    },
+  });
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,3 +14,4 @@ export { resolveSafe, isWithinWorkspace, PathTraversalError } from './security/p
 export { filterResponse, createStreamFilter, type StreamFilter } from './agent/response-filter.js';
 export { normalizeInsightMarkers } from './agent/insights.js';
 export { getOutputStylePrompt, OUTPUT_STYLES, type OutputStyle } from './agent/output-styles.js';
+export { createSubagentTool } from './agent/subagent-tool.js';

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -194,6 +194,7 @@ export type AgentEvent =
   | { type: 'tool-output-partial'; toolName: string; chunk: string }
   | { type: 'task-created'; task: AgentTask }
   | { type: 'task-updated'; task: AgentTask }
+  | { type: 'subagent-result'; subagentType: string; model: string; cost: number; toolCalls: string[] }
   | { type: 'interrupted' }
   | { type: 'error'; error: Error }
   | { type: 'done'; totalCost: number; totalTokens?: { input: number; output: number } };


### PR DESCRIPTION
## Summary
- Add `subagent` tool that models can call to spawn focused subagents (single or parallel mode)
- 5 types: explore (read-only, cheap), plan (read+tasks), code (all tools), review (read+git), general
- Tool defined in `@brainstorm/core` via factory (`createSubagentTool`) to avoid circular deps with tools package
- Add `subagent-result` AgentEvent for TUI display of subagent completions
- Wire subagent result events in agent loop and ChatApp TUI

## Test plan
- [ ] Build passes: `npx turbo run build --force`
- [ ] Model can call `subagent` tool with `task` + `type` for single execution
- [ ] Model can call `subagent` tool with `parallel` array for concurrent execution
- [ ] TUI shows subagent completion with type, model, cost, tool call count

🤖 Generated with [Claude Code](https://claude.com/claude-code)