### PR TITLE
fix: paid keys default to quality-first routing

### DIFF
--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -1045,7 +1045,13 @@ program
     let { prompt: systemPrompt, frontmatter } = buildSystemPrompt(projectPath, currentOutputStyle);
     systemPrompt += buildToolAwarenessSection(tools.listTools());
     const router = new BrainstormRouter(config, registry, costTracker, frontmatter);
-    if (opts.strategy) router.setStrategy(opts.strategy as any);
+    // Paid keys get quality-first by default — you're paying, use the good models.
+    // Community tier stays on whatever BR's server-side routing picks (cost-first).
+    if (opts.strategy) {
+      router.setStrategy(opts.strategy as any);
+    } else if (!isCommunityTier && router.getActiveStrategy() !== 'capability') {
+      router.setStrategy('quality-first');
+    }
 
     // Register the subagent tool (model can spawn focused subagents)
     const subagentTool = createSubagentTool({

--- a/packages/core/src/agent/context.ts
+++ b/packages/core/src/agent/context.ts
@@ -6,7 +6,9 @@ import { homedir } from 'node:os';
 import { INSIGHT_PROMPT_SECTION } from './insights.js';
 import { getOutputStylePrompt, type OutputStyle } from './output-styles.js';
 
-const DEFAULT_SYSTEM_PROMPT = `You are Brainstorm, an AI coding assistant with intelligent model routing. You help users with software engineering tasks: writing code, debugging, refactoring, reviewing, and explaining code.
+const DEFAULT_SYSTEM_PROMPT = `You are Brainstorm, an AI coding assistant powered by BrainstormRouter — an intelligent model routing gateway. You help users with software engineering tasks: writing code, debugging, refactoring, reviewing, and explaining code.
+
+You have real tools — use them. When the user asks you to look at files, run commands, or search for information, USE YOUR TOOLS. Do not print shell commands as code blocks — actually call the shell tool. Do not say you cannot access something — try it first with a tool call.
 
 # Core Behaviors
 


### PR DESCRIPTION
DeepSeek V3 can't reliably use tools in multi-turn chat. Paid keys now default to quality-first so users get Sonnet/GPT-4.1. Also strengthened tool-use instructions in system prompt.