### PR TITLE
feat: extended thinking/reasoning block support

### DIFF
--- a/packages/cli/src/components/ChatApp.tsx
+++ b/packages/cli/src/components/ChatApp.tsx
@@ -112,6 +112,12 @@ export function ChatApp({ strategy, modelCount, onSendMessage, onAbort }: ChatAp
             fullResponse += event.delta;
             setStreamingText(fullResponse);
             break;
+          case 'reasoning':
+            setMessages((prev) => [
+              ...prev,
+              { role: 'reasoning', content: event.content },
+            ]);
+            break;
           case 'tool-call-start':
             setMessages((prev) => [
               ...prev,

--- a/packages/cli/src/components/MessageList.tsx
+++ b/packages/cli/src/components/MessageList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Box, Text } from 'ink';
 
 export interface ChatMessage {
-  role: 'user' | 'assistant' | 'system' | 'routing';
+  role: 'user' | 'assistant' | 'system' | 'routing' | 'reasoning';
   content: string;
   model?: string;
   cost?: number;
@@ -52,6 +52,13 @@ function MessageBubble({ message }: { message: ChatMessage }) {
           {message.cost !== undefined && message.cost > 0 && (
             <Text color="gray" dimColor>  ${message.cost.toFixed(4)}</Text>
           )}
+        </Box>
+      );
+    case 'reasoning':
+      return (
+        <Box marginBottom={0} paddingLeft={2}>
+          <Text color="gray" dimColor>{'▸ '}</Text>
+          <Text color="gray" dimColor>{message.content.length > 200 ? message.content.slice(0, 200) + '...' : message.content}</Text>
         </Box>
       );
     case 'routing':

--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -133,7 +133,10 @@ export async function* runAgentLoop(
     const streamFilter = createStreamFilter();
 
     for await (const part of result.fullStream) {
-      if (part.type === 'text-delta') {
+      if (part.type === 'reasoning-delta') {
+        const content = (part as any).text ?? (part as any).delta ?? '';
+        if (content) yield { type: 'reasoning', content };
+      } else if (part.type === 'text-delta') {
         const raw = (part as any).text ?? (part as any).delta ?? '';
         const filtered = streamFilter.filter(raw);
         if (filtered) yield { type: 'text-delta', delta: normalizeInsightMarkers(filtered) };

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -195,6 +195,7 @@ export type AgentEvent =
   | { type: 'task-created'; task: AgentTask }
   | { type: 'task-updated'; task: AgentTask }
   | { type: 'subagent-result'; subagentType: string; model: string; cost: number; toolCalls: string[] }
+  | { type: 'reasoning'; content: string }
   | { type: 'interrupted' }
   | { type: 'error'; error: Error }
   | { type: 'done'; totalCost: number; totalTokens?: { input: number; output: number } };


### PR DESCRIPTION
## Summary
- Detect `reasoning-delta` events from AI SDK v6 stream
- Yield `reasoning` AgentEvent for TUI consumption
- Render reasoning blocks in dimmed text with `▸` prefix (truncated to 200 chars)
- Add `reasoning` role to `ChatMessage` type

## Test plan
- [ ] Build passes: `npx turbo run build --force`
- [ ] With a model supporting extended thinking, reasoning blocks appear in TUI
- [ ] Long reasoning blocks truncated to 200 chars
- [ ] Models without thinking blocks unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)