### PR TITLE
feat: shell sandbox mode

### DIFF
--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -35,6 +35,7 @@ const compactionSchema = z.object({
 const shellSchema = z.object({
   defaultTimeout: z.number().default(120_000),
   maxOutputBytes: z.number().default(50_000),
+  sandbox: z.enum(['none', 'restricted', 'container']).default('none'),
 });
 
 // ── Budget Config ────────────────────────────────────────────────────

--- a/packages/tools/src/builtin/sandbox.ts
+++ b/packages/tools/src/builtin/sandbox.ts
@@ -1,0 +1,69 @@
+/**
+ * Shell sandbox — blocks dangerous commands before execution.
+ *
+ * Three levels:
+ * - none: no restrictions (current default)
+ * - restricted: block dangerous patterns, warn on risky ones
+ * - container: (future) Docker isolation
+ */
+
+export type SandboxLevel = 'none' | 'restricted' | 'container';
+
+export interface SandboxResult {
+  allowed: boolean;
+  reason?: string;
+}
+
+/** Patterns that are always blocked in restricted mode. */
+const BLOCKED_PATTERNS: Array<{ pattern: RegExp; reason: string }> = [
+  { pattern: /\brm\s+(-\w*r\w*\s+.*)?\/\s*$/, reason: 'Recursive deletion of root filesystem' },
+  { pattern: /\brm\s+-\w*rf\w*\s+\//, reason: 'Recursive force deletion from root' },
+  { pattern: /\bsudo\b/, reason: 'Elevated privileges not allowed in sandbox' },
+  { pattern: /\bchmod\s+777\b/, reason: 'World-writable permissions are insecure' },
+  { pattern: /\bmkfs\b/, reason: 'Filesystem creation is destructive' },
+  { pattern: /\bdd\s+if=/, reason: 'Raw disk operations blocked' },
+  { pattern: /:\(\)\s*\{\s*:\|:&\s*\}\s*;/, reason: 'Fork bomb detected' },
+  { pattern: />\s*\/dev\/sd[a-z]/, reason: 'Direct device writes blocked' },
+  { pattern: /\bcurl\b.*\|\s*(ba)?sh/, reason: 'Piping remote content to shell is risky' },
+  { pattern: /\bwget\b.*\|\s*(ba)?sh/, reason: 'Piping remote content to shell is risky' },
+  { pattern: /\beval\s+"?\$\(.*curl/, reason: 'Eval of remote content blocked' },
+  { pattern: /\bshutdown\b/, reason: 'System shutdown blocked' },
+  { pattern: /\breboot\b/, reason: 'System reboot blocked' },
+  { pattern: /\binit\s+[06]\b/, reason: 'System halt/reboot blocked' },
+];
+
+/**
+ * Check if a command is allowed under the given sandbox level.
+ */
+export function checkSandbox(command: string, level: SandboxLevel, projectPath?: string): SandboxResult {
+  if (level === 'none') {
+    return { allowed: true };
+  }
+
+  if (level === 'container') {
+    // Container mode not yet implemented — fall back to restricted
+    return checkRestricted(command, projectPath);
+  }
+
+  return checkRestricted(command, projectPath);
+}
+
+function checkRestricted(command: string, projectPath?: string): SandboxResult {
+  // Check against blocked patterns
+  for (const { pattern, reason } of BLOCKED_PATTERNS) {
+    if (pattern.test(command)) {
+      return { allowed: false, reason: `Sandbox blocked: ${reason}` };
+    }
+  }
+
+  // Check for writes outside project directory (heuristic)
+  if (projectPath) {
+    // Detect absolute path writes that aren't within the project
+    const absWritePattern = /(?:>|tee|cp|mv|install)\s+\/?(?:usr|etc|var|opt|tmp|home|root)\//;
+    if (absWritePattern.test(command)) {
+      return { allowed: false, reason: 'Sandbox blocked: writing outside project directory' };
+    }
+  }
+
+  return { allowed: true };
+}

--- a/packages/tools/src/builtin/shell.ts
+++ b/packages/tools/src/builtin/shell.ts
@@ -2,10 +2,21 @@ import { z } from 'zod';
 import { spawn } from 'node:child_process';
 import { defineTool } from '../base.js';
 import { checkGitSafety, formatViolations, hasHardBlock } from './git-safety.js';
+import { checkSandbox, type SandboxLevel } from './sandbox.js';
 
 const DEFAULT_TIMEOUT = 120_000;
 const HEAD_BYTES = 20_000;
 const TAIL_BYTES = 20_000;
+
+// Module-level sandbox config — set by the CLI during startup
+let currentSandboxLevel: SandboxLevel = 'none';
+let currentProjectPath: string | undefined;
+
+/** Configure the shell sandbox level. Call once during CLI startup. */
+export function configureSandbox(level: SandboxLevel, projectPath?: string): void {
+  currentSandboxLevel = level;
+  currentProjectPath = projectPath;
+}
 
 /**
  * Collect output with head+tail truncation.
@@ -64,6 +75,17 @@ export const shellTool = defineTool({
     timeout: z.number().optional().describe(`Timeout in milliseconds (default ${DEFAULT_TIMEOUT})`),
   }),
   async execute({ command, cwd, timeout }) {
+    // Sandbox check — block dangerous commands based on configured level
+    const sandboxResult = checkSandbox(command, currentSandboxLevel, currentProjectPath);
+    if (!sandboxResult.allowed) {
+      return {
+        stdout: '',
+        stderr: sandboxResult.reason ?? 'Command blocked by sandbox',
+        exitCode: 1,
+        blocked: true,
+      };
+    }
+
     // Git safety check — block destructive git operations
     if (/\bgit\b/.test(command)) {
       const violations = checkGitSafety(command);

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -12,6 +12,8 @@ export { gitDiffTool } from './builtin/git-diff.js';
 export { gitLogTool } from './builtin/git-log.js';
 export { gitCommitTool } from './builtin/git-commit.js';
 export { checkGitSafety, formatViolations, hasHardBlock, type GitSafetyViolation } from './builtin/git-safety.js';
+export { checkSandbox, type SandboxLevel } from './builtin/sandbox.js';
+export { configureSandbox } from './builtin/shell.js';
 export { ghPrTool } from './builtin/gh-pr.js';
 export { ghIssueTool } from './builtin/gh-issue.js';
 export { gitBranchTool } from './builtin/git-branch.js';


### PR DESCRIPTION
## Summary
- Three sandbox levels: none, restricted, container (future)
- Restricted blocks: rm -rf /, sudo, chmod 777, mkfs, fork bombs, curl|sh, device writes
- Blocks writes outside project directory
- `shell.sandbox` config option + `configureSandbox()` for CLI startup

## Test plan
- [ ] Build passes: `npx turbo run build --force`
- [ ] Set sandbox=restricted, try `rm -rf /` → blocked
- [ ] Normal commands pass through in restricted mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)