### PR TITLE
feat: tool health tracking — agent avoids broken tools (PR 4/47)

### DIFF
--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -4,7 +4,7 @@ import type { BrainstormConfig } from '@brainstorm/config';
 import type { ProviderRegistry } from '@brainstorm/providers';
 import { BrainstormRouter, CostTracker } from '@brainstorm/router';
 import type { ToolRegistry, PermissionCheckFn } from '@brainstorm/tools';
-import { setTaskEventHandler, clearTasks, setBackgroundEventHandler } from '@brainstorm/tools';
+import { setTaskEventHandler, clearTasks, setBackgroundEventHandler, getToolHealthTracker } from '@brainstorm/tools';
 import type { AgentEvent, GatewayFeedbackData, ModelEntry, TurnContext } from '@brainstorm/shared';
 import { serializeRoutingMetadata } from '@brainstorm/shared';
 import { createStreamFilter } from './response-filter.js';
@@ -304,7 +304,7 @@ export async function* runAgentLoop(
     let fallbacks = decision.fallbacks;
     if (fallbacks.length === 0 && (isEmpty)) {
       // When BR Auto returns empty, construct fallbacks from explicit models in the registry
-      const RETRY_MODELS = ['anthropic/claude-sonnet-4-5-20250929', 'openai/gpt-4.1', 'anthropic/claude-haiku-4-5-20251001'];
+      const RETRY_MODELS = ['anthropic/claude-sonnet-4.5-20250929', 'openai/gpt-4.1', 'anthropic/claude-haiku-4.5-20251001'];
       fallbacks = RETRY_MODELS
         .filter((id) => id !== decision.model.id)
         .map((id) => options.registry.getModel(id))
@@ -369,6 +369,7 @@ export async function* runAgentLoop(
         filesRead,
         filesWritten,
         sessionMinutes: 0, // caller sets this
+        unhealthyTools: getToolHealthTracker().getUnhealthy(),
       });
     }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -219,6 +219,7 @@ export interface TurnContext {
   filesRead: string[];
   filesWritten: string[];
   sessionMinutes: number;
+  unhealthyTools: Array<{ name: string; error: string }>;
 }
 
 /** Format TurnContext as a compact one-line summary for system message injection. */
@@ -239,6 +240,9 @@ export function formatTurnContext(ctx: TurnContext): string {
     `budget ${ctx.budgetPercent}%`,
   ];
   if (fileStr) parts.push(`files: ${fileStr}`);
+  if (ctx.unhealthyTools.length > 0) {
+    parts.push(`unhealthy: ${ctx.unhealthyTools.map((t) => t.name).join(',')}`);
+  }
   parts.push(`${ctx.sessionMinutes}min`);
   return `[${parts.join(' | ')}]`;
 }

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -1,5 +1,6 @@
 export { defineTool, type BrainstormToolDef } from './base.js';
 export { SessionFileTracker, getFileTracker, resetFileTracker } from './file-tracker.js';
+export { ToolHealthTracker, getToolHealthTracker, resetToolHealthTracker, type ToolHealthEntry } from './tool-health.js';
 export { CheckpointManager } from './checkpoint.js';
 export { ToolRegistry, type PermissionCheckFn } from './registry.js';
 export { fileReadTool } from './builtin/file-read.js';

--- a/packages/tools/src/registry.ts
+++ b/packages/tools/src/registry.ts
@@ -1,6 +1,7 @@
 import { tool } from 'ai';
 import type { ToolPermission } from '@brainstorm/shared';
 import type { BrainstormToolDef } from './base.js';
+import { getToolHealthTracker } from './tool-health.js';
 
 export type PermissionCheckFn = (toolName: string, toolPermission: ToolPermission) => 'allow' | 'confirm' | 'deny';
 
@@ -96,13 +97,23 @@ export class ToolRegistry {
         execute: async (input: any) => {
           const decision = check(name, toolDef.permission);
           if (decision === 'deny') {
-            return normalizeResult({ error: `Tool '${name}' is blocked in the current permission mode.`, blocked: true });
+            const result = normalizeResult({ error: `Tool '${name}' is blocked in the current permission mode.`, blocked: true });
+            getToolHealthTracker().recordFailure(name, result.error);
+            return result;
           }
           try {
             const raw = await toolDef.execute(input);
-            return normalizeResult(raw);
+            const result = normalizeResult(raw);
+            if (result.ok) {
+              getToolHealthTracker().recordSuccess(name);
+            } else {
+              getToolHealthTracker().recordFailure(name, result.error ?? 'unknown error');
+            }
+            return result;
           } catch (err: any) {
-            return normalizeResult({ error: err.message ?? String(err) });
+            const result = normalizeResult({ error: err.message ?? String(err) });
+            getToolHealthTracker().recordFailure(name, result.error);
+            return result;
           }
         },
       });

--- a/packages/tools/src/tool-health.ts
+++ b/packages/tools/src/tool-health.ts
@@ -1,0 +1,78 @@
+/**
+ * Session-level tool health tracker.
+ * Records success/failure per tool so the agent knows which tools are working
+ * and can avoid calling broken ones.
+ */
+
+export interface ToolHealthEntry {
+  successes: number;
+  failures: number;
+  lastError?: string;
+  lastFailure?: number;
+}
+
+export class ToolHealthTracker {
+  private entries = new Map<string, ToolHealthEntry>();
+
+  recordSuccess(toolName: string): void {
+    const entry = this.getOrCreate(toolName);
+    entry.successes++;
+  }
+
+  recordFailure(toolName: string, error: string): void {
+    const entry = this.getOrCreate(toolName);
+    entry.failures++;
+    entry.lastError = error;
+    entry.lastFailure = Date.now();
+  }
+
+  /** Tools with 2+ consecutive failures and no recent successes. */
+  getUnhealthy(): Array<{ name: string; error: string }> {
+    const result: Array<{ name: string; error: string }> = [];
+    for (const [name, entry] of this.entries) {
+      // Unhealthy: 2+ failures AND failure rate > 50%
+      if (entry.failures >= 2 && entry.failures > entry.successes && entry.lastError) {
+        result.push({ name, error: entry.lastError });
+      }
+    }
+    return result;
+  }
+
+  /** Get health summary for all tracked tools. */
+  getHealthMap(): Record<string, ToolHealthEntry> {
+    return Object.fromEntries(this.entries);
+  }
+
+  /** Format unhealthy tools as a context string for system prompt injection. */
+  formatUnhealthyContext(): string {
+    const unhealthy = this.getUnhealthy();
+    if (unhealthy.length === 0) return '';
+    const items = unhealthy.map((t) => `${t.name}: ${t.error}`).join('; ');
+    return `[Unhealthy tools — avoid calling these: ${items}]`;
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  private getOrCreate(toolName: string): ToolHealthEntry {
+    let entry = this.entries.get(toolName);
+    if (!entry) {
+      entry = { successes: 0, failures: 0 };
+      this.entries.set(toolName, entry);
+    }
+    return entry;
+  }
+}
+
+/** Global singleton for the current session. */
+let tracker: ToolHealthTracker | null = null;
+
+export function getToolHealthTracker(): ToolHealthTracker {
+  if (!tracker) tracker = new ToolHealthTracker();
+  return tracker;
+}
+
+export function resetToolHealthTracker(): void {
+  tracker = new ToolHealthTracker();
+}


### PR DESCRIPTION
## Summary

- **ToolHealthTracker** (`tools/src/tool-health.ts`): Session-level singleton that records success/failure per tool. Marks tools as "unhealthy" when they have 2+ failures and >50% failure rate.
- **Registry wiring** (`tools/src/registry.ts`): Every tool execution through `toAISDKToolsWithPermissions` automatically records health — success on `ok: true`, failure on errors/blocks.
- **TurnContext integration** (`shared/src/types.ts`, `core/src/agent/loop.ts`): `unhealthyTools` field added to `TurnContext`. The `formatTurnContext` one-liner now includes `unhealthy: shell,br_memory_store` when tools are failing, so the agent knows to avoid them.

Wave 1 Foundation — PR 4 of 47.

## Test plan

- [ ] Build passes across all 15 packages
- [ ] Shell tool blocked → after 2 failures, next turn context shows "unhealthy: shell"
- [ ] Tool recovers (succeeds) → failure rate drops below threshold → removed from unhealthy list
- [ ] `getToolHealthTracker().getHealthMap()` returns correct counts