### PR TITLE
feat: build state persistence — agent never forgets a broken build (PR 5/47)

### DIFF
--- a/packages/core/src/agent/build-state.ts
+++ b/packages/core/src/agent/build-state.ts
@@ -1,0 +1,115 @@
+/**
+ * Build State Tracker — persists last build/test result across turns.
+ * When a shell command matches the project's build_command or test_command,
+ * the result is captured. If the build is broken, a persistent warning
+ * is injected into the system context until it passes again.
+ */
+
+export interface BuildResult {
+  command: string;
+  exitCode: number;
+  errorSummary: string;
+  timestamp: number;
+}
+
+export type BuildStatus = 'passing' | 'failing' | 'unknown';
+
+export class BuildStateTracker {
+  private lastBuild: BuildResult | null = null;
+  private lastTest: BuildResult | null = null;
+  private buildPatterns: RegExp[] = [];
+  private testPatterns: RegExp[] = [];
+
+  constructor(buildCommand?: string, testCommand?: string) {
+    // Build default patterns + user-configured commands
+    this.buildPatterns = [
+      /\b(npm|pnpm|yarn|npx|turbo)\s+(run\s+)?build\b/,
+      /\btsc\b/,
+      /\bmake\b/,
+    ];
+    this.testPatterns = [
+      /\b(npm|pnpm|yarn|npx|turbo)\s+(run\s+)?test\b/,
+      /\bvitest\b/,
+      /\bjest\b/,
+      /\bpytest\b/,
+    ];
+
+    if (buildCommand) {
+      this.buildPatterns.unshift(new RegExp(escapeRegex(buildCommand)));
+    }
+    if (testCommand) {
+      this.testPatterns.unshift(new RegExp(escapeRegex(testCommand)));
+    }
+  }
+
+  /** Check if a shell command is a build or test command and record the result. */
+  recordShellResult(command: string, exitCode: number, stderr: string): void {
+    const isBuild = this.buildPatterns.some((p) => p.test(command));
+    const isTest = this.testPatterns.some((p) => p.test(command));
+
+    if (isBuild) {
+      this.lastBuild = {
+        command,
+        exitCode,
+        errorSummary: exitCode !== 0 ? extractErrorSummary(stderr) : '',
+        timestamp: Date.now(),
+      };
+    }
+
+    if (isTest) {
+      this.lastTest = {
+        command,
+        exitCode,
+        errorSummary: exitCode !== 0 ? extractErrorSummary(stderr) : '',
+        timestamp: Date.now(),
+      };
+    }
+  }
+
+  getStatus(): BuildStatus {
+    if (!this.lastBuild && !this.lastTest) return 'unknown';
+    if (this.lastBuild?.exitCode !== 0 && this.lastBuild) return 'failing';
+    if (this.lastTest?.exitCode !== 0 && this.lastTest) return 'failing';
+    return 'passing';
+  }
+
+  getLastBuild(): BuildResult | null {
+    return this.lastBuild;
+  }
+
+  getLastTest(): BuildResult | null {
+    return this.lastTest;
+  }
+
+  /** Format a persistent warning if the build is broken. Empty string if passing. */
+  formatBuildWarning(): string {
+    const warnings: string[] = [];
+
+    if (this.lastBuild && this.lastBuild.exitCode !== 0) {
+      warnings.push(`BUILD BROKEN: ${this.lastBuild.errorSummary || 'non-zero exit'}`);
+    }
+    if (this.lastTest && this.lastTest.exitCode !== 0) {
+      warnings.push(`TESTS FAILING: ${this.lastTest.errorSummary || 'non-zero exit'}`);
+    }
+
+    if (warnings.length === 0) return '';
+    return `[WARNING — ${warnings.join(' | ')}. Fix before creating new features.]`;
+  }
+
+  clear(): void {
+    this.lastBuild = null;
+    this.lastTest = null;
+  }
+}
+
+/** Extract the most useful error lines from stderr (last 3 non-empty lines, max 200 chars). */
+function extractErrorSummary(stderr: string): string {
+  if (!stderr) return '';
+  const lines = stderr.split('\n').filter((l) => l.trim().length > 0);
+  const summary = lines.slice(-3).join(' | ');
+  return summary.length > 200 ? summary.slice(-200) : summary;
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -6,6 +6,7 @@ import { BrainstormRouter, CostTracker } from '@brainstorm/router';
 import type { ToolRegistry, PermissionCheckFn } from '@brainstorm/tools';
 import { setTaskEventHandler, clearTasks, setBackgroundEventHandler, getToolHealthTracker } from '@brainstorm/tools';
 import type { AgentEvent, GatewayFeedbackData, ModelEntry, TurnContext } from '@brainstorm/shared';
+import type { BuildStateTracker } from './build-state.js';
 import { serializeRoutingMetadata } from '@brainstorm/shared';
 import { createStreamFilter } from './response-filter.js';
 import { normalizeInsightMarkers } from './insights.js';
@@ -103,6 +104,8 @@ export interface AgentLoopOptions {
   permissionCheck?: PermissionCheckFn;
   /** Callback to inject turn context after each completion. */
   onTurnComplete?: (ctx: TurnContext) => void;
+  /** Build state tracker — records build/test results for persistent warnings. */
+  buildState?: BuildStateTracker;
   /** Internal: marks this as a retry attempt to prevent infinite recursion. */
   _retryAttempt?: boolean;
 }
@@ -263,6 +266,11 @@ export async function* runAgentLoop(
             const path = (part as any).input?.path ?? (part as any).args?.path;
             if (path) filesWritten.push(path);
           }
+          // Track build/test results for persistent build state warnings
+          if (part.toolName === 'shell' && options.buildState && toolResult && typeof toolResult === 'object') {
+            const cmd = (part as any).input?.command ?? (part as any).args?.command ?? '';
+            options.buildState.recordShellResult(cmd, toolResult.exitCode ?? 0, toolResult.stderr ?? '');
+          }
           yield { type: 'tool-call-result', toolName: part.toolName, result: toolResult };
           // Emit subagent-result events for TUI display
           if (part.toolName === 'subagent' && toolResult && typeof toolResult === 'object') {
@@ -370,6 +378,8 @@ export async function* runAgentLoop(
         filesWritten,
         sessionMinutes: 0, // caller sets this
         unhealthyTools: getToolHealthTracker().getUnhealthy(),
+        buildStatus: options.buildState?.getStatus() ?? 'unknown',
+        buildWarning: options.buildState?.formatBuildWarning() ?? '',
       });
     }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,3 +16,4 @@ export { filterResponse, createStreamFilter, type StreamFilter } from './agent/r
 export { normalizeInsightMarkers } from './agent/insights.js';
 export { getOutputStylePrompt, OUTPUT_STYLES, type OutputStyle } from './agent/output-styles.js';
 export { createSubagentTool } from './agent/subagent-tool.js';
+export { BuildStateTracker, type BuildResult, type BuildStatus } from './agent/build-state.js';

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -220,6 +220,8 @@ export interface TurnContext {
   filesWritten: string[];
   sessionMinutes: number;
   unhealthyTools: Array<{ name: string; error: string }>;
+  buildStatus: 'passing' | 'failing' | 'unknown';
+  buildWarning: string;
 }
 
 /** Format TurnContext as a compact one-line summary for system message injection. */
@@ -243,8 +245,13 @@ export function formatTurnContext(ctx: TurnContext): string {
   if (ctx.unhealthyTools.length > 0) {
     parts.push(`unhealthy: ${ctx.unhealthyTools.map((t) => t.name).join(',')}`);
   }
+  if (ctx.buildStatus !== 'unknown') {
+    parts.push(`build: ${ctx.buildStatus}`);
+  }
   parts.push(`${ctx.sessionMinutes}min`);
-  return `[${parts.join(' | ')}]`;
+  let result = `[${parts.join(' | ')}]`;
+  if (ctx.buildWarning) result += `\n${ctx.buildWarning}`;
+  return result;
 }
 
 function basename(path: string): string {


### PR DESCRIPTION
## Summary

- **BuildStateTracker** (`core/src/agent/build-state.ts`): Captures build/test exit codes from shell tool results. Matches commands via regex patterns (npm build, vitest, jest, pytest, tsc, make) plus user-configured `build_command`/`test_command` from config.
- **Persistent warning**: When build fails, `formatBuildWarning()` returns `[WARNING — BUILD BROKEN: <last 3 error lines>. Fix before creating new features.]`. Clears when build passes.
- **TurnContext integration**: `buildStatus` ('passing'|'failing'|'unknown') and `buildWarning` added to TurnContext. `formatTurnContext` shows `build: failing` in the compact one-liner.
- **Agent loop wiring**: Shell tool results automatically fed to `buildState.recordShellResult()`.

Wave 1 Foundation — PR 5 of 47.

## Test plan

- [ ] Build passes across all 15 packages
- [ ] Run `npm run build` in shell → exits 0 → buildStatus: 'passing'
- [ ] Break a file → `npm run build` fails → next turn context shows BUILD BROKEN warning
- [ ] Fix file → `npm run build` passes → warning clears