### PR TITLE
feat: community API key for zero-setup onboarding

### DIFF
--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import { loadConfig } from '@brainstorm/config';
 import { getDb } from '@brainstorm/db';
-import { createProviderRegistry } from '@brainstorm/providers';
+import { createProviderRegistry, getBrainstormApiKey, isCommunityKey } from '@brainstorm/providers';
 import { BrainstormRouter, CostTracker } from '@brainstorm/router';
 import { createDefaultToolRegistry, configureSandbox } from '@brainstorm/tools';
 import { runAgentLoop, buildSystemPrompt, buildToolAwarenessSection, SessionManager, PermissionManager, createSubagentTool, spawnSubagent, type CompactionCallbacks } from '@brainstorm/core';
@@ -1022,6 +1022,9 @@ program
 
     const db = getDb();
     const resolvedKeys = await resolveProviderKeys();
+    const isCommunityTier = isCommunityKey(
+      resolvedKeys.get('BRAINSTORM_API_KEY') ?? getBrainstormApiKey()
+    );
     const registry = await createProviderRegistry(config, resolvedKeys);
     const costTracker = new CostTracker(db, config.budget);
     const tools = createDefaultToolRegistry();
@@ -1081,7 +1084,8 @@ program
       const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 
       console.log(`\n  brainstorm v0.1.0`);
-      console.log(`  Strategy: ${config.general.defaultStrategy} | Models: ${localCount} local, ${cloudCount} cloud`);
+      console.log(`  Strategy: ${router.getActiveStrategy()} | Models: ${localCount} local, ${cloudCount} cloud`);
+      if (isCommunityTier) console.log(`  Community tier (100 req/day, cheap models). Set BRAINSTORM_API_KEY for full access.`);
       console.log(`  Type your message. /quit to exit.\n`);
 
       let simpleAbortController: AbortController | null = null;

--- a/packages/providers/src/cloud/brainstorm-saas.ts
+++ b/packages/providers/src/cloud/brainstorm-saas.ts
@@ -16,8 +16,24 @@ export function createBrainstormSaaSProvider(apiKey: string) {
 }
 
 /**
- * Check if BR SaaS is configured and available.
+ * Community tier API key — ships with the CLI for zero-setup onboarding.
+ * Rate-limited server-side by BrainstormRouter: 5 RPM, 100 req/day, $2/day,
+ * cheap models only (DeepSeek V3, Haiku, GPT-4.1-mini, Gemini Flash).
+ * Users override with BRAINSTORM_API_KEY for full access to 357 models.
  */
-export function getBrainstormApiKey(): string | null {
-  return process.env.BRAINSTORM_API_KEY ?? null;
+const COMMUNITY_KEY = 'br_live_b028d73791f9a2d614acafe80b89d36f66e69d3091d9b70b24658ccc03a5a48a';
+
+/**
+ * Get the BrainstormRouter API key.
+ * Priority: BRAINSTORM_API_KEY env var → community key (free tier).
+ */
+export function getBrainstormApiKey(): string {
+  return process.env.BRAINSTORM_API_KEY ?? COMMUNITY_KEY;
+}
+
+/**
+ * Check if the current key is the community tier (for UI messaging).
+ */
+export function isCommunityKey(key: string): boolean {
+  return key === COMMUNITY_KEY;
 }

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -4,5 +4,5 @@ export { createLMStudioProvider, createLlamaCppProvider, discoverOpenAICompatMod
 export { discoverLocalModels, type DiscoveryResult } from './local/discovery.js';
 export { CLOUD_MODELS } from './cloud/models.js';
 export { checkProviderHealth, markDegraded, markUnavailable, markAvailable } from './health.js';
-export { createBrainstormSaaSProvider, getBrainstormApiKey } from './cloud/brainstorm-saas.js';
+export { createBrainstormSaaSProvider, getBrainstormApiKey, isCommunityKey } from './cloud/brainstorm-saas.js';
 export { readDiscoveryCache, writeDiscoveryCache, invalidateDiscoveryCache } from './local/cache.js';


### PR DESCRIPTION
## Summary

Embeds the BrainstormRouter community key as the default fallback so first-time users can `brainstorm chat` immediately — zero API key setup.

- Key: `br_live_b028...` (rate-limited server-side, cheap models only)
- Priority: `BRAINSTORM_API_KEY` env → vault → community key
- `isCommunityKey()` exported for UI tier detection
- Banner shows "Community tier (100 req/day)" when active

## Test plan
- [ ] Build passes
- [ ] `brainstorm run "hello" --json` with NO env key → routes through community key
- [ ] `BRAINSTORM_API_KEY=xxx brainstorm run "hello" --json` → uses user key, bypasses community tier

🤖 Generated with [Claude Code](https://claude.com/claude-code)