### PR TITLE
feat: wire checkpoint system + undo tool (PR 9/47)

### DIFF
--- a/packages/tools/src/builtin/batch-edit.ts
+++ b/packages/tools/src/builtin/batch-edit.ts
@@ -79,6 +79,9 @@ export const batchEditTool = defineTool({
 
       // Write if any edits succeeded
       if (fileResult.applied > 0) {
+        const { getCheckpointManager } = await import('../checkpoint.js');
+        const cp = getCheckpointManager();
+        if (cp) cp.snapshot(safePath);
         writeFileSync(safePath, content, 'utf-8');
       }
 

--- a/packages/tools/src/builtin/file-edit.ts
+++ b/packages/tools/src/builtin/file-edit.ts
@@ -49,6 +49,11 @@ export const fileEditTool = defineTool({
       return { error: `old_string found ${occurrences} times — must be unique. Provide more surrounding context.` };
     }
 
+    // Snapshot before editing
+    const { getCheckpointManager } = await import('../checkpoint.js');
+    const cp = getCheckpointManager();
+    if (cp) cp.snapshot(safePath);
+
     const updated = content.replace(old_string, new_string);
     writeFileSync(safePath, updated, 'utf-8');
     return { success: true, path };

--- a/packages/tools/src/builtin/file-write.ts
+++ b/packages/tools/src/builtin/file-write.ts
@@ -38,6 +38,11 @@ export const fileWriteTool = defineTool({
     let safePath: string;
     try { safePath = ensureSafePath(path); } catch (e: any) { return { error: e.message }; }
 
+    // Snapshot before overwriting (if file exists)
+    const { getCheckpointManager } = await import('../checkpoint.js');
+    const cp = getCheckpointManager();
+    if (cp) cp.snapshot(safePath);
+
     mkdirSync(dirname(safePath), { recursive: true });
     writeFileSync(safePath, content, 'utf-8');
 

--- a/packages/tools/src/builtin/multi-edit.ts
+++ b/packages/tools/src/builtin/multi-edit.ts
@@ -35,6 +35,9 @@ export const multiEditTool = defineTool({
 
     const applied = results.filter((r) => r.applied).length;
     if (applied > 0) {
+      const { getCheckpointManager } = await import('../checkpoint.js');
+      const cp = getCheckpointManager();
+      if (cp) cp.snapshot(path);
       writeFileSync(path, content, 'utf-8');
     }
 

--- a/packages/tools/src/builtin/undo.ts
+++ b/packages/tools/src/builtin/undo.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+import { defineTool } from '../base.js';
+import { getCheckpointManager } from '../checkpoint.js';
+
+export const undoTool = defineTool({
+  name: 'undo_last_write',
+  description: 'Revert the most recent file write or edit. Optionally specify a file path to revert only that file. Returns { success, revertedFile } or { error }.',
+  permission: 'confirm',
+  inputSchema: z.object({
+    path: z.string().optional().describe('Specific file to revert (optional — defaults to most recent write)'),
+  }),
+  async execute({ path }) {
+    const cp = getCheckpointManager();
+    if (!cp) {
+      return { error: 'Checkpoint system not initialized. No undo history available.' };
+    }
+
+    const reverted = cp.revertLast(path);
+    if (!reverted) {
+      return { error: path ? `No checkpoint found for ${path}` : 'No checkpoints to revert.' };
+    }
+
+    return { success: true, revertedFile: reverted };
+  },
+});

--- a/packages/tools/src/checkpoint.ts
+++ b/packages/tools/src/checkpoint.ts
@@ -96,3 +96,15 @@ export class CheckpointManager {
     }
   }
 }
+
+/** Global checkpoint manager singleton — set during session init. */
+let activeCheckpoint: CheckpointManager | null = null;
+
+export function initCheckpointManager(sessionId: string): CheckpointManager {
+  activeCheckpoint = new CheckpointManager(sessionId);
+  return activeCheckpoint;
+}
+
+export function getCheckpointManager(): CheckpointManager | null {
+  return activeCheckpoint;
+}

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -1,7 +1,8 @@
 export { defineTool, type BrainstormToolDef } from './base.js';
 export { SessionFileTracker, getFileTracker, resetFileTracker } from './file-tracker.js';
 export { ToolHealthTracker, getToolHealthTracker, resetToolHealthTracker, type ToolHealthEntry } from './tool-health.js';
-export { CheckpointManager } from './checkpoint.js';
+export { CheckpointManager, initCheckpointManager, getCheckpointManager } from './checkpoint.js';
+export { undoTool } from './builtin/undo.js';
 export { ToolRegistry, type PermissionCheckFn } from './registry.js';
 export { fileReadTool } from './builtin/file-read.js';
 export { fileWriteTool } from './builtin/file-write.js';
@@ -54,6 +55,7 @@ import { webFetchTool } from './builtin/web-fetch.js';
 import { webSearchTool } from './builtin/web-search.js';
 import { processSpawnTool, processKillTool } from './builtin/process-manage.js';
 import { taskCreateTool, taskUpdateTool, taskListTool } from './builtin/task-manage.js';
+import { undoTool } from './builtin/undo.js';
 import {
   brStatusTool, brBudgetTool, brLeaderboardTool, brInsightsTool,
   brModelsTool, brMemorySearchTool, brMemoryStoreTool, brHealthTool,
@@ -91,6 +93,8 @@ export function createDefaultToolRegistry(): ToolRegistry {
   registry.register(taskCreateTool);
   registry.register(taskUpdateTool);
   registry.register(taskListTool);
+  // Undo (1)
+  registry.register(undoTool);
   // BrainstormRouter intelligence (8) — native REST calls, no MCP needed
   registry.register(brStatusTool);
   registry.register(brBudgetTool);


### PR DESCRIPTION
## Summary

- **Checkpoint wiring**: `file_write`, `file_edit`, `multi_edit`, `batch_edit` now call `checkpoint.snapshot()` before modifying files. Snapshots stored in `~/.brainstorm/checkpoints/<sessionId>/`.
- **Singleton pattern**: `initCheckpointManager(sessionId)` at session start, `getCheckpointManager()` accessed via dynamic import in tools.
- **undo_last_write tool**: New tool that calls `checkpoint.revertLast()`. Supports reverting a specific file or the most recent write. Permission: confirm.
- **Registered**: Tool added to `createDefaultToolRegistry()` (now 33 tools total).

Wave 1 Foundation — PR 9 of 47.

## Test plan

- [ ] Build passes across all 15 packages
- [ ] Write a file → undo_last_write → original content restored
- [ ] Edit a file → undo_last_write with path → that specific file reverted
- [ ] New file (no previous version) → undo returns "no checkpoint"