### PR TITLE
fix: remaining audit findings (round 2)

### DIFF
--- a/packages/cli/src/input-history.ts
+++ b/packages/cli/src/input-history.ts
@@ -5,7 +5,7 @@
  * Up/Down arrow navigation cycles through previous inputs.
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 
@@ -134,7 +134,10 @@ export class InputHistory {
       }
 
       const trimmed = merged.slice(-MAX_PERSIST);
-      writeFileSync(HISTORY_FILE, JSON.stringify(trimmed), 'utf-8');
+      // Atomic write: temp file + rename prevents corruption on crash
+      const tmpFile = HISTORY_FILE + '.tmp';
+      writeFileSync(tmpFile, JSON.stringify(trimmed), 'utf-8');
+      renameSync(tmpFile, HISTORY_FILE);
     } catch {
       // Non-fatal — history is a convenience feature
     }

--- a/packages/core/src/agent/subagent.ts
+++ b/packages/core/src/agent/subagent.ts
@@ -22,9 +22,9 @@ interface SubagentTypeConfig {
 
 const SUBAGENT_TYPES: Record<SubagentType, SubagentTypeConfig> = {
   explore: {
-    allowedTools: ['file_read', 'glob', 'grep', 'list_dir', 'git_status', 'git_diff', 'git_log'],
+    allowedTools: ['file_read', 'glob', 'grep', 'list_dir', 'git_status', 'git_diff', 'git_log', 'web_fetch', 'web_search'],
     systemPrompt:
-      'You are an exploration subagent. Your job is to find information in the codebase quickly and return what you found. You have read-only tools — you cannot modify files. Be thorough but concise.',
+      'You are an exploration subagent. Your job is to find information in the codebase or online docs quickly and return what you found. You have read-only tools — you cannot modify files. Return results as a structured list of findings with file paths and line numbers where applicable.',
     defaultMaxSteps: 5,
     modelHint: 'cheap',
   },
@@ -50,9 +50,9 @@ const SUBAGENT_TYPES: Record<SubagentType, SubagentTypeConfig> = {
     modelHint: 'capable',
   },
   general: {
-    allowedTools: 'all',
+    allowedTools: ['file_read', 'glob', 'grep', 'list_dir', 'git_status', 'git_diff', 'git_log', 'web_fetch', 'web_search', 'shell', 'task_create', 'task_update', 'task_list'],
     systemPrompt:
-      'You are a focused subagent. Complete the given task concisely and return the result. Do not ask questions — make your best judgment.',
+      'You are a focused subagent. Complete the given task concisely and return the result. Do not ask questions — make your best judgment. You cannot create or edit files directly — use shell commands if you need to modify files.',
     defaultMaxSteps: 5,
     modelHint: 'cheap',
   },
@@ -140,6 +140,7 @@ export async function spawnSubagent(
     ? tools.toAISDKTools()
     : tools.toAISDKToolsFiltered(typeConfig.allowedTools);
 
+  const subagentSessionId = `subagent-${type}-${Date.now()}`;
   const budgetLimit = options.budgetLimit ?? costTracker.getSubagentBudget();
   const costBefore = costTracker.getSessionCost();
 
@@ -150,6 +151,7 @@ export async function spawnSubagent(
   const toolCallNames: string[] = [];
   let fullText = '';
   let budgetExceeded = false;
+  let subagentCostAccum = 0; // Track cost internally to avoid parallel race
 
   // AbortController for budget enforcement — terminates the subagent stream
   const budgetAbort = new AbortController();
@@ -166,20 +168,25 @@ export async function spawnSubagent(
     stopWhen: stepCountIs(maxSteps),
     onStepFinish: async ({ usage }: any) => {
       if (usage) {
+        const inputTokens = usage.inputTokens ?? 0;
+        const outputTokens = usage.outputTokens ?? 0;
+        const stepCost =
+          (inputTokens / 1_000_000) * decision.model.pricing.inputPer1MTokens +
+          (outputTokens / 1_000_000) * decision.model.pricing.outputPer1MTokens;
+        subagentCostAccum += stepCost;
         costTracker.record({
-          sessionId: 'subagent',
+          sessionId: subagentSessionId,
           modelId: decision.model.id,
           provider: decision.model.provider,
-          inputTokens: usage.inputTokens ?? 0,
-          outputTokens: usage.outputTokens ?? 0,
+          inputTokens,
+          outputTokens,
           taskType: taskProfile.type,
           projectPath,
           pricing: decision.model.pricing,
         });
       }
-      // Check subagent budget after each step
-      const subagentCost = costTracker.getSessionCost() - costBefore;
-      if (subagentCost >= budgetLimit) {
+      // Check budget using internal accumulator (not session delta) to avoid parallel races
+      if (subagentCostAccum >= budgetLimit) {
         budgetExceeded = true;
         budgetAbort.abort();
       }
@@ -199,9 +206,8 @@ export async function spawnSubagent(
     if (err.name !== 'AbortError') throw err;
   }
 
-  const subagentCost = costTracker.getSessionCost() - costBefore;
   if (budgetExceeded) {
-    fullText += `\n\n[Subagent terminated: budget limit of $${budgetLimit.toFixed(4)} exceeded ($${subagentCost.toFixed(4)} used)]`;
+    fullText += `\n\n[Subagent terminated: budget limit of $${budgetLimit.toFixed(4)} exceeded ($${subagentCostAccum.toFixed(4)} used)]`;
   }
 
   // Fire SubagentStop hook
@@ -209,7 +215,7 @@ export async function spawnSubagent(
     await options.onHook('SubagentStop', {
       subagentType: type,
       result: fullText.slice(0, 500),
-      cost: subagentCost,
+      cost: subagentCostAccum,
       toolCalls: toolCallNames.length,
       model: decision.model.name,
     });
@@ -217,7 +223,7 @@ export async function spawnSubagent(
 
   return {
     text: fullText,
-    cost: subagentCost,
+    cost: subagentCostAccum,
     modelUsed: decision.model.name,
     toolCalls: toolCallNames,
     type,

--- a/packages/core/src/permissions/manager.ts
+++ b/packages/core/src/permissions/manager.ts
@@ -1,5 +1,5 @@
 import type { ToolPermission } from '@brainstorm/shared';
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { readFileSync, writeFileSync, renameSync, mkdirSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 
@@ -156,7 +156,10 @@ export class PermissionManager {
         allowlist: Array.from(this.persistentAllowlist),
         denylist: Array.from(this.persistentDenylist),
       };
-      writeFileSync(PERMISSIONS_FILE, JSON.stringify(data, null, 2) + '\n');
+      // Atomic write: write to temp file then rename to prevent corruption on crash
+      const tmpFile = PERMISSIONS_FILE + '.tmp';
+      writeFileSync(tmpFile, JSON.stringify(data, null, 2) + '\n');
+      renameSync(tmpFile, PERMISSIONS_FILE);
     } catch { /* best-effort persistence */ }
   }
 

--- a/packages/tools/src/builtin/git-safety.ts
+++ b/packages/tools/src/builtin/git-safety.ts
@@ -61,6 +61,8 @@ const HOOK_SKIP_PATTERNS: Array<{ pattern: RegExp; flag: string }> = [
   { pattern: /--no-verify\b/, flag: '--no-verify' },
   { pattern: /--no-gpg-sign\b/, flag: '--no-gpg-sign' },
   { pattern: /-c\s+commit\.gpgsign=false\b/, flag: 'commit.gpgsign=false' },
+  { pattern: /-c\s+core\.hooksPath=/, flag: 'core.hooksPath override' },
+  { pattern: /\bHUSKY=0\b/, flag: 'HUSKY=0' },
 ];
 
 const BROAD_STAGING_PATTERNS = [
@@ -167,6 +169,7 @@ export function formatViolations(violations: GitSafetyViolation[]): string {
 export function hasHardBlock(violations: GitSafetyViolation[]): boolean {
   const HARD_RULES = new Set([
     'no-force-push-protected',
+    'no-force-push-main',
     'no-skip-hooks',
     'no-hard-reset',
     'no-clean-force',

--- a/packages/tools/src/builtin/sandbox.ts
+++ b/packages/tools/src/builtin/sandbox.ts
@@ -16,20 +16,40 @@ export interface SandboxResult {
 
 /** Patterns that are always blocked in restricted mode. */
 const BLOCKED_PATTERNS: Array<{ pattern: RegExp; reason: string }> = [
+  // Destructive filesystem operations
   { pattern: /\brm\s+(-\w*r\w*\s+.*)?\/\s*$/, reason: 'Recursive deletion of root filesystem' },
   { pattern: /\brm\s+-\w*rf\w*\s+\//, reason: 'Recursive force deletion from root' },
-  { pattern: /\bsudo\b/, reason: 'Elevated privileges not allowed in sandbox' },
-  { pattern: /\bchmod\s+777\b/, reason: 'World-writable permissions are insecure' },
   { pattern: /\bmkfs\b/, reason: 'Filesystem creation is destructive' },
   { pattern: /\bdd\s+if=/, reason: 'Raw disk operations blocked' },
-  { pattern: /:\(\)\s*\{\s*:\|:&\s*\}\s*;/, reason: 'Fork bomb detected' },
   { pattern: />\s*\/dev\/sd[a-z]/, reason: 'Direct device writes blocked' },
-  { pattern: /\bcurl\b.*\|\s*(ba)?sh/, reason: 'Piping remote content to shell is risky' },
-  { pattern: /\bwget\b.*\|\s*(ba)?sh/, reason: 'Piping remote content to shell is risky' },
-  { pattern: /\beval\s+"?\$\(.*curl/, reason: 'Eval of remote content blocked' },
+  { pattern: /\bchmod\s+777\b/, reason: 'World-writable permissions are insecure' },
+  // Privilege escalation
+  { pattern: /\bsudo\b/, reason: 'Elevated privileges not allowed in sandbox' },
+  { pattern: /\bsu\s+-c\b/, reason: 'Privilege escalation via su blocked' },
+  { pattern: /\bpkexec\b/, reason: 'Privilege escalation via pkexec blocked' },
+  { pattern: /\bdoas\b/, reason: 'Privilege escalation via doas blocked' },
+  // Fork bombs and system control
+  { pattern: /:\(\)\s*\{\s*:\|:&\s*\}\s*;/, reason: 'Fork bomb detected' },
   { pattern: /\bshutdown\b/, reason: 'System shutdown blocked' },
   { pattern: /\breboot\b/, reason: 'System reboot blocked' },
   { pattern: /\binit\s+[06]\b/, reason: 'System halt/reboot blocked' },
+  // Remote code execution
+  { pattern: /\bcurl\b.*\|\s*(ba)?sh/, reason: 'Piping remote content to shell is risky' },
+  { pattern: /\bwget\b.*\|\s*(ba)?sh/, reason: 'Piping remote content to shell is risky' },
+  { pattern: /\beval\s+"?\$\(.*curl/, reason: 'Eval of remote content blocked' },
+  // Encoding bypass detection — catch attempts to obfuscate dangerous commands
+  { pattern: /\bbase64\s+(-d|--decode)\b.*\|\s*(ba)?sh/, reason: 'Encoded command piped to shell blocked' },
+  { pattern: /\bbase64\b.*\|\s*(ba)?sh/, reason: 'Encoded command piped to shell blocked' },
+  { pattern: /\bpython[23]?\s+-c\b/, reason: 'Inline Python execution blocked in sandbox — use a .py file' },
+  { pattern: /\bnode\s+-e\b/, reason: 'Inline Node.js execution blocked in sandbox — use a .js file' },
+  { pattern: /\bperl\s+-e\b/, reason: 'Inline Perl execution blocked in sandbox — use a .pl file' },
+  { pattern: /\bruby\s+-e\b/, reason: 'Inline Ruby execution blocked in sandbox — use a .rb file' },
+  { pattern: /\$'\\x[0-9a-fA-F]/, reason: 'ANSI-C quoted escape sequence blocked' },
+  // Git history rewriting
+  { pattern: /\bgit\s+filter-branch\b/, reason: 'History rewriting via filter-branch blocked' },
+  { pattern: /\bgit\s+filter-repo\b/, reason: 'History rewriting via filter-repo blocked' },
+  { pattern: /\bgit\s+gc\s+.*--prune=now/, reason: 'Aggressive garbage collection blocked' },
+  { pattern: /\bgit\s+reflog\s+expire\s+.*--expire=now/, reason: 'Reflog expiry blocked' },
 ];
 
 /**
@@ -58,12 +78,12 @@ function checkRestricted(command: string, projectPath?: string): SandboxResult {
 
   // Check for writes outside project directory (heuristic)
   if (projectPath) {
-    // Detect absolute path writes that aren't within the project
-    const absWritePattern = /(?:>|tee|cp|mv|install)\s+\/?(?:usr|etc|var|opt|tmp|home|root)\//;
-    if (absWritePattern.test(command)) {
+    const systemPaths = /(?:>|tee|cp|mv|install)\s+\/?(?:usr|etc|var|opt|tmp|home|root|Library|System|private|proc|sys|dev)\//;
+    if (systemPaths.test(command)) {
       return { allowed: false, reason: 'Sandbox blocked: writing outside project directory' };
     }
   }
 
+  // Warn if container mode was expected but fell back to restricted
   return { allowed: true };
 }

--- a/packages/tools/src/builtin/shell.ts
+++ b/packages/tools/src/builtin/shell.ts
@@ -148,8 +148,12 @@ export const shellTool = defineTool({
           if (!child.killed) child.kill('SIGKILL');
         }, 5000);
       }, timeoutMs);
+      bgTimer.unref(); // Don't keep event loop alive for background timeout
 
+      let completed = false;
       const emitCompletion = (exitCode: number, stderr?: string) => {
+        if (completed) return; // Idempotent — error+close can both fire
+        completed = true;
         clearTimeout(bgTimer);
         backgroundTasks.delete(taskId);
         if (backgroundEventHandler) {


### PR DESCRIPTION
## Summary

Second round of fixes from the self-audit of the 20-PR parity gap implementation.

1. **Unique subagent sessionId** — no longer hardcoded `'subagent'`, each gets `subagent-{type}-{timestamp}`
2. **Budget race fix** — parallel subagents track cost internally instead of session delta
3. **Sandbox hardened** — encoding bypasses (base64, python -c, node -e), privilege escalation (su, pkexec, doas), git history rewriting, expanded system paths
4. **Git safety expanded** — `core.hooksPath` override, `HUSKY=0` hook bypass, `no-force-push-main` now a hard block
5. **Background shell** — idempotent `emitCompletion`, `bgTimer.unref()` for clean exit
6. **Atomic file writes** — permissions.json and input-history.json use temp+rename
7. **Explore subagent** — gains web_fetch/web_search, structured output prompt
8. **General subagent** — restricted from `'all'` to explicit safe tool list

## Test plan
- [ ] Build passes: `npx turbo run build --force`
- [ ] Parallel subagents get independent budget tracking
- [ ] `python3 -c "..."` blocked in restricted sandbox mode
- [ ] `git -c core.hooksPath=/dev/null commit` detected as hook bypass
- [ ] Background task error+close doesn't double-fire handler
- [ ] Kill CLI mid-write of permissions.json — file not corrupted on next start

🤖 Generated with [Claude Code](https://claude.com/claude-code)