### PR TITLE
feat: wire all dark features into CLI

### DIFF
--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -4,7 +4,8 @@ import { getDb } from '@brainstorm/db';
 import { createProviderRegistry } from '@brainstorm/providers';
 import { BrainstormRouter, CostTracker } from '@brainstorm/router';
 import { createDefaultToolRegistry, configureSandbox } from '@brainstorm/tools';
-import { runAgentLoop, buildSystemPrompt, SessionManager, type CompactionCallbacks } from '@brainstorm/core';
+import { runAgentLoop, buildSystemPrompt, SessionManager, PermissionManager, createSubagentTool, type CompactionCallbacks } from '@brainstorm/core';
+import type { OutputStyle } from '@brainstorm/core';
 import { AgentManager, parseAgentNL } from '@brainstorm/agents';
 import { runWorkflow, getPresetWorkflow, autoSelectPreset, PRESET_WORKFLOWS } from '@brainstorm/workflow';
 import { renderMarkdownToString } from '../components/MarkdownRenderer.js';
@@ -993,9 +994,28 @@ program
     await connectMCPServers(tools, config);
     const projectPath = process.cwd();
     configureSandbox(config.shell.sandbox as any, projectPath);
+
+    // Permission manager — gates tool execution
+    const permissionManager = new PermissionManager(
+      config.general.defaultPermissionMode as any,
+      config.permissions,
+    );
+
+    // Output style — mutable so /style can change it mid-session
+    let currentOutputStyle: OutputStyle = (config.general.outputStyle as OutputStyle) ?? 'concise';
+
     const sessionManager = new SessionManager(db);
-    const { prompt: systemPrompt, frontmatter } = buildSystemPrompt(projectPath);
+    let { prompt: systemPrompt, frontmatter } = buildSystemPrompt(projectPath, currentOutputStyle);
     const router = new BrainstormRouter(config, registry, costTracker, frontmatter);
+
+    // Register the subagent tool (model can spawn focused subagents)
+    const subagentTool = createSubagentTool({
+      config, registry, router, costTracker, tools, projectPath,
+    });
+    tools.register(subagentTool);
+
+    // Preferred model override — mutable so /model can change it
+    let preferredModelId: string | undefined;
 
     // Session management: resume, fork, or start new
     let session: any;
@@ -1056,6 +1076,8 @@ program
           sessionId: session.id, projectPath, systemPrompt,
           compaction: buildCompactionCallbacks(sessionManager),
           signal: simpleAbortController.signal,
+          permissionCheck: (name, perm) => permissionManager.check(name, perm),
+          preferredModelId,
         })) {
           if (event.type === 'routing') process.stderr.write(`[${event.decision.strategy} -> ${event.decision.model.name}] `);
           if (event.type === 'text-delta') { fullResponse += event.delta; process.stdout.write(event.delta); }
@@ -1086,6 +1108,8 @@ program
         sessionId: session.id, projectPath, systemPrompt,
         compaction: buildCompactionCallbacks(sessionManager),
         signal: currentAbortController.signal,
+        permissionCheck: (name, perm) => permissionManager.check(name, perm),
+        preferredModelId,
       });
       // Wrap to capture assistant message after completion
       return (async function* () {
@@ -1112,6 +1136,27 @@ program
         modelCount: { local: localCount, cloud: cloudCount },
         onSendMessage: handleSendMessage,
         onAbort: handleAbort,
+        slashCallbacks: {
+          setModel: (model: string) => { preferredModelId = model; },
+          setStrategy: (s: string) => { router.setStrategy(s as any); },
+          setMode: (mode: string) => { permissionManager.setMode(mode as any); },
+          getMode: () => permissionManager.getMode(),
+          setOutputStyle: (style: string) => {
+            currentOutputStyle = style as OutputStyle;
+            const rebuilt = buildSystemPrompt(projectPath, currentOutputStyle);
+            systemPrompt = rebuilt.prompt;
+          },
+          getOutputStyle: () => currentOutputStyle,
+          getBudget: () => {
+            const state = costTracker.getBudgetState();
+            if (!state.sessionLimit) return null;
+            return { remaining: Math.max(0, state.sessionLimit - state.sessionUsed), limit: state.sessionLimit };
+          },
+          compact: async () => {
+            const cb = buildCompactionCallbacks(sessionManager);
+            await cb.compact({ contextWindow: 128_000 });
+          },
+        },
       }),
     );
   });

--- a/packages/cli/src/components/ChatApp.tsx
+++ b/packages/cli/src/components/ChatApp.tsx
@@ -14,9 +14,20 @@ interface ChatAppProps {
   modelCount: { local: number; cloud: number };
   onSendMessage: (text: string) => AsyncGenerator<AgentEvent>;
   onAbort?: () => void;
+  /** Mutable context for slash commands — callbacks that affect session state */
+  slashCallbacks?: {
+    setModel?: (model: string) => void;
+    setStrategy?: (strategy: string) => void;
+    setMode?: (mode: string) => void;
+    getMode?: () => string;
+    setOutputStyle?: (style: string) => void;
+    getOutputStyle?: () => string;
+    getBudget?: () => { remaining: number; limit: number } | null;
+    compact?: () => Promise<void>;
+  };
 }
 
-export function ChatApp({ strategy, modelCount, onSendMessage, onAbort }: ChatAppProps) {
+export function ChatApp({ strategy, modelCount, onSendMessage, onAbort, slashCallbacks }: ChatAppProps) {
   const { exit } = useApp();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
@@ -68,12 +79,21 @@ export function ChatApp({ strategy, modelCount, onSendMessage, onAbort }: ChatAp
   const slashCtx: SlashContext = useMemo(() => ({
     getModel: () => currentModel,
     getSessionCost: () => sessionCost,
+    getTokenCount: () => tokenCount,
     exit: () => exit(),
     clearHistory: () => {
       setMessages([]);
       setStreamingText(undefined);
     },
-  }), [currentModel, sessionCost, exit]);
+    setModel: slashCallbacks?.setModel,
+    setStrategy: slashCallbacks?.setStrategy,
+    setMode: slashCallbacks?.setMode,
+    getMode: slashCallbacks?.getMode,
+    setOutputStyle: slashCallbacks?.setOutputStyle,
+    getOutputStyle: slashCallbacks?.getOutputStyle,
+    getBudget: slashCallbacks?.getBudget,
+    compact: slashCallbacks?.compact,
+  }), [currentModel, sessionCost, tokenCount, exit, slashCallbacks]);
 
   const handleSubmit = useCallback(async (text: string) => {
     if (!text.trim() || isProcessing) return;


### PR DESCRIPTION
## Summary

Multiple features were built across PRs #61-82 but never connected to the CLI entry point. This PR lights them all up:

- **Permission system**: `PermissionManager` created at startup, `permissionCheck` passed to `runAgentLoop` — tool execution is now actually gated
- **Subagent tool**: registered in the default tool registry — model can now spawn focused parallel subagents via the `subagent` tool
- **Output styles**: `config.general.outputStyle` passed to `buildSystemPrompt()` — concise/detailed/learning active from first message
- **All slash commands wired**: `/model`, `/strategy`, `/mode`, `/style`, `/budget`, `/compact`, `/cost` all connected to real state mutations
- **Both modes updated**: simple readline and Ink TUI

## Test plan
- [ ] Build passes
- [ ] `/mode plan` restricts tools to read-only
- [ ] `/model opus` overrides routing for next message
- [ ] `/style learning` changes response format with insight annotations
- [ ] `/budget` shows remaining session budget
- [ ] `/compact` triggers context compaction
- [ ] Model can call `subagent` tool with `type: 'explore'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)