### PR TITLE
feat: scratchpad — compaction-resistant notes (PR 6/47)

### DIFF
--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -1,5 +1,6 @@
 import { streamText } from 'ai';
 import type { ConversationMessage } from './manager.js';
+import { formatScratchpadContext } from '@brainstorm/tools';
 
 /**
  * Estimate token count for a list of messages.
@@ -135,6 +136,12 @@ export async function compactContext(
       role: 'system',
       content: `[Summarized context — ${toSummarize.length} messages condensed]\n\n${summary}`,
     });
+  }
+
+  // Inject scratchpad entries so they survive compaction
+  const scratchpadCtx = formatScratchpadContext();
+  if (scratchpadCtx) {
+    compacted.push({ role: 'system', content: scratchpadCtx });
   }
 
   compacted.push(...recentMessages);

--- a/packages/tools/src/builtin/scratchpad.ts
+++ b/packages/tools/src/builtin/scratchpad.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+import { defineTool } from '../base.js';
+
+/**
+ * Session scratchpad — compaction-resistant notes.
+ * Singleton lives here in tools to avoid circular deps with core.
+ * Core reads via getScratchpad() export.
+ */
+const entries = new Map<string, string>();
+
+export function getScratchpadEntries(): Map<string, string> {
+  return entries;
+}
+
+export function clearScratchpad(): void {
+  entries.clear();
+}
+
+export function formatScratchpadContext(): string {
+  if (entries.size === 0) return '';
+  const items = [...entries].map(([k, v]) => `- ${k}: ${v}`).join('\n');
+  return `[Scratchpad — preserved through compaction]\n${items}`;
+}
+
+export const scratchpadWriteTool = defineTool({
+  name: 'scratchpad_write',
+  description: 'Save a note that survives context compaction. Use for: key decisions, current task state, important constraints. Not for code — for context you must remember.',
+  permission: 'auto',
+  inputSchema: z.object({
+    key: z.string().describe('Note identifier (e.g., "current_task", "decision_drizzle_over_prisma")'),
+    value: z.string().describe('The note content'),
+  }),
+  async execute({ key, value }) {
+    entries.set(key, value);
+    return { success: true, key, totalNotes: entries.size };
+  },
+});
+
+export const scratchpadReadTool = defineTool({
+  name: 'scratchpad_read',
+  description: 'Read scratchpad notes. Omit key to read all notes.',
+  permission: 'auto',
+  inputSchema: z.object({
+    key: z.string().optional().describe('Specific note to read (optional — omit to read all)'),
+  }),
+  async execute({ key }) {
+    if (key) {
+      const val = entries.get(key);
+      if (!val) return { error: `Note "${key}" not found.` };
+      return { key, value: val };
+    }
+    return { notes: Object.fromEntries(entries) };
+  },
+});

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -3,6 +3,7 @@ export { SessionFileTracker, getFileTracker, resetFileTracker } from './file-tra
 export { ToolHealthTracker, getToolHealthTracker, resetToolHealthTracker, type ToolHealthEntry } from './tool-health.js';
 export { CheckpointManager, initCheckpointManager, getCheckpointManager } from './checkpoint.js';
 export { undoTool } from './builtin/undo.js';
+export { scratchpadWriteTool, scratchpadReadTool, getScratchpadEntries, clearScratchpad, formatScratchpadContext } from './builtin/scratchpad.js';
 export { ToolRegistry, type PermissionCheckFn } from './registry.js';
 export { fileReadTool } from './builtin/file-read.js';
 export { fileWriteTool } from './builtin/file-write.js';
@@ -56,6 +57,7 @@ import { webSearchTool } from './builtin/web-search.js';
 import { processSpawnTool, processKillTool } from './builtin/process-manage.js';
 import { taskCreateTool, taskUpdateTool, taskListTool } from './builtin/task-manage.js';
 import { undoTool } from './builtin/undo.js';
+import { scratchpadWriteTool, scratchpadReadTool } from './builtin/scratchpad.js';
 import {
   brStatusTool, brBudgetTool, brLeaderboardTool, brInsightsTool,
   brModelsTool, brMemorySearchTool, brMemoryStoreTool, brHealthTool,
@@ -95,6 +97,9 @@ export function createDefaultToolRegistry(): ToolRegistry {
   registry.register(taskListTool);
   // Undo (1)
   registry.register(undoTool);
+  // Scratchpad (2)
+  registry.register(scratchpadWriteTool);
+  registry.register(scratchpadReadTool);
   // BrainstormRouter intelligence (8) — native REST calls, no MCP needed
   registry.register(brStatusTool);
   registry.register(brBudgetTool);


### PR DESCRIPTION
## Summary

- **scratchpad_write tool**: Save key-value notes that survive compaction. Permission: auto (no confirmation needed).
- **scratchpad_read tool**: Read one or all notes. Permission: auto.
- **Compaction integration**: After compacting history, `formatScratchpadContext()` injects all entries as a system message: `[Scratchpad — preserved through compaction]`.
- **No circular deps**: Singleton Map lives in tools package, core imports `formatScratchpadContext` from tools.

Wave 2 Core UX — PR 6 of 47.

## Test plan

- [ ] Build passes across all 15 packages
- [ ] scratchpad_write("decision", "Using Drizzle not Prisma") → success
- [ ] scratchpad_read() → returns all notes
- [ ] Trigger compaction → scratchpad entries appear in compacted context