### PR TITLE
feat: PDF text extraction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -856,6 +856,190 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.80.tgz",
+      "integrity": "sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==",
+      "license": "MIT",
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-x64": "0.1.80",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.80",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.80",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.80"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.80.tgz",
+      "integrity": "sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.80.tgz",
+      "integrity": "sha512-O64APRTXRUiAz0P8gErkfEr3lipLJgM6pjATwavZ22ebhjYl/SUbpgM0xcWPQBNMP1n29afAC/Us5PX1vg+JNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.80.tgz",
+      "integrity": "sha512-FqqSU7qFce0Cp3pwnTjVkKjjOtxMqRe6lmINxpIZYaZNnVI0H5FtsaraZJ36SiTHNjZlUB69/HhxNDT1Aaa9vA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.80.tgz",
+      "integrity": "sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.80.tgz",
+      "integrity": "sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.80.tgz",
+      "integrity": "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.80.tgz",
+      "integrity": "sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.80.tgz",
+      "integrity": "sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.80.tgz",
+      "integrity": "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.80.tgz",
+      "integrity": "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
@@ -1411,6 +1595,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/pdf-parse": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/pdf-parse/-/pdf-parse-1.1.5.tgz",
+      "integrity": "sha512-kBfrSXsloMnUJOKi25s3+hRmkycHfLK6A09eRGqF/N8BkQoPUmaCr+q8Cli5FnfohEz/rsv82zAiPz/LXtOGhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/prop-types": {
@@ -2817,6 +3011,38 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"
+      }
+    },
+    "node_modules/pdf-parse": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-2.4.5.tgz",
+      "integrity": "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@napi-rs/canvas": "0.1.80",
+        "pdfjs-dist": "5.4.296"
+      },
+      "bin": {
+        "pdf-parse": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.16.0 <21 || >=22.3.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/mehmet-kozan"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.4.296",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
+      "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.80"
       }
     },
     "node_modules/picocolors": {
@@ -4232,9 +4458,11 @@
         "@brainstorm/router": "*",
         "@brainstorm/shared": "*",
         "@brainstorm/tools": "*",
-        "ai": "^6"
+        "ai": "^6",
+        "pdf-parse": "^2.4.5"
       },
       "devDependencies": {
+        "@types/pdf-parse": "^1.1.5",
         "tsup": "^8",
         "typescript": "^5.7"
       }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,16 +16,18 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@brainstorm/shared": "*",
     "@brainstorm/config": "*",
     "@brainstorm/db": "*",
-    "@brainstorm/router": "*",
-    "@brainstorm/providers": "*",
-    "@brainstorm/tools": "*",
     "@brainstorm/gateway": "*",
-    "ai": "^6"
+    "@brainstorm/providers": "*",
+    "@brainstorm/router": "*",
+    "@brainstorm/shared": "*",
+    "@brainstorm/tools": "*",
+    "ai": "^6",
+    "pdf-parse": "^2.4.5"
   },
   "devDependencies": {
+    "@types/pdf-parse": "^1.1.5",
     "tsup": "^8",
     "typescript": "^5.7"
   }

--- a/packages/core/src/multimodal/reader.ts
+++ b/packages/core/src/multimodal/reader.ts
@@ -28,9 +28,9 @@ export function isPdfFile(filePath: string): boolean {
 /**
  * Read a file and return multimodal content.
  * Images are base64-encoded for vision model consumption.
- * PDFs return a text note (full PDF parsing deferred to future PR).
+ * PDFs are parsed to extract text content.
  */
-export function readMultimodalFile(filePath: string): MultimodalContent | null {
+export async function readMultimodalFile(filePath: string, pages?: string): Promise<MultimodalContent | null> {
   if (!existsSync(filePath)) return null;
 
   const ext = extname(filePath).toLowerCase();
@@ -52,15 +52,84 @@ export function readMultimodalFile(filePath: string): MultimodalContent | null {
   }
 
   if (ext === PDF_EXTENSION) {
-    return {
-      type: 'text',
-      text: '[PDF file detected. Full PDF parsing will be available in a future update. For now, use a tool to extract text from the PDF.]',
-    };
+    return readPdfFile(filePath, pages);
   }
 
   // Regular text file
   const content = readFileSync(filePath, 'utf-8');
   return { type: 'text', text: content };
+}
+
+/**
+ * Extract text from a PDF file.
+ * Optionally filter to specific pages (e.g., "1-5", "3", "10-20").
+ */
+async function readPdfFile(filePath: string, pages?: string): Promise<MultimodalContent> {
+  try {
+    const pdfParseModule: any = await import('pdf-parse');
+    const pdfParse = pdfParseModule.default ?? pdfParseModule;
+    const buffer = readFileSync(filePath);
+    const data = await pdfParse(buffer);
+
+    let text = data.text;
+
+    // If pages specified, extract only those page ranges
+    if (pages && data.numpages > 1) {
+      const pageTexts = splitByPages(text, data.numpages);
+      const selectedPages = parsePageRange(pages, data.numpages);
+      text = selectedPages
+        .map((p) => pageTexts[p - 1] ?? '')
+        .filter(Boolean)
+        .join('\n\n--- Page break ---\n\n');
+    }
+
+    // Truncate extremely long PDFs (> 100k chars)
+    if (text.length > 100_000) {
+      text = text.slice(0, 100_000) + `\n\n[PDF truncated — ${text.length.toLocaleString()} chars total, showing first 100,000]`;
+    }
+
+    return {
+      type: 'text',
+      text: `[PDF: ${data.numpages} pages]\n\n${text}`,
+    };
+  } catch (err: any) {
+    return {
+      type: 'text',
+      text: `[PDF parsing failed: ${err.message}. Try using a shell tool to extract text with pdftotext.]`,
+    };
+  }
+}
+
+/** Rough page splitting by form feed characters or equal segments. */
+function splitByPages(text: string, numPages: number): string[] {
+  // Try form feed characters first (many PDFs use these)
+  const ffPages = text.split('\f');
+  if (ffPages.length >= numPages) return ffPages;
+
+  // Fall back to equal-length segments
+  const charsPerPage = Math.ceil(text.length / numPages);
+  const pages: string[] = [];
+  for (let i = 0; i < numPages; i++) {
+    pages.push(text.slice(i * charsPerPage, (i + 1) * charsPerPage));
+  }
+  return pages;
+}
+
+/** Parse page range string: "1-5", "3", "1,3,5-7" */
+function parsePageRange(pages: string, max: number): number[] {
+  const result = new Set<number>();
+  for (const part of pages.split(',')) {
+    const range = part.trim().split('-');
+    if (range.length === 2) {
+      const start = Math.max(1, parseInt(range[0], 10) || 1);
+      const end = Math.min(max, parseInt(range[1], 10) || max);
+      for (let i = start; i <= end; i++) result.add(i);
+    } else {
+      const page = parseInt(part.trim(), 10);
+      if (page >= 1 && page <= max) result.add(page);
+    }
+  }
+  return Array.from(result).sort((a, b) => a - b);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace PDF stub with actual `pdf-parse` text extraction
- Support page range filtering (`pages: "1-5"`)
- Form feed and equal-segment page splitting
- 100k char truncation for large PDFs
- Graceful error handling with fallback message
- `readMultimodalFile` is now async (no callers affected — not yet used in CLI)

## Test plan
- [ ] Build passes: `npx turbo run build --force`
- [ ] `@document.pdf` in chat injects PDF text into conversation
- [ ] Page range filtering works (e.g., pages "1-3")
- [ ] Large PDFs truncated at 100k chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)