### PR TITLE
feat: auto-connect to BR's 64 MCP tools on startup

### DIFF
--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -65,6 +65,7 @@ function buildCompactionCallbacks(sessionManager: SessionManager): CompactionCal
 async function connectMCPServers(
   tools: ReturnType<typeof createDefaultToolRegistry>,
   config: ReturnType<typeof loadConfig>,
+  resolvedBRKey?: string | null,
 ): Promise<void> {
   const mcp = new MCPClientManager();
 
@@ -82,21 +83,17 @@ async function connectMCPServers(
     })));
   }
 
-  // Built-in BrainstormRouter gateway MCP (if API key available)
-  const brKey = process.env.BRAINSTORM_API_KEY;
+  // Built-in BrainstormRouter MCP — connects to BR's 64 control-plane tools
+  // via Streamable HTTP transport. All BR tools become available to the model.
+  const brKey = resolvedBRKey ?? process.env.BRAINSTORM_API_KEY;
   if (brKey) {
     mcp.addServers([{
       name: 'brainstormrouter',
-      transport: 'stdio',
-      url: 'brainstormrouter-mcp',
-      command: 'npx',
-      args: ['brainstormrouter-mcp'],
+      transport: 'http',
+      url: 'https://api.brainstormrouter.com/v1/mcp/connect',
       env: { BRAINSTORM_API_KEY: brKey },
-      toolFilter: [
-        'br_get_ops_status', 'br_list_models', 'br_get_budget',
-        'br_get_memory', 'br_store_memory', 'br_query_memory',
-        'br_get_config', 'br_set_config', 'br_get_insights',
-      ],
+      // No toolFilter — expose all 64 BR tools to the model.
+      // The model decides which to use based on the system prompt guidance.
     }]);
   }
 
@@ -662,7 +659,7 @@ program
     const registry = await createProviderRegistry(config, resolvedKeys);
     const costTracker = new CostTracker(db, config.budget);
     const tools = createDefaultToolRegistry();
-    await connectMCPServers(tools, config);
+    await connectMCPServers(tools, config, resolvedKeys.get('BRAINSTORM_API_KEY'));
     const sessionManager = new SessionManager(db);
     const projectPath = process.cwd();
     configureSandbox(config.shell.sandbox as any, projectPath);
@@ -1080,7 +1077,7 @@ program
     const registry = await createProviderRegistry(config, resolvedKeys);
     const costTracker = new CostTracker(db, config.budget);
     const tools = createDefaultToolRegistry();
-    await connectMCPServers(tools, config);
+    await connectMCPServers(tools, config, resolvedKeys.get('BRAINSTORM_API_KEY'));
     const projectPath = process.cwd();
     configureSandbox(config.shell.sandbox as any, projectPath);
 

--- a/packages/core/src/agent/context.ts
+++ b/packages/core/src/agent/context.ts
@@ -293,5 +293,23 @@ export function buildToolAwarenessSection(
     '- To change models or routing, edit `~/.brainstorm/config.toml` or use `/model` and `/strategy` slash commands.',
   ].join('\n');
 
-  return `\n## Available Tools\n\nYou have access to ${tools.length} tools:\n\n${sections.join('\n\n')}\n${selfAwareness}`;
+  // Add BrainstormRouter intelligence section if BR MCP tools are connected
+  const hasBRTools = tools.some((t) => t.name.startsWith('mcp_brainstormrouter_'));
+  const brSection = hasBRTools ? [
+    '',
+    '### BrainstormRouter Intelligence',
+    'You are connected to BrainstormRouter — an intelligent AI gateway with 64 control-plane tools.',
+    'Use these situationally when the context calls for it:',
+    '',
+    '- **Before expensive operations** → `mcp_brainstormrouter_br_agent_limits` (check budget and rate limits)',
+    '- **When something fails** → `mcp_brainstormrouter_br_get_ops_status` (system health dashboard)',
+    '- **For model info** → `mcp_brainstormrouter_br_get_leaderboard` (real performance rankings)',
+    '- **For cost savings** → `mcp_brainstormrouter_br_get_insights` (optimization recommendations)',
+    '- **For persistent memory** → `mcp_brainstormrouter_br_memory_query` / `br_memory_store`',
+    '- **For system overview** → `mcp_brainstormrouter_br_get_ops_status` (start here)',
+    '',
+    'You don\'t need to call these routinely — use them when the situation calls for it.',
+  ].join('\n') : '';
+
+  return `\n## Available Tools\n\nYou have access to ${tools.length} tools:\n\n${sections.join('\n\n')}\n${selfAwareness}${brSection}`;
 }

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -46,7 +46,14 @@ export class MCPClientManager {
 
         const transport = server.transport === 'stdio'
           ? await this.createStdioTransport(server)
-          : { type: server.transport as 'sse' | 'http', url: server.url };
+          : {
+              type: server.transport as 'sse' | 'http',
+              url: server.url,
+              // Pass API key as Bearer token for authenticated MCP servers
+              ...(server.env?.BRAINSTORM_API_KEY ? {
+                headers: { Authorization: `Bearer ${server.env.BRAINSTORM_API_KEY}` },
+              } : {}),
+            };
 
         const client = await createMCPClient({ transport });
 
@@ -57,8 +64,10 @@ export class MCPClientManager {
           const filterSet = server.toolFilter ? new Set(server.toolFilter) : null;
           for (const [toolName, toolDef] of Object.entries(tools)) {
             if (filterSet && !filterSet.has(toolName)) continue;
-            (registry as any).tools.set(`mcp:${server.name}:${toolName}`, {
-              name: `mcp:${server.name}:${toolName}`,
+            // Use underscores instead of colons — LLM providers reject colons in tool names
+            const registeredName = `mcp_${server.name}_${toolName}`;
+            (registry as any).tools.set(registeredName, {
+              name: registeredName,
               description: (toolDef as any).description ?? toolName,
               permission: 'confirm' as const,
               toAISDKTool: () => toolDef,


### PR DESCRIPTION
## Summary

The CLI now auto-connects to BrainstormRouter's MCP server when an API key is available, giving the model access to 64 control-plane tools (ops dashboard, model rankings, budget, memory, insights, agent management).

- HTTP transport with Bearer auth to /v1/mcp/connect
- Tool names use underscores (mcp_brainstormrouter_X) for provider compatibility
- System prompt includes BR intelligence section when tools are connected
- Vault-resolved key passed to MCP connection

Known issue: MCP tool schemas need type:"object" normalization for Anthropic compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)