### PR TITLE
feat: pre-validation for file writes (PR 8/47)

### DIFF
--- a/packages/tools/src/builtin/file-edit.ts
+++ b/packages/tools/src/builtin/file-edit.ts
@@ -55,7 +55,16 @@ export const fileEditTool = defineTool({
     if (cp) cp.snapshot(safePath);
 
     const updated = content.replace(old_string, new_string);
+
+    // Pre-validate content before writing (non-blocking)
+    const { preValidate } = await import('../pre-validate.js');
+    const validation = preValidate(safePath, updated);
+
     writeFileSync(safePath, updated, 'utf-8');
-    return { success: true, path };
+    return {
+      success: true,
+      path,
+      ...(validation.warnings.length > 0 ? { preValidation: validation.warnings } : {}),
+    };
   },
 });

--- a/packages/tools/src/builtin/file-write.ts
+++ b/packages/tools/src/builtin/file-write.ts
@@ -43,6 +43,10 @@ export const fileWriteTool = defineTool({
     const cp = getCheckpointManager();
     if (cp) cp.snapshot(safePath);
 
+    // Pre-validate content before writing (non-blocking)
+    const { preValidate } = await import('../pre-validate.js');
+    const validation = preValidate(safePath, content);
+
     mkdirSync(dirname(safePath), { recursive: true });
     writeFileSync(safePath, content, 'utf-8');
 
@@ -50,6 +54,11 @@ export const fileWriteTool = defineTool({
     const { getFileTracker } = await import('../file-tracker.js');
     getFileTracker().recordWrite(safePath);
 
-    return { success: true, path, bytesWritten: Buffer.byteLength(content) };
+    return {
+      success: true,
+      path,
+      bytesWritten: Buffer.byteLength(content),
+      ...(validation.warnings.length > 0 ? { preValidation: validation.warnings } : {}),
+    };
   },
 });

--- a/packages/tools/src/pre-validate.ts
+++ b/packages/tools/src/pre-validate.ts
@@ -1,0 +1,116 @@
+/**
+ * Pre-validation — check file content before writing to disk.
+ * Validates JSON and detects obvious syntax issues.
+ * Returns warnings (does NOT block writes).
+ */
+
+import { extname } from 'node:path';
+
+export interface PreValidationResult {
+  ok: boolean;
+  warnings: string[];
+}
+
+/** Validate content based on file extension. Non-blocking — returns warnings. */
+export function preValidate(filePath: string, content: string): PreValidationResult {
+  const ext = extname(filePath).toLowerCase();
+  const warnings: string[] = [];
+
+  if (ext === '.json') {
+    try {
+      JSON.parse(content);
+    } catch (e: any) {
+      warnings.push(`JSON syntax error: ${e.message}`);
+    }
+  }
+
+  if (ext === '.ts' || ext === '.tsx' || ext === '.js' || ext === '.jsx') {
+    // Quick heuristic checks (not a full parser, just obvious issues)
+    const tsWarnings = checkBracketBalance(content);
+    warnings.push(...tsWarnings);
+  }
+
+  if (ext === '.yaml' || ext === '.yml') {
+    // Basic YAML check: indentation consistency
+    const yamlWarnings = checkYamlBasics(content);
+    warnings.push(...yamlWarnings);
+  }
+
+  return { ok: warnings.length === 0, warnings };
+}
+
+/** Check for mismatched brackets/braces/parens. */
+function checkBracketBalance(content: string): string[] {
+  const warnings: string[] = [];
+  const stack: Array<{ char: string; line: number }> = [];
+  const pairs: Record<string, string> = { '(': ')', '[': ']', '{': '}' };
+  const closers = new Set([')', ']', '}']);
+  let inString = false;
+  let stringChar = '';
+  let escaped = false;
+  let lineNum = 1;
+  let inTemplateString = false;
+
+  for (let i = 0; i < content.length; i++) {
+    const ch = content[i];
+
+    if (ch === '\n') { lineNum++; continue; }
+
+    if (escaped) { escaped = false; continue; }
+    if (ch === '\\') { escaped = true; continue; }
+
+    // Track string state
+    if (!inString && !inTemplateString) {
+      if (ch === "'" || ch === '"') { inString = true; stringChar = ch; continue; }
+      if (ch === '`') { inTemplateString = true; continue; }
+    } else if (inString && ch === stringChar) {
+      inString = false; continue;
+    } else if (inTemplateString && ch === '`') {
+      inTemplateString = false; continue;
+    }
+
+    if (inString || inTemplateString) continue;
+
+    // Skip single-line comments
+    if (ch === '/' && i + 1 < content.length && content[i + 1] === '/') {
+      while (i < content.length && content[i] !== '\n') i++;
+      lineNum++;
+      continue;
+    }
+
+    if (pairs[ch]) {
+      stack.push({ char: ch, line: lineNum });
+    } else if (closers.has(ch)) {
+      const expected = stack.length > 0 ? pairs[stack[stack.length - 1].char] : null;
+      if (expected === ch) {
+        stack.pop();
+      } else {
+        warnings.push(`Unexpected '${ch}' at line ${lineNum}`);
+        return warnings; // Stop at first mismatch
+      }
+    }
+  }
+
+  if (stack.length > 0) {
+    const unclosed = stack[stack.length - 1];
+    warnings.push(`Unclosed '${unclosed.char}' from line ${unclosed.line}`);
+  }
+
+  return warnings;
+}
+
+/** Basic YAML validation. */
+function checkYamlBasics(content: string): string[] {
+  const warnings: string[] = [];
+  const lines = content.split('\n');
+
+  // Check for tabs (YAML doesn't allow tabs for indentation)
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].startsWith('\t')) {
+      warnings.push(`Line ${i + 1}: YAML does not allow tab indentation`);
+      break; // One warning is enough
+    }
+  }
+
+  return warnings;
+}


### PR DESCRIPTION
## Summary

- **preValidate()** (`tools/src/pre-validate.ts`): Validates file content before writing based on extension. Non-blocking — writes always proceed, warnings returned in result.
- **JSON**: Full `JSON.parse()` validation
- **TS/JS/TSX/JSX**: Bracket/brace/paren balance checker (handles strings, template literals, comments)
- **YAML**: Tab indentation detection
- **file_write**: Returns `preValidation: ["JSON syntax error: ..."]` when issues found
- **file_edit**: Same — validates the post-edit content

Wave 2 Core UX — PR 8 of 47.

## Test plan

- [ ] Build passes across all 15 packages
- [ ] Write invalid JSON → result includes preValidation warning
- [ ] Write .ts with unclosed brace → result includes bracket warning
- [ ] Write valid file → no preValidation field in result