### PR TITLE
feat: model retry + momentum routing

### DIFF
--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -721,6 +721,11 @@ program
           if (gwLine) process.stderr.write(`${gwLine}\n`);
           break;
         }
+        case 'model-retry':
+          process.stderr.write(`\n[retry] ${event.fromModel} → ${event.toModel} (${event.reason})\n`);
+          modelName = event.toModel;
+          fullResponse = ''; // Reset for retry
+          break;
         case 'done':
           if (opts.json) {
             // Structured JSON output for CI/CD — only valid JSON on stdout

--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -45,6 +45,8 @@ export interface AgentLoopOptions {
   signal?: AbortSignal;
   /** Permission check function. When provided, tools are gated by this check. */
   permissionCheck?: PermissionCheckFn;
+  /** Internal: marks this as a retry attempt to prevent infinite recursion. */
+  _retryAttempt?: boolean;
 }
 
 // All task types get tools — the model decides whether to use them.
@@ -155,18 +157,24 @@ export async function* runAgentLoop(
 
     // Apply response filter to strip LLM filler from the beginning of text output
     const streamFilter = createStreamFilter();
+    let textDeltaCount = 0;
+    let toolCallCount = 0;
+    let hasToolBlocked = false;
 
     try {
       for await (const part of result.fullStream) {
         if (part.type === 'reasoning-delta') {
           const content = (part as any).text ?? (part as any).delta ?? '';
-          if (content) yield { type: 'reasoning', content };
+          if (content) yield { type: 'reasoning' as const, content };
         } else if (part.type === 'text-delta') {
+          textDeltaCount++;
           const raw = (part as any).text ?? (part as any).delta ?? '';
+          if (raw.includes('[TOOL BLOCKED]')) hasToolBlocked = true;
           const filtered = streamFilter.filter(raw);
-          if (filtered) yield { type: 'text-delta', delta: normalizeInsightMarkers(filtered) };
+          if (filtered) yield { type: 'text-delta' as const, delta: normalizeInsightMarkers(filtered) };
         } else if (part.type === 'tool-call') {
-          yield { type: 'tool-call-start', toolName: part.toolName, args: (part as any).input ?? (part as any).args };
+          toolCallCount++;
+          yield { type: 'tool-call-start' as const, toolName: part.toolName, args: (part as any).input ?? (part as any).args };
         } else if (part.type === 'tool-result') {
           const toolResult = (part as any).output ?? (part as any).result;
           yield { type: 'tool-call-result', toolName: part.toolName, result: toolResult };
@@ -204,6 +212,25 @@ export async function* runAgentLoop(
     const remaining = streamFilter.flush();
     if (remaining) yield { type: 'text-delta', delta: normalizeInsightMarkers(remaining) };
 
+    // ── Empty/blocked response detection + retry with fallback model ──
+    const isEmpty = textDeltaCount === 0 && toolCallCount === 0;
+    const isBlocked = hasToolBlocked && toolCallCount === 0;
+    if ((isEmpty || isBlocked) && decision.fallbacks.length > 0 && !options._retryAttempt) {
+      const reason = isEmpty ? 'empty_response' : 'tool_blocked';
+      router.recordFailure(decision.model.id, reason);
+      const fallbackModel = decision.fallbacks[0];
+      yield { type: 'model-retry' as const, fromModel: decision.model.id, toModel: fallbackModel.id, reason };
+
+      // Retry with fallback model — recurse with _retryAttempt flag to prevent infinite loop
+      const retryDecision = { ...decision, model: fallbackModel, fallbacks: decision.fallbacks.slice(1) };
+      yield* runAgentLoop(messages, {
+        ...options,
+        preferredModelId: fallbackModel.id,
+        _retryAttempt: true,
+      } as any);
+      return;
+    }
+
     // Extract gateway response headers (X-BR-*) for cost reconciliation and telemetry.
     // Use a timeout to prevent hanging if the response promise never resolves
     // (happens when the stream errored on the guardian SSE event).
@@ -226,6 +253,9 @@ export async function* runAgentLoop(
     } catch {
       // Gateway headers not available (local models) — non-fatal
     }
+
+    // Record success for model momentum
+    router.recordSuccess?.(decision.model.id);
 
     yield { type: 'done', totalCost: costTracker.getSessionCost(), totalTokens: costTracker.getSessionTokens() };
   } catch (error: any) {

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -17,6 +17,7 @@ export class BrainstormRouter {
   private strategies: Record<StrategyName, RoutingStrategy>;
   private activeStrategy: StrategyName;
   private recentFailures: Array<{ modelId: string; timestamp: number; error: string }> = [];
+  private momentum: { modelId: string; successCount: number; lastSuccess: number } | null = null;
   private projectHints?: StormFrontmatter['routing'];
 
   constructor(
@@ -73,6 +74,20 @@ export class BrainstormRouter {
     const candidates = this.getEligibleModels(task);
     const context = this.buildRoutingContext(opts.conversationTokens);
 
+    // Model momentum: if a model has been working well, stick with it (within 5 min)
+    if (this.momentum && Date.now() - this.momentum.lastSuccess < 300_000) {
+      const momentumModel = candidates.find((m) => m.id === this.momentum!.modelId);
+      if (momentumModel) {
+        return {
+          model: momentumModel,
+          fallbacks: candidates.filter((m) => m.id !== momentumModel.id).slice(0, 3),
+          reason: `Momentum: ${momentumModel.name} (${this.momentum.successCount} consecutive successes)`,
+          estimatedCost: 0,
+          strategy: this.activeStrategy,
+        };
+      }
+    }
+
     // If preferCheap, try cost-first strategy first
     if (opts.preferCheap && this.strategies['cost-first']) {
       const cheapDecision = this.strategies['cost-first'].select(task, candidates, context);
@@ -97,7 +112,7 @@ export class BrainstormRouter {
 
     return {
       model: anyModel,
-      fallbacks: [],
+      fallbacks: candidates.filter((m) => m.id !== anyModel.id && m.status === 'available').slice(0, 3),
       reason: `Fallback: only available model is ${anyModel.name}`,
       estimatedCost: 0,
       strategy: this.activeStrategy,
@@ -108,6 +123,20 @@ export class BrainstormRouter {
     this.recentFailures.push({ modelId, timestamp: Date.now(), error });
     // Keep only last 10 failures
     if (this.recentFailures.length > 10) this.recentFailures.shift();
+    // Break momentum on failure
+    if (this.momentum?.modelId === modelId) {
+      this.momentum = null;
+    }
+  }
+
+  /** Record a successful completion — builds model momentum. */
+  recordSuccess(modelId: string): void {
+    if (this.momentum?.modelId === modelId) {
+      this.momentum.successCount++;
+      this.momentum.lastSuccess = Date.now();
+    } else {
+      this.momentum = { modelId, successCount: 1, lastSuccess: Date.now() };
+    }
   }
 
   setStrategy(name: StrategyName): void {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -197,6 +197,8 @@ export type AgentEvent =
   | { type: 'subagent-result'; subagentType: string; model: string; cost: number; toolCalls: string[] }
   | { type: 'reasoning'; content: string }
   | { type: 'background-complete'; taskId: string; command: string; exitCode: number; stdout: string; stderr: string }
+  | { type: 'model-retry'; fromModel: string; toModel: string; reason: string }
+  | { type: 'empty-response'; modelId: string }
   | { type: 'interrupted' }
   | { type: 'error'; error: Error }
   | { type: 'done'; totalCost: number; totalTokens?: { input: number; output: number } };


### PR DESCRIPTION
## Summary

Combined PRs 4+5+6 from the plan:
- **Fallback population**: Last-resort routing path now populates fallbacks
- **Empty/blocked response retry**: When model returns nothing or [TOOL BLOCKED] text, retries with fallback
- **Model momentum**: Successful models are preferred for subsequent calls (5min decay, breaks on failure)
- **CLI display**: Shows `[retry] modelA → modelB (reason)` on retry

## Test plan

- [x] Build passes (15/15 packages)
- [ ] `storm run --model deepseek/deepseek-chat --tools "read page.tsx"` → retries with fallback if empty
- [ ] 3 consecutive `storm run` calls → same model used (momentum)

🤖 Generated with [Claude Code](https://claude.ai/code)