### PR TITLE
fix: /fast toggle, subagent permissions, compact context window

### DIFF
--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -1011,6 +1011,7 @@ program
     // Register the subagent tool (model can spawn focused subagents)
     const subagentTool = createSubagentTool({
       config, registry, router, costTracker, tools, projectPath,
+      permissionCheck: (name, perm) => permissionManager.check(name, perm),
     });
     tools.register(subagentTool);
 
@@ -1139,6 +1140,7 @@ program
         slashCallbacks: {
           setModel: (model: string) => { preferredModelId = model; },
           setStrategy: (s: string) => { router.setStrategy(s as any); },
+          getStrategy: () => router.getActiveStrategy(),
           setMode: (mode: string) => { permissionManager.setMode(mode as any); },
           getMode: () => permissionManager.getMode(),
           setOutputStyle: (style: string) => {
@@ -1153,8 +1155,14 @@ program
             return { remaining: Math.max(0, state.sessionLimit - state.sessionUsed), limit: state.sessionLimit };
           },
           compact: async () => {
+            // Use the current model's context window, or fall back to 128k
+            const models = router.getModels();
+            const activeModel = preferredModelId
+              ? models.find((m) => m.id === preferredModelId)
+              : models[0];
+            const contextWindow = activeModel?.limits?.contextWindow || 128_000;
             const cb = buildCompactionCallbacks(sessionManager);
-            await cb.compact({ contextWindow: 128_000 });
+            await cb.compact({ contextWindow });
           },
         },
       }),

--- a/packages/cli/src/components/ChatApp.tsx
+++ b/packages/cli/src/components/ChatApp.tsx
@@ -18,6 +18,7 @@ interface ChatAppProps {
   slashCallbacks?: {
     setModel?: (model: string) => void;
     setStrategy?: (strategy: string) => void;
+    getStrategy?: () => string;
     setMode?: (mode: string) => void;
     getMode?: () => string;
     setOutputStyle?: (style: string) => void;
@@ -87,6 +88,7 @@ export function ChatApp({ strategy, modelCount, onSendMessage, onAbort, slashCal
     },
     setModel: slashCallbacks?.setModel,
     setStrategy: slashCallbacks?.setStrategy,
+    getStrategy: slashCallbacks?.getStrategy,
     setMode: slashCallbacks?.setMode,
     getMode: slashCallbacks?.getMode,
     setOutputStyle: slashCallbacks?.setOutputStyle,

--- a/packages/core/src/agent/subagent.ts
+++ b/packages/core/src/agent/subagent.ts
@@ -95,6 +95,8 @@ export interface SubagentOptions {
   budgetLimit?: number;
   /** Optional hook callback for SubagentStart/SubagentStop events. */
   onHook?: SubagentHookFn;
+  /** Permission check — when provided, subagent tools are gated by this function. */
+  permissionCheck?: (toolName: string, toolPermission: any) => 'allow' | 'confirm' | 'deny';
 }
 
 export interface SubagentResult {
@@ -135,10 +137,13 @@ export async function spawnSubagent(
   const systemPrompt = options.systemPrompt ?? typeConfig.systemPrompt;
   const maxSteps = options.maxSteps ?? typeConfig.defaultMaxSteps;
 
-  // Filter tools based on subagent type
-  const filteredTools = typeConfig.allowedTools === 'all'
-    ? tools.toAISDKTools()
+  // Filter tools based on subagent type, with permission gating if available
+  const baseTools = typeConfig.allowedTools === 'all'
+    ? (options.permissionCheck
+      ? tools.toAISDKToolsWithPermissions(options.permissionCheck)
+      : tools.toAISDKTools())
     : tools.toAISDKToolsFiltered(typeConfig.allowedTools);
+  const filteredTools = baseTools;
 
   const subagentSessionId = `subagent-${type}-${Date.now()}`;
   const budgetLimit = options.budgetLimit ?? costTracker.getSubagentBudget();


### PR DESCRIPTION
## Summary

Fixes 3 issues from the PR #83 code review:

1. **`/fast` toggle fixed** — `getStrategy` wired into `slashCallbacks` and `slashCtx` so the toggle reads actual router state instead of always defaulting to `quality-first`
2. **Subagent permission gating** — `permissionCheck` passed to `createSubagentTool` and threaded into `spawnSubagent`. Code subagents in `plan` mode now get tools gated by PermissionManager
3. **Model-aware compact** — `/compact` uses the active model's context window instead of hardcoded 128k. Local models with 4k-32k windows get correct compaction thresholds

## Test plan
- [ ] Build passes
- [ ] `/fast` toggles between cost-first and quality-first correctly
- [ ] Subagent in plan mode gets read-only tools (write tools blocked)
- [ ] `/compact` with a local model uses its actual context window

🤖 Generated with [Claude Code](https://claude.com/claude-code)