### PR TITLE
feat: background shell execution

### DIFF
--- a/packages/cli/src/components/ChatApp.tsx
+++ b/packages/cli/src/components/ChatApp.tsx
@@ -144,6 +144,12 @@ export function ChatApp({ strategy, modelCount, onSendMessage, onAbort }: ChatAp
               prev.map((t) => (t.id === event.task.id ? event.task : t)),
             );
             break;
+          case 'background-complete':
+            setMessages((prev) => [
+              ...prev,
+              { role: 'routing', content: `[bg] ${event.taskId} completed (exit ${event.exitCode}): ${event.command.slice(0, 60)}` },
+            ]);
+            break;
           case 'interrupted':
             setMessages((prev) => [
               ...prev,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -196,6 +196,7 @@ export type AgentEvent =
   | { type: 'task-updated'; task: AgentTask }
   | { type: 'subagent-result'; subagentType: string; model: string; cost: number; toolCalls: string[] }
   | { type: 'reasoning'; content: string }
+  | { type: 'background-complete'; taskId: string; command: string; exitCode: number; stdout: string; stderr: string }
   | { type: 'interrupted' }
   | { type: 'error'; error: Error }
   | { type: 'done'; totalCost: number; totalTokens?: { input: number; output: number } };

--- a/packages/tools/src/builtin/shell.ts
+++ b/packages/tools/src/builtin/shell.ts
@@ -18,6 +18,28 @@ export function configureSandbox(level: SandboxLevel, projectPath?: string): voi
   currentProjectPath = projectPath;
 }
 
+// ── Background Task Management ──────────────────────────────────────
+
+interface BackgroundTask {
+  id: string;
+  command: string;
+  startedAt: number;
+}
+
+const backgroundTasks = new Map<string, BackgroundTask>();
+let nextTaskId = 0;
+let backgroundEventHandler: ((event: { taskId: string; command: string; exitCode: number; stdout: string; stderr: string }) => void) | null = null;
+
+/** Set a callback for background task completion events. */
+export function setBackgroundEventHandler(handler: typeof backgroundEventHandler): void {
+  backgroundEventHandler = handler;
+}
+
+/** Get list of currently running background tasks. */
+export function getBackgroundTasks(): BackgroundTask[] {
+  return Array.from(backgroundTasks.values());
+}
+
 /**
  * Collect output with head+tail truncation.
  * Keeps the first HEAD_BYTES and last TAIL_BYTES of output,
@@ -73,8 +95,9 @@ export const shellTool = defineTool({
     command: z.string().describe('The command to execute (passed to /bin/sh -c)'),
     cwd: z.string().optional().describe('Working directory for the command'),
     timeout: z.number().optional().describe(`Timeout in milliseconds (default ${DEFAULT_TIMEOUT})`),
+    background: z.boolean().optional().describe('Run in background. Returns immediately with a task ID. You will be notified on completion.'),
   }),
-  async execute({ command, cwd, timeout }) {
+  async execute({ command, cwd, timeout, background }) {
     // Sandbox check — block dangerous commands based on configured level
     const sandboxResult = checkSandbox(command, currentSandboxLevel, currentProjectPath);
     if (!sandboxResult.allowed) {
@@ -97,6 +120,42 @@ export const shellTool = defineTool({
           blocked: true,
         };
       }
+    }
+
+    // Background mode: spawn detached and return immediately
+    if (background) {
+      const taskId = `bg-${nextTaskId++}`;
+      const child = spawn('/bin/sh', ['-c', command], {
+        cwd: cwd ?? process.cwd(),
+        stdio: ['ignore', 'pipe', 'pipe'],
+        detached: true,
+      });
+
+      backgroundTasks.set(taskId, { id: taskId, command, startedAt: Date.now() });
+
+      // Collect output in background
+      const bgStdout = new OutputCollector();
+      const bgStderr = new OutputCollector();
+      child.stdout.setEncoding('utf-8');
+      child.stderr.setEncoding('utf-8');
+      child.stdout.on('data', (chunk: string) => bgStdout.append(chunk));
+      child.stderr.on('data', (chunk: string) => bgStderr.append(chunk));
+
+      child.on('close', (code) => {
+        backgroundTasks.delete(taskId);
+        if (backgroundEventHandler) {
+          backgroundEventHandler({
+            taskId,
+            command,
+            exitCode: code ?? 1,
+            stdout: bgStdout.toString(),
+            stderr: bgStderr.toString(),
+          });
+        }
+      });
+
+      child.unref(); // Allow parent process to exit independently
+      return { taskId, status: 'running', message: `Running in background (${taskId}). You will be notified on completion.` };
     }
 
     const timeoutMs = timeout ?? DEFAULT_TIMEOUT;

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -13,7 +13,7 @@ export { gitLogTool } from './builtin/git-log.js';
 export { gitCommitTool } from './builtin/git-commit.js';
 export { checkGitSafety, formatViolations, hasHardBlock, type GitSafetyViolation } from './builtin/git-safety.js';
 export { checkSandbox, type SandboxLevel } from './builtin/sandbox.js';
-export { configureSandbox } from './builtin/shell.js';
+export { configureSandbox, setBackgroundEventHandler, getBackgroundTasks } from './builtin/shell.js';
 export { ghPrTool } from './builtin/gh-pr.js';
 export { ghIssueTool } from './builtin/gh-issue.js';
 export { gitBranchTool } from './builtin/git-branch.js';


### PR DESCRIPTION
## Summary
- Add `background: true` option to shell tool for non-blocking execution
- Background processes spawn detached, return immediately with task ID
- `background-complete` AgentEvent emitted on process completion
- `setBackgroundEventHandler()` / `getBackgroundTasks()` management API
- TUI displays `[bg] task-id completed (exit N)` notifications

## Test plan
- [ ] Build passes: `npx turbo run build --force`
- [ ] Run `npm test` with background=true → returns task ID immediately
- [ ] Background task completion notification appears in TUI
- [ ] Normal (foreground) shell execution unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)