### PR TITLE
fix: routing picks explicit models over brainstormrouter/auto

### DIFF
--- a/packages/router/src/strategies/capability.ts
+++ b/packages/router/src/strategies/capability.ts
@@ -51,7 +51,14 @@ function getRequiredCapabilities(task: TaskProfile): Partial<Record<keyof Capabi
  */
 function scoreModel(model: ModelEntry, requirements: Partial<Record<keyof CapabilityScores, number>>): number {
   const scores = model.capabilities.capabilityScores;
-  if (!scores) return 0.5; // Default score for models without eval data
+
+  // Models without eval data: derive score from qualityTier (1=best → 0.9, 2 → 0.7, 3 → 0.5)
+  // This prevents brainstormrouter/auto (qualityTier 1, $0 cost) from always winning the
+  // tiebreaker — explicit models with known capabilities should be preferred.
+  if (!scores) {
+    const tier = model.capabilities.qualityTier ?? 3;
+    return tier === 1 ? 0.9 : tier === 2 ? 0.7 : 0.5;
+  }
 
   let totalScore = 0;
   let totalWeight = 0;
@@ -84,8 +91,16 @@ export const capabilityStrategy: RoutingStrategy = {
   name: 'capability',
 
   select(task: TaskProfile, candidates: ModelEntry[], context: RoutingContext): RoutingDecision | null {
-    const available = candidates.filter((m) => m.status === 'available');
+    let available = candidates.filter((m) => m.status === 'available');
     if (available.length === 0) return null;
+
+    // Prefer explicit models over brainstormrouter/auto.
+    // Auto is a black box — we can't predict or control what model it picks.
+    // Keep auto only as a last resort when no explicit models are available.
+    if (available.length > 1) {
+      const explicit = available.filter((m) => m.id !== 'brainstormrouter/auto');
+      if (explicit.length > 0) available = explicit;
+    }
 
     const requirements = getRequiredCapabilities(task);
 

--- a/packages/router/src/strategies/quality-first.ts
+++ b/packages/router/src/strategies/quality-first.ts
@@ -5,8 +5,17 @@ export const qualityFirstStrategy: RoutingStrategy = {
   name: 'quality-first',
 
   select(task: TaskProfile, candidates: ModelEntry[], context: RoutingContext): RoutingDecision | null {
-    const available = candidates.filter((m) => m.status === 'available');
+    let available = candidates.filter((m) => m.status === 'available');
     if (available.length === 0) return null;
+
+    // Prefer explicit models over brainstormrouter/auto.
+    // Auto is a black box — we can't predict which model it picks, and the
+    // user is paying for a key that gives access to specific quality models.
+    // Keep auto only as a last resort.
+    if (available.length > 1) {
+      const explicit = available.filter((m) => m.id !== 'brainstormrouter/auto');
+      if (explicit.length > 0) available = explicit;
+    }
 
     // Sort by quality tier (1 = best) then speed
     const sorted = available.sort((a, b) => {


### PR DESCRIPTION
## Summary

The #1 usability issue: routing always picked brainstormrouter/auto because it had qualityTier 1 and $0 cost, winning every tiebreaker. Auto is a black box that frequently selects cheap models that can't do tool calling.

Fix: quality-first and capability strategies now filter out auto when explicit models are available. Also derives score from qualityTier for models without eval data (was flat 0.5).

## Test plan

- [x] Build passes
- [x] `storm run --tools "Read src/app/page.tsx"` → picks Claude Sonnet 4.5 (not BR Auto)
- [ ] Full chat session test

🤖 Generated with [Claude Code](https://claude.ai/code)