### PR TITLE
feat: loop detection — nudge agent out of repetitive patterns (PR 7/47)

### DIFF
--- a/packages/core/src/agent/loop-detector.ts
+++ b/packages/core/src/agent/loop-detector.ts
@@ -1,0 +1,91 @@
+/**
+ * Loop Detector — detects repetitive agent behavior within a single turn.
+ *
+ * Tracks consecutive tool calls and emits warnings when the agent appears stuck:
+ * - N consecutive reads with no write → nudge to write
+ * - Same file read twice → warn about duplicate read
+ * - Same tool called N times in a row → warn about potential loop
+ */
+
+export interface LoopWarning {
+  type: 'consecutive-reads' | 'duplicate-read' | 'tool-repeat';
+  message: string;
+}
+
+export class LoopDetector {
+  private recentTools: string[] = [];
+  private filesReadThisTurn = new Set<string>();
+  private writesSinceLastCheck = 0;
+  private readonly readThreshold: number;
+  private readonly repeatThreshold: number;
+
+  constructor(readThreshold = 4, repeatThreshold = 3) {
+    this.readThreshold = readThreshold;
+    this.repeatThreshold = repeatThreshold;
+  }
+
+  /** Record a tool call and check for loop patterns. Returns warnings if any. */
+  recordToolCall(toolName: string, filePath?: string): LoopWarning[] {
+    this.recentTools.push(toolName);
+    const warnings: LoopWarning[] = [];
+
+    // Track writes
+    if (toolName === 'file_write' || toolName === 'file_edit' || toolName === 'multi_edit' || toolName === 'batch_edit') {
+      this.writesSinceLastCheck = this.recentTools.length;
+    }
+
+    // Check: duplicate file read
+    if (toolName === 'file_read' && filePath) {
+      if (this.filesReadThisTurn.has(filePath)) {
+        warnings.push({
+          type: 'duplicate-read',
+          message: `You already read "${filePath}" this turn. Use the content from before.`,
+        });
+      }
+      this.filesReadThisTurn.add(filePath);
+    }
+
+    // Check: consecutive reads without writing
+    const readsSinceWrite = this.countConsecutiveReads();
+    if (readsSinceWrite >= this.readThreshold) {
+      warnings.push({
+        type: 'consecutive-reads',
+        message: `You've read ${readsSinceWrite} files without writing. Consider making changes now.`,
+      });
+    }
+
+    // Check: same tool called N times in a row
+    if (this.recentTools.length >= this.repeatThreshold) {
+      const last = this.recentTools.slice(-this.repeatThreshold);
+      if (last.every((t) => t === last[0])) {
+        warnings.push({
+          type: 'tool-repeat',
+          message: `"${last[0]}" called ${this.repeatThreshold} times in a row. Consider a different approach.`,
+        });
+      }
+    }
+
+    return warnings;
+  }
+
+  reset(): void {
+    this.recentTools = [];
+    this.filesReadThisTurn.clear();
+    this.writesSinceLastCheck = 0;
+  }
+
+  private countConsecutiveReads(): number {
+    let count = 0;
+    for (let i = this.recentTools.length - 1; i >= 0; i--) {
+      if (this.recentTools[i] === 'file_read' || this.recentTools[i] === 'grep' || this.recentTools[i] === 'glob') {
+        count++;
+      } else if (this.recentTools[i] === 'file_write' || this.recentTools[i] === 'file_edit' || this.recentTools[i] === 'multi_edit' || this.recentTools[i] === 'batch_edit') {
+        break; // Stop counting at the last write
+      } else {
+        // Other tools (shell, git, etc.) don't break the read streak
+        count++;
+      }
+    }
+    return count;
+  }
+}

--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -7,6 +7,7 @@ import type { ToolRegistry, PermissionCheckFn } from '@brainstorm/tools';
 import { setTaskEventHandler, clearTasks, setBackgroundEventHandler, getToolHealthTracker } from '@brainstorm/tools';
 import type { AgentEvent, GatewayFeedbackData, ModelEntry, TurnContext } from '@brainstorm/shared';
 import type { BuildStateTracker } from './build-state.js';
+import { LoopDetector } from './loop-detector.js';
 import { serializeRoutingMetadata } from '@brainstorm/shared';
 import { createStreamFilter } from './response-filter.js';
 import { normalizeInsightMarkers } from './insights.js';
@@ -231,6 +232,7 @@ export async function* runAgentLoop(
     const toolCallResults: Array<{ name: string; ok: boolean }> = [];
     const filesRead: string[] = [];
     const filesWritten: string[] = [];
+    const loopDetector = new LoopDetector();
     const STREAM_TIMEOUT_MS = 60_000; // 60s without any SSE event = dead stream
 
     try {
@@ -272,6 +274,12 @@ export async function* runAgentLoop(
             options.buildState.recordShellResult(cmd, toolResult.exitCode ?? 0, toolResult.stderr ?? '');
           }
           yield { type: 'tool-call-result', toolName: part.toolName, result: toolResult };
+          // Loop detection — warn about repetitive behavior
+          const toolPath = (part as any).input?.path ?? (part as any).args?.path;
+          const loopWarnings = loopDetector.recordToolCall(part.toolName, toolPath);
+          for (const w of loopWarnings) {
+            yield { type: 'loop-warning' as const, message: w.message };
+          }
           // Emit subagent-result events for TUI display
           if (part.toolName === 'subagent' && toolResult && typeof toolResult === 'object') {
             if (toolResult.mode === 'single') {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,3 +17,4 @@ export { normalizeInsightMarkers } from './agent/insights.js';
 export { getOutputStylePrompt, OUTPUT_STYLES, type OutputStyle } from './agent/output-styles.js';
 export { createSubagentTool } from './agent/subagent-tool.js';
 export { BuildStateTracker, type BuildResult, type BuildStatus } from './agent/build-state.js';
+export { LoopDetector, type LoopWarning } from './agent/loop-detector.js';

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -201,6 +201,7 @@ export type AgentEvent =
   | { type: 'model-retry'; fromModel: string; toModel: string; reason: string }
   | { type: 'empty-response'; modelId: string }
   | { type: 'context-budget'; used: number; limit: number; percent: number }
+  | { type: 'loop-warning'; message: string }
   | { type: 'interrupted' }
   | { type: 'error'; error: Error }
   | { type: 'done'; totalCost: number; totalTokens?: { input: number; output: number } };


### PR DESCRIPTION
## Summary

- **LoopDetector** (`core/src/agent/loop-detector.ts`): Tracks tool calls within a turn and detects three patterns:
  - **Consecutive reads**: 4+ file_read/grep/glob with no write → nudge to write
  - **Duplicate reads**: Same file read twice → warn about wasted step
  - **Tool repeats**: Same tool called 3x in a row → suggest different approach
- **Agent event**: New `loop-warning` event type with message string
- **Configurable thresholds**: readThreshold (default 4), repeatThreshold (default 3)

Wave 2 Core UX — PR 7 of 47.

## Test plan

- [ ] Build passes across all 15 packages
- [ ] Read 4 files in a row → see consecutive-reads warning
- [ ] Read same file twice → see duplicate-read warning
- [ ] Call grep 3x in a row → see tool-repeat warning