### PR TITLE
feat: subagent hook events

### DIFF
--- a/packages/core/src/agent/subagent.ts
+++ b/packages/core/src/agent/subagent.ts
@@ -72,6 +72,12 @@ export const SUBAGENT_TYPE_NAMES: SubagentType[] = ['explore', 'plan', 'code', '
 
 // ── Subagent Execution ──────────────────────────────────────────────
 
+/** Callback for subagent lifecycle hooks (injected to avoid circular deps with @brainstorm/hooks). */
+export type SubagentHookFn = (
+  event: 'SubagentStart' | 'SubagentStop',
+  context: { subagentType: string; prompt?: string; budget?: number; result?: string; cost?: number; toolCalls?: number; model?: string },
+) => Promise<void>;
+
 export interface SubagentOptions {
   config: BrainstormConfig;
   registry: ProviderRegistry;
@@ -87,6 +93,8 @@ export interface SubagentOptions {
   maxSteps?: number;
   /** Budget limit in dollars. If exceeded, subagent is terminated (parent continues). */
   budgetLimit?: number;
+  /** Optional hook callback for SubagentStart/SubagentStop events. */
+  onHook?: SubagentHookFn;
 }
 
 export interface SubagentResult {
@@ -134,6 +142,11 @@ export async function spawnSubagent(
 
   const budgetLimit = options.budgetLimit ?? costTracker.getSubagentBudget();
   const costBefore = costTracker.getSessionCost();
+
+  // Fire SubagentStart hook
+  if (options.onHook) {
+    await options.onHook('SubagentStart', { subagentType: type, prompt: task, budget: budgetLimit });
+  }
   const toolCallNames: string[] = [];
   let fullText = '';
   let budgetExceeded = false;
@@ -189,6 +202,17 @@ export async function spawnSubagent(
   const subagentCost = costTracker.getSessionCost() - costBefore;
   if (budgetExceeded) {
     fullText += `\n\n[Subagent terminated: budget limit of $${budgetLimit.toFixed(4)} exceeded ($${subagentCost.toFixed(4)} used)]`;
+  }
+
+  // Fire SubagentStop hook
+  if (options.onHook) {
+    await options.onHook('SubagentStop', {
+      subagentType: type,
+      result: fullText.slice(0, 500),
+      cost: subagentCost,
+      toolCalls: toolCallNames.length,
+      model: decision.model.name,
+    });
   }
 
   return {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@ export { buildSystemPrompt, parseAtMentions } from './agent/context.js';
 export { SessionManager } from './session/manager.js';
 export { PermissionManager } from './permissions/manager.js';
 export { compactContext, estimateTokenCount, needsCompaction } from './session/compaction.js';
-export { spawnSubagent, spawnParallel, getSubagentTypeConfig, SUBAGENT_TYPE_NAMES, type SubagentOptions, type SubagentResult, type SubagentType } from './agent/subagent.js';
+export { spawnSubagent, spawnParallel, getSubagentTypeConfig, SUBAGENT_TYPE_NAMES, type SubagentOptions, type SubagentResult, type SubagentType, type SubagentHookFn } from './agent/subagent.js';
 export { loadSkills, findSkill, type SkillDefinition } from './skills/loader.js';
 export { MemoryManager, type MemoryEntry } from './memory/manager.js';
 export { getPlanModeTools, getPlanModePrompt } from './plan/mode.js';

--- a/packages/hooks/src/manager.ts
+++ b/packages/hooks/src/manager.ts
@@ -44,10 +44,16 @@ export class HookManager {
   ): Promise<HookResult[]> {
     const matching = this.hooks.filter((h) => {
       if (h.event !== event) return false;
-      if (h.matcher && context?.toolName) {
-        try {
-          return new RegExp(h.matcher).test(context.toolName);
-        } catch { return false; }
+      if (h.matcher) {
+        // For subagent hooks, match against subagent type
+        const matchTarget = (event === 'SubagentStart' || event === 'SubagentStop')
+          ? context?.subagentType as string
+          : context?.toolName;
+        if (matchTarget) {
+          try {
+            return new RegExp(h.matcher).test(matchTarget);
+          } catch { return false; }
+        }
       }
       return true;
     });
@@ -64,6 +70,9 @@ export class HookManager {
           let cmd = hook.command;
           if (context?.filePath) cmd = cmd.replace(/\$FILE/g, context.filePath);
           if (context?.toolName) cmd = cmd.replace(/\$TOOL/g, context.toolName);
+          if (context?.subagentType) cmd = cmd.replace(/\$SUBAGENT_TYPE/g, String(context.subagentType));
+          if (context?.subagentCost !== undefined) cmd = cmd.replace(/\$SUBAGENT_COST/g, String(context.subagentCost));
+          if (context?.subagentModel) cmd = cmd.replace(/\$SUBAGENT_MODEL/g, String(context.subagentModel));
 
           const { stdout, stderr } = await execFileAsync('/bin/sh', ['-c', cmd], {
             timeout: 10_000,

--- a/packages/hooks/src/types.ts
+++ b/packages/hooks/src/types.ts
@@ -9,7 +9,9 @@ export type HookEvent =
   | 'SessionEnd'      // When a session ends
   | 'Stop'            // When the agent finishes responding
   | 'PreCompact'      // Before context compaction
-  | 'PreCommit';      // Before a git commit
+  | 'PreCommit'       // Before a git commit
+  | 'SubagentStart'   // When a subagent is spawned
+  | 'SubagentStop';   // When a subagent completes (or is terminated)
 
 export type HookType = 'command' | 'prompt';
 


### PR DESCRIPTION
## Summary
- Add `SubagentStart` and `SubagentStop` to `HookEvent` type
- Hooks can match on subagent type via regex matcher (e.g., `explore|plan`)
- Expand `$SUBAGENT_TYPE`, `$SUBAGENT_COST`, `$SUBAGENT_MODEL` variables in hook commands
- Use `SubagentHookFn` callback pattern to avoid circular dependency (core → hooks)
- Fire hooks before and after subagent execution in `spawnSubagent()`

## Test plan
- [ ] Build passes: `npx turbo run build --force`
- [ ] Register SubagentStop hook, spawn subagent — hook fires with type, cost, model
- [ ] Matcher filters by subagent type (e.g., only fire for `code` subagents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)