### PR TITLE
feat: subagent budget isolation

### DIFF
--- a/packages/core/src/agent/subagent.ts
+++ b/packages/core/src/agent/subagent.ts
@@ -85,6 +85,8 @@ export interface SubagentOptions {
   systemPrompt?: string;
   /** Max steps override (overrides type's default). */
   maxSteps?: number;
+  /** Budget limit in dollars. If exceeded, subagent is terminated (parent continues). */
+  budgetLimit?: number;
 }
 
 export interface SubagentResult {
@@ -130,9 +132,14 @@ export async function spawnSubagent(
     ? tools.toAISDKTools()
     : tools.toAISDKToolsFiltered(typeConfig.allowedTools);
 
+  const budgetLimit = options.budgetLimit ?? costTracker.getSubagentBudget();
   const costBefore = costTracker.getSessionCost();
   const toolCallNames: string[] = [];
   let fullText = '';
+  let budgetExceeded = false;
+
+  // AbortController for budget enforcement — terminates the subagent stream
+  const budgetAbort = new AbortController();
 
   const metadataHeader = serializeRoutingMetadata(taskProfile, decision);
 
@@ -142,6 +149,7 @@ export async function spawnSubagent(
     messages: [{ role: 'user' as const, content: task }],
     tools: filteredTools,
     ...(metadataHeader ? { headers: { 'x-br-metadata': metadataHeader } } : {}),
+    abortSignal: budgetAbort.signal,
     stopWhen: stepCountIs(maxSteps),
     onStepFinish: async ({ usage }: any) => {
       if (usage) {
@@ -156,20 +164,36 @@ export async function spawnSubagent(
           pricing: decision.model.pricing,
         });
       }
+      // Check subagent budget after each step
+      const subagentCost = costTracker.getSessionCost() - costBefore;
+      if (subagentCost >= budgetLimit) {
+        budgetExceeded = true;
+        budgetAbort.abort();
+      }
     },
   });
 
-  for await (const part of result.fullStream) {
-    if (part.type === 'text-delta') {
-      fullText += (part as any).delta ?? (part as any).text ?? '';
-    } else if (part.type === 'tool-call') {
-      toolCallNames.push(part.toolName);
+  try {
+    for await (const part of result.fullStream) {
+      if (part.type === 'text-delta') {
+        fullText += (part as any).delta ?? (part as any).text ?? '';
+      } else if (part.type === 'tool-call') {
+        toolCallNames.push(part.toolName);
+      }
     }
+  } catch (err: any) {
+    // AbortError from budget enforcement is expected — not an error
+    if (err.name !== 'AbortError') throw err;
+  }
+
+  const subagentCost = costTracker.getSessionCost() - costBefore;
+  if (budgetExceeded) {
+    fullText += `\n\n[Subagent terminated: budget limit of $${budgetLimit.toFixed(4)} exceeded ($${subagentCost.toFixed(4)} used)]`;
   }
 
   return {
     text: fullText,
-    cost: costTracker.getSessionCost() - costBefore,
+    cost: subagentCost,
     modelUsed: decision.model.name,
     toolCalls: toolCallNames,
     type,

--- a/packages/router/src/cost-tracker.ts
+++ b/packages/router/src/cost-tracker.ts
@@ -92,6 +92,21 @@ export class CostTracker {
   }
 
   /**
+   * Calculate a budget limit for a subagent.
+   * Default: remaining session budget / 4, or a fixed amount if no session limit.
+   */
+  getSubagentBudget(overrideBudget?: number): number {
+    if (overrideBudget !== undefined) return overrideBudget;
+    const sessionLimit = this.budgetConfig.perSession;
+    if (sessionLimit) {
+      const remaining = Math.max(0, sessionLimit - this.sessionCost);
+      return remaining / 4;
+    }
+    // No session limit — default to $0.50 per subagent
+    return 0.5;
+  }
+
+  /**
    * Reconcile actual cost from gateway headers with local tracking.
    * When the gateway reports the real cost, use it instead of our estimate.
    */


### PR DESCRIPTION
## Summary
- Each subagent gets a budget envelope (default: remaining session budget / 4, or $0.50)
- Budget checked after each step via `onStepFinish` callback
- Subagent terminated via `AbortController` when budget exceeded — parent continues
- Add `getSubagentBudget()` to `CostTracker` and `budgetLimit` to `SubagentOptions`

## Test plan
- [ ] Build passes: `npx turbo run build --force`
- [ ] Subagent with low budget limit terminates gracefully with budget message
- [ ] Parent session continues after subagent budget termination
- [ ] Default budget calculation: session limit / 4 or $0.50

🤖 Generated with [Claude Code](https://claude.com/claude-code)