### PR TITLE
feat: turn context injection — agent self-awareness (PR 2/47)

### DIFF
--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -1198,6 +1198,11 @@ program
           signal: simpleAbortController.signal,
           permissionCheck: (name, perm) => permissionManager.check(name, perm),
           preferredModelId,
+          onTurnComplete: (ctx) => {
+            ctx.turn = sessionManager.incrementTurn();
+            ctx.sessionMinutes = sessionManager.getSessionMinutes();
+            sessionManager.addTurnContext(ctx);
+          },
         })) {
           switch (event.type) {
             case 'thinking':

--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -5,7 +5,7 @@ import type { ProviderRegistry } from '@brainstorm/providers';
 import { BrainstormRouter, CostTracker } from '@brainstorm/router';
 import type { ToolRegistry, PermissionCheckFn } from '@brainstorm/tools';
 import { setTaskEventHandler, clearTasks, setBackgroundEventHandler } from '@brainstorm/tools';
-import type { AgentEvent, GatewayFeedbackData, ModelEntry } from '@brainstorm/shared';
+import type { AgentEvent, GatewayFeedbackData, ModelEntry, TurnContext } from '@brainstorm/shared';
 import { serializeRoutingMetadata } from '@brainstorm/shared';
 import { createStreamFilter } from './response-filter.js';
 import { normalizeInsightMarkers } from './insights.js';
@@ -101,6 +101,8 @@ export interface AgentLoopOptions {
   signal?: AbortSignal;
   /** Permission check function. When provided, tools are gated by this check. */
   permissionCheck?: PermissionCheckFn;
+  /** Callback to inject turn context after each completion. */
+  onTurnComplete?: (ctx: TurnContext) => void;
   /** Internal: marks this as a retry attempt to prevent infinite recursion. */
   _retryAttempt?: boolean;
 }
@@ -223,6 +225,9 @@ export async function* runAgentLoop(
     let toolCallCount = 0;
     let hasToolBlocked = false;
     let lastEventTime = Date.now();
+    const toolCallResults: Array<{ name: string; ok: boolean }> = [];
+    const filesRead: string[] = [];
+    const filesWritten: string[] = [];
     const STREAM_TIMEOUT_MS = 60_000; // 60s without any SSE event = dead stream
 
     try {
@@ -247,6 +252,17 @@ export async function* runAgentLoop(
           yield { type: 'tool-call-start' as const, toolName: part.toolName, args: (part as any).input ?? (part as any).args };
         } else if (part.type === 'tool-result') {
           const toolResult = (part as any).output ?? (part as any).result;
+          // Track tool call success/failure for turn context
+          const toolOk = !(toolResult && typeof toolResult === 'object' && (toolResult.error || toolResult.ok === false));
+          toolCallResults.push({ name: part.toolName, ok: toolOk });
+          // Track file access for turn context
+          if (part.toolName === 'file_read' && toolOk) {
+            const path = (part as any).input?.path ?? (part as any).args?.path;
+            if (path) filesRead.push(path);
+          } else if ((part.toolName === 'file_write' || part.toolName === 'file_edit') && toolOk) {
+            const path = (part as any).input?.path ?? (part as any).args?.path;
+            if (path) filesWritten.push(path);
+          }
           yield { type: 'tool-call-result', toolName: part.toolName, result: toolResult };
           // Emit subagent-result events for TUI display
           if (part.toolName === 'subagent' && toolResult && typeof toolResult === 'object') {
@@ -335,6 +351,26 @@ export async function* runAgentLoop(
 
     // Record success for model momentum
     router.recordSuccess?.(decision.model.id);
+
+    // Inject turn context for next turn's self-awareness
+    if (options.onTurnComplete) {
+      const turnCost = costTracker.getSessionCost(); // approximate per-turn
+      const budget = costTracker.getBudgetState();
+      const budgetRemaining = budget.dailyLimit ? budget.dailyLimit - budget.dailyUsed : 0;
+      const budgetPercent = budget.dailyLimit ? Math.round((budgetRemaining / budget.dailyLimit) * 100) : 100;
+      options.onTurnComplete({
+        turn: 0, // caller sets this
+        model: decision.model.name,
+        strategy: decision.strategy,
+        toolCalls: toolCallResults,
+        turnCost,
+        budgetRemaining,
+        budgetPercent,
+        filesRead,
+        filesWritten,
+        sessionMinutes: 0, // caller sets this
+      });
+    }
 
     yield { type: 'done', totalCost: costTracker.getSessionCost(), totalTokens: costTracker.getSessionTokens() };
   } catch (error: any) {

--- a/packages/core/src/session/manager.ts
+++ b/packages/core/src/session/manager.ts
@@ -1,5 +1,6 @@
 import { SessionRepository, MessageRepository } from '@brainstorm/db';
-import type { Session } from '@brainstorm/shared';
+import type { Session, TurnContext } from '@brainstorm/shared';
+import { formatTurnContext } from '@brainstorm/shared';
 import { estimateTokenCount, needsCompaction, compactContext } from './compaction.js';
 
 export interface ConversationMessage {
@@ -12,6 +13,8 @@ export class SessionManager {
   private messages: MessageRepository;
   private currentSession: Session | null = null;
   private conversationHistory: ConversationMessage[] = [];
+  private turnCount = 0;
+  private sessionStartTime = Date.now();
 
   constructor(private db: any) {
     this.sessions = new SessionRepository(db);
@@ -88,6 +91,24 @@ export class SessionManager {
     this.messages.create(this.currentSession.id, 'assistant', content, modelId);
     this.sessions.incrementMessages(this.currentSession.id);
     this.conversationHistory.push({ role: 'assistant', content });
+  }
+
+  /** Inject turn context as an invisible system message the model sees but the user doesn't. */
+  addTurnContext(ctx: TurnContext): void {
+    const summary = formatTurnContext(ctx);
+    this.conversationHistory.push({ role: 'system', content: summary });
+  }
+
+  getTurnCount(): number {
+    return this.turnCount;
+  }
+
+  incrementTurn(): number {
+    return ++this.turnCount;
+  }
+
+  getSessionMinutes(): number {
+    return Math.round((Date.now() - this.sessionStartTime) / 60_000);
   }
 
   getHistory(): ConversationMessage[] {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -205,6 +205,48 @@ export type AgentEvent =
   | { type: 'error'; error: Error }
   | { type: 'done'; totalCost: number; totalTokens?: { input: number; output: number } };
 
+// ── Turn Context ─────────────────────────────────────────────────────
+
+/** Per-turn state injected between turns so the agent knows what just happened. */
+export interface TurnContext {
+  turn: number;
+  model: string;
+  strategy: string;
+  toolCalls: Array<{ name: string; ok: boolean }>;
+  turnCost: number;
+  budgetRemaining: number;
+  budgetPercent: number;
+  filesRead: string[];
+  filesWritten: string[];
+  sessionMinutes: number;
+}
+
+/** Format TurnContext as a compact one-line summary for system message injection. */
+export function formatTurnContext(ctx: TurnContext): string {
+  const tools = ctx.toolCalls.length > 0
+    ? ctx.toolCalls.map((t) => `${t.name}${t.ok ? '' : '✗'}`).join(' ')
+    : 'none';
+  const files = [
+    ...ctx.filesRead.map((f) => `${basename(f)}↓`),
+    ...ctx.filesWritten.map((f) => `${basename(f)}↑`),
+  ];
+  const fileStr = files.length > 0 ? files.slice(0, 6).join(' ') : '';
+  const parts = [
+    `Turn ${ctx.turn}`,
+    ctx.model,
+    `tools: ${tools}`,
+    `$${ctx.turnCost.toFixed(3)}`,
+    `budget ${ctx.budgetPercent}%`,
+  ];
+  if (fileStr) parts.push(`files: ${fileStr}`);
+  parts.push(`${ctx.sessionMinutes}min`);
+  return `[${parts.join(' | ')}]`;
+}
+
+function basename(path: string): string {
+  return path.split('/').pop() ?? path;
+}
+
 // ── Tool System ──────────────────────────────────────────────────────
 
 export type ToolPermission = 'auto' | 'confirm' | 'deny';


### PR DESCRIPTION
## Summary

PR 2 of 47: Agent self-awareness foundation.

After each completion, a TurnContext is injected as a system message so the model knows what just happened:
- Model used + strategy
- Tool calls with success/failure
- Cost + budget remaining
- Files read/written
- Session duration

This is the foundation for PRs 3-7 (file tracking, tool health, build state, loop detection).

🤖 Generated with [Claude Code](https://claude.ai/code)