### PR TITLE
feat: CLI UX foundations — truthful tools, thinking indicator, path fix

### DIFF
--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -705,9 +705,20 @@ program
       permissionCheck: (tool, args) => permissionManager.check(tool, args),
     })) {
       switch (event.type) {
+        case 'thinking':
+          if (!opts.json) {
+            const phases: Record<string, string> = {
+              classifying: 'Classifying task...',
+              routing: 'Selecting model...',
+              connecting: `Connecting...`,
+              streaming: 'Streaming...',
+            };
+            process.stderr.write(`\r${phases[event.phase] ?? event.phase}`);
+          }
+          break;
         case 'routing':
           modelName = event.decision.model.name;
-          process.stderr.write(`[${event.decision.strategy}] → ${modelName}\n`);
+          process.stderr.write(`\r[${event.decision.strategy}] → ${modelName}\n`);
           break;
         case 'text-delta':
           fullResponse += event.delta;

--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -80,17 +80,23 @@ export async function* runAgentLoop(
     } as AgentEvent);
   });
 
-  // Classify from the last user message
+  // Phase: classifying
+  yield { type: 'thinking' as const, phase: 'classifying' as const };
   const lastUserMsg = [...messages].reverse().find((m) => m.role === 'user');
   const userText = lastUserMsg?.content ?? '';
-
   const task = router.classify(userText);
+
+  // Phase: routing
+  yield { type: 'thinking' as const, phase: 'routing' as const };
   const conversationTokens = options.compaction?.getTokenEstimate() ?? 0;
   const decision = options.preferredModelId
     ? { ...router.route(task, conversationTokens), model: options.registry.getModel(options.preferredModelId) ?? router.route(task, conversationTokens).model, reason: `Cross-model workflow override: ${options.preferredModelId}` }
     : router.route(task, conversationTokens);
 
   yield { type: 'routing', decision };
+
+  // Phase: connecting
+  yield { type: 'thinking' as const, phase: 'connecting' as const };
 
   // Check if context compaction is needed before the LLM call
   if (options.compaction && config.compaction?.enabled !== false) {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -184,6 +184,7 @@ export interface AgentTask {
 }
 
 export type AgentEvent =
+  | { type: 'thinking'; phase: 'classifying' | 'routing' | 'connecting' | 'streaming' }
   | { type: 'routing'; decision: RoutingDecision }
   | { type: 'text-delta'; delta: string }
   | { type: 'tool-call-start'; toolName: string; args: unknown }

--- a/packages/tools/src/builtin/file-edit.ts
+++ b/packages/tools/src/builtin/file-edit.ts
@@ -1,21 +1,31 @@
 import { z } from 'zod';
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { resolve, relative } from 'node:path';
+import { homedir } from 'node:os';
 import { defineTool } from '../base.js';
 
 function ensureSafePath(filePath: string): string {
   const cwd = process.cwd();
   const resolved = resolve(cwd, filePath);
-  const rel = relative(cwd, resolved);
-  if (rel.startsWith('..') || rel.startsWith('/')) {
-    throw new Error(`Path traversal blocked: "${filePath}" escapes workspace`);
+  const home = homedir();
+
+  const BLOCKED_PREFIXES = ['/etc', '/usr', '/var', '/proc', '/sys', '/dev', '/sbin', '/boot'];
+  if (BLOCKED_PREFIXES.some((p) => resolved.startsWith(p))) {
+    throw new Error(`Path blocked: "${filePath}" is a protected system path`);
   }
+
+  const isInHome = resolved.startsWith(home);
+  const isInCwd = !relative(cwd, resolved).startsWith('..');
+  if (!isInHome && !isInCwd) {
+    throw new Error(`Path blocked: "${filePath}" is outside home directory and workspace`);
+  }
+
   return resolved;
 }
 
 export const fileEditTool = defineTool({
   name: 'file_edit',
-  description: 'Perform a surgical string replacement in a file. The old_string must match exactly one location in the file.',
+  description: 'Perform a surgical string replacement in a file. The old_string must match exactly one location. Returns { success, replacements } or { error }. Supports absolute paths within home directory.',
   permission: 'confirm',
   inputSchema: z.object({
     path: z.string().describe('Path to the file to edit'),

--- a/packages/tools/src/builtin/file-read.ts
+++ b/packages/tools/src/builtin/file-read.ts
@@ -3,19 +3,33 @@ import { readFileSync, existsSync } from 'node:fs';
 import { resolve, relative } from 'node:path';
 import { defineTool } from '../base.js';
 
+import { homedir } from 'node:os';
+
 function ensureSafePath(filePath: string): string {
   const cwd = process.cwd();
   const resolved = resolve(cwd, filePath);
-  const rel = relative(cwd, resolved);
-  if (rel.startsWith('..') || rel.startsWith('/')) {
-    throw new Error(`Path traversal blocked: "${filePath}" escapes workspace`);
+  const home = homedir();
+
+  // Allow: paths within cwd OR within home directory
+  // Block: system paths (/etc, /usr, /var, /proc, /sys, /dev)
+  const BLOCKED_PREFIXES = ['/etc', '/usr', '/var', '/proc', '/sys', '/dev', '/sbin', '/boot'];
+  if (BLOCKED_PREFIXES.some((p) => resolved.startsWith(p))) {
+    throw new Error(`Path blocked: "${filePath}" is a protected system path`);
   }
+
+  // Allow absolute paths within home dir or within cwd
+  const isInHome = resolved.startsWith(home);
+  const isInCwd = !relative(cwd, resolved).startsWith('..');
+  if (!isInHome && !isInCwd) {
+    throw new Error(`Path blocked: "${filePath}" is outside home directory and workspace`);
+  }
+
   return resolved;
 }
 
 export const fileReadTool = defineTool({
   name: 'file_read',
-  description: 'Read the contents of a file at the given path. Returns the file content as a string.',
+  description: 'Read the contents of a file. Supports absolute paths within the home directory (~/Projects, ~/Desktop, etc.) and relative paths within the project. Use `limit` and `offset` for large files — default reads the full file. Returns { content, totalLines } on success, { error } on failure.',
   permission: 'auto',
   inputSchema: z.object({
     path: z.string().describe('Absolute or relative path to the file to read'),

--- a/packages/tools/src/builtin/file-write.ts
+++ b/packages/tools/src/builtin/file-write.ts
@@ -3,19 +3,32 @@ import { writeFileSync, mkdirSync } from 'node:fs';
 import { dirname, resolve, relative } from 'node:path';
 import { defineTool } from '../base.js';
 
+import { homedir } from 'node:os';
+
 function ensureSafePath(filePath: string): string {
   const cwd = process.cwd();
   const resolved = resolve(cwd, filePath);
-  const rel = relative(cwd, resolved);
-  if (rel.startsWith('..') || rel.startsWith('/')) {
-    throw new Error(`Path traversal blocked: "${filePath}" escapes workspace`);
+  const home = homedir();
+
+  // Block system paths
+  const BLOCKED_PREFIXES = ['/etc', '/usr', '/var', '/proc', '/sys', '/dev', '/sbin', '/boot'];
+  if (BLOCKED_PREFIXES.some((p) => resolved.startsWith(p))) {
+    throw new Error(`Path blocked: "${filePath}" is a protected system path`);
   }
+
+  // Allow within home dir or within cwd
+  const isInHome = resolved.startsWith(home);
+  const isInCwd = !relative(cwd, resolved).startsWith('..');
+  if (!isInHome && !isInCwd) {
+    throw new Error(`Path blocked: "${filePath}" is outside home directory and workspace`);
+  }
+
   return resolved;
 }
 
 export const fileWriteTool = defineTool({
   name: 'file_write',
-  description: 'Write content to a file, creating it if it does not exist. Creates parent directories as needed.',
+  description: 'Write content to a file, creating it if it does not exist. Creates parent directories as needed. Supports absolute paths within home directory. Returns { success, path, bytesWritten } on success, { error } on failure.',
   permission: 'confirm',
   inputSchema: z.object({
     path: z.string().describe('Path to the file to write'),

--- a/packages/tools/src/builtin/grep.ts
+++ b/packages/tools/src/builtin/grep.ts
@@ -7,7 +7,7 @@ const execFileAsync = promisify(execFile);
 
 export const grepTool = defineTool({
   name: 'grep',
-  description: 'Search file contents using ripgrep. Returns matching lines with file paths and line numbers.',
+  description: 'Search file contents using ripgrep (regex). Returns matching lines with file:line format. Default: max 50 results from current directory. Use `glob` to filter files (e.g., "*.ts"). Use `path` to search a specific directory. Returns { matches: string[], matchCount } or { error }.',
   permission: 'auto',
   inputSchema: z.object({
     pattern: z.string().describe('Regex pattern to search for'),

--- a/packages/tools/src/builtin/shell.ts
+++ b/packages/tools/src/builtin/shell.ts
@@ -90,7 +90,7 @@ class OutputCollector {
 
 export const shellTool = defineTool({
   name: 'shell',
-  description: 'Execute a shell command and return its stdout, stderr, and exit code. Streams output in real-time for long-running commands (builds, tests). Use for running tests, builds, git operations, etc.',
+  description: 'Execute a shell command via /bin/sh -c. Returns { stdout, stderr, exitCode }. Output is truncated to first 200 + last 200 lines if >400 lines total. Default timeout: 30s. Use `background: true` for long-running commands (returns immediately with a task ID, notifies on completion). Blocked by sandbox for dangerous commands (rm -rf, sudo, etc.).',
   permission: 'confirm',
   inputSchema: z.object({
     command: z.string().describe('The command to execute (passed to /bin/sh -c)'),


### PR DESCRIPTION
## Summary

Three fixes addressing core usability issues found during deep audit:

1. **Path validation fixed** — file-read/write/edit now allow absolute paths within home dir (~). Previously blocked ALL absolute paths, contradicting the system prompt. System paths still blocked.

2. **Tool descriptions rewritten** — Each tool now tells the model its limits, output format, and failure modes. Shell mentions truncation. Grep mentions max results. File tools mention return formats.

3. **Thinking indicator** — New `thinking` event emitted at phase transitions (classifying → routing → connecting). CLI shows progress instead of blank screen.

## Test plan

- [x] Build passes (15/15)
- [x] `storm run --tools "Read ~/Projects/brainstorm/README.md"` → absolute path works
- [x] Thinking phases displayed before model responds

🤖 Generated with [Claude Code](https://claude.ai/code)