### PR TITLE
fix: scorer sandbox, workflow strategy, /fast compat

### DIFF
--- a/packages/cli/src/commands/slash.ts
+++ b/packages/cli/src/commands/slash.ts
@@ -44,7 +44,7 @@ interface SlashCommand {
   aliases: string[];
   description: string;
   usage: string;
-  execute: (args: string, ctx: SlashContext) => string | Promise<string>;
+  execute: (args: string, ctx: SlashContext, invokedAs?: string) => string | Promise<string>;
 }
 
 const commands: SlashCommand[] = [
@@ -81,17 +81,17 @@ const commands: SlashCommand[] = [
     aliases: ['fast'],
     description: 'Switch routing strategy',
     usage: '/strategy [cost-first|quality-first|combined|capability|rule-based]',
-    execute: (args, ctx) => {
+    execute: (args, ctx, invokedAs) => {
       const valid = ['cost-first', 'quality-first', 'combined', 'capability', 'rule-based'];
-      if (!args) {
-        return `Current strategy: ${ctx.getStrategy?.() ?? 'combined'}. Options: ${valid.join(', ')}`;
-      }
-      // /fast backward compat
-      if (args === 'fast' || args === 'toggle') {
+      // /fast with no args → toggle (backward compat)
+      if (!args && invokedAs === 'fast') {
         const current = ctx.getStrategy?.() ?? 'combined';
         const next = current === 'cost-first' ? 'quality-first' : 'cost-first';
         ctx.setStrategy?.(next);
         return `Routing strategy: ${next}`;
+      }
+      if (!args) {
+        return `Current strategy: ${ctx.getStrategy?.() ?? 'combined'}. Options: ${valid.join(', ')}`;
       }
       if (!valid.includes(args)) {
         return `Unknown strategy: ${args}. Options: ${valid.join(', ')}`;
@@ -234,7 +234,8 @@ export async function executeSlashCommand(input: string, ctx: SlashContext): Pro
     return `Unknown command: /${name}. Type /help for available commands.`;
   }
 
-  return cmd.execute(args, ctx);
+  // Pass the invoked name so commands can detect alias invocation (e.g., /fast vs /strategy)
+  return cmd.execute(args, ctx, name);
 }
 
 /**

--- a/packages/eval/src/runner.ts
+++ b/packages/eval/src/runner.ts
@@ -45,16 +45,18 @@ export async function runProbe(probe: Probe, options: RunnerOptions = {}): Promi
       }
     }
 
-    const projectDir = options.projectDir ?? process.cwd();
-    const config = loadConfig(projectDir);
+    // Use sandboxDir as the agent's working directory so model-generated files
+    // end up in the sandbox (where the scorer checks for them)
+    const configDir = options.projectDir ?? process.cwd();
+    const config = loadConfig(configDir);
     const db = getDb();
     const registry = await createProviderRegistry(config);
     const costTracker = new CostTracker(db, config.budget);
     const router = new BrainstormRouter(config, registry, costTracker);
     const tools = createDefaultToolRegistry();
     const sessionManager = new SessionManager(db);
-    const session = sessionManager.start(projectDir);
-    const { prompt: systemPrompt } = buildSystemPrompt(projectDir);
+    const session = sessionManager.start(sandboxDir);
+    const { prompt: systemPrompt } = buildSystemPrompt(sandboxDir);
 
     sessionManager.addUserMessage(probe.prompt);
 
@@ -66,7 +68,7 @@ export async function runProbe(probe: Probe, options: RunnerOptions = {}): Promi
     const runPromise = (async () => {
       for await (const event of runAgentLoop(sessionManager.getHistory(), {
         config, registry, router, costTracker, tools,
-        sessionId: session.id, projectPath: projectDir, systemPrompt,
+        sessionId: session.id, projectPath: sandboxDir, systemPrompt,
         ...(options.modelId && options.modelId !== 'default' ? { preferredModelId: options.modelId } : {}),
         ...(options.maxSteps ? { maxSteps: options.maxSteps } : {}),
       })) {

--- a/tests/workflow-demo/run-demo.ts
+++ b/tests/workflow-demo/run-demo.ts
@@ -120,6 +120,7 @@ async function runStep(prompt: string, strategy: string): Promise<Omit<StepResul
     const { stdout, stderr } = await execFileAsync('node', [
       BRAINSTORM_CLI, 'run', prompt,
       '--tools', '--max-steps', '10', '--json',
+      '--strategy', strategy,
     ], {
       cwd: OUTPUT_DIR,
       timeout: 180_000,


### PR DESCRIPTION
## Summary
1. **Scorer sandbox fix** — agent runs in sandboxDir so code_compiles/files_modified find generated files
2. **Workflow demo** — --strategy flag forwarded to CLI args per step
3. **/fast compat** — invokedAs param detects alias invocation for toggle behavior

## Test plan
- [ ] Build passes
- [ ] /fast toggles between cost-first and quality-first
- [ ] /strategy shows options list
- [ ] npm run test:workflow passes --strategy per step

🤖 Generated with [Claude Code](https://claude.com/claude-code)