### PR TITLE
feat: ask-user tool — agent pauses for design decisions (PR 10/47)

### DIFF
--- a/packages/tools/src/builtin/ask-user.ts
+++ b/packages/tools/src/builtin/ask-user.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+import { defineTool } from '../base.js';
+
+/**
+ * Ask-User Tool — pauses execution and asks the user a question.
+ *
+ * The tool emits a 'brainstorm:ask-user' event on process. The CLI
+ * listens for this event, displays the question, waits for user input,
+ * and calls the resolver to resume execution.
+ */
+
+let pendingResolver: ((answer: string) => void) | null = null;
+
+/** Called by the CLI when the user answers a question. */
+export function resolveAskUser(answer: string): void {
+  if (pendingResolver) {
+    const resolve = pendingResolver;
+    pendingResolver = null;
+    resolve(answer);
+  }
+}
+
+/** Check if there's a pending question waiting for an answer. */
+export function hasPendingQuestion(): boolean {
+  return pendingResolver !== null;
+}
+
+export const askUserTool = defineTool({
+  name: 'ask_user',
+  description: 'Pause and ask the user a question. Use for design decisions with multiple valid approaches, not routine confirmations. Returns { answer: string }.',
+  permission: 'auto',
+  inputSchema: z.object({
+    question: z.string().describe('The question to ask the user'),
+    options: z.array(z.string()).optional().describe('Optional choices (user can also type free text)'),
+  }),
+  async execute({ question, options }) {
+    return new Promise<{ answer: string }>((resolve) => {
+      pendingResolver = (answer) => {
+        resolve({ answer });
+      };
+      // Emit event for CLI to display and handle
+      process.emit('brainstorm:ask-user' as any, { question, options } as any);
+    });
+  },
+});

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -4,6 +4,7 @@ export { ToolHealthTracker, getToolHealthTracker, resetToolHealthTracker, type T
 export { CheckpointManager, initCheckpointManager, getCheckpointManager } from './checkpoint.js';
 export { undoTool } from './builtin/undo.js';
 export { scratchpadWriteTool, scratchpadReadTool, getScratchpadEntries, clearScratchpad, formatScratchpadContext } from './builtin/scratchpad.js';
+export { askUserTool, resolveAskUser, hasPendingQuestion } from './builtin/ask-user.js';
 export { ToolRegistry, type PermissionCheckFn } from './registry.js';
 export { fileReadTool } from './builtin/file-read.js';
 export { fileWriteTool } from './builtin/file-write.js';
@@ -58,6 +59,7 @@ import { processSpawnTool, processKillTool } from './builtin/process-manage.js';
 import { taskCreateTool, taskUpdateTool, taskListTool } from './builtin/task-manage.js';
 import { undoTool } from './builtin/undo.js';
 import { scratchpadWriteTool, scratchpadReadTool } from './builtin/scratchpad.js';
+import { askUserTool } from './builtin/ask-user.js';
 import {
   brStatusTool, brBudgetTool, brLeaderboardTool, brInsightsTool,
   brModelsTool, brMemorySearchTool, brMemoryStoreTool, brHealthTool,
@@ -100,6 +102,8 @@ export function createDefaultToolRegistry(): ToolRegistry {
   // Scratchpad (2)
   registry.register(scratchpadWriteTool);
   registry.register(scratchpadReadTool);
+  // Ask user (1)
+  registry.register(askUserTool);
   // BrainstormRouter intelligence (8) — native REST calls, no MCP needed
   registry.register(brStatusTool);
   registry.register(brBudgetTool);


### PR DESCRIPTION
## Summary

- **ask_user tool**: Pauses agent execution and asks the user a question. Returns `{ answer: string }`.
- **Promise-based pause**: `execute()` returns a Promise. CLI calls `resolveAskUser(answer)` to resume.
- **Event mechanism**: `process.emit('brainstorm:ask-user', { question, options })` — CLI listens and handles display/input.
- **Permission**: auto (no confirmation needed — the question IS the interaction)
- **Enables**: PR 13 (cost negotiation) and PR 14 (intent verification)

Wave 2 Core UX — PR 10 of 47.

## Test plan

- [ ] Build passes across all 15 packages
- [ ] Model calls ask_user → CLI displays question → user types answer → model receives it
- [ ] hasPendingQuestion() returns true while waiting, false after resolved