### PR TITLE
feat: compaction improvements — warnings, summaries, keep tags (PR 11/47)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,7 +2,7 @@ export { runAgentLoop, type AgentLoopOptions, type CompactionCallbacks } from '.
 export { buildSystemPrompt, parseAtMentions, buildToolAwarenessSection } from './agent/context.js';
 export { SessionManager } from './session/manager.js';
 export { PermissionManager } from './permissions/manager.js';
-export { compactContext, estimateTokenCount, needsCompaction } from './session/compaction.js';
+export { compactContext, estimateTokenCount, needsCompaction, getContextPercent } from './session/compaction.js';
 export { spawnSubagent, spawnParallel, getSubagentTypeConfig, SUBAGENT_TYPE_NAMES, type SubagentOptions, type SubagentResult, type SubagentType, type SubagentHookFn } from './agent/subagent.js';
 export { loadSkills, findSkill, type SkillDefinition } from './skills/loader.js';
 export { MemoryManager, type MemoryEntry } from './memory/manager.js';

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -23,6 +23,12 @@ export function needsCompaction(messages: ConversationMessage[], contextWindow: 
   return tokens > contextWindow * 0.8;
 }
 
+/** Get context usage as a percentage (0-100). Useful for pre-compaction warnings. */
+export function getContextPercent(messages: ConversationMessage[], contextWindow: number): number {
+  const tokens = estimateTokenCount(messages);
+  return Math.round((tokens / contextWindow) * 100);
+}
+
 /**
  * Compact conversation history by summarizing old messages.
  *
@@ -138,6 +144,14 @@ export async function compactContext(
     });
   }
 
+  // Post-compaction summary — tell the agent what happened
+  const summaryParts = [`Compacted: ${oldMessages.length} old messages processed.`];
+  if (kept.length > 0) summaryParts.push(`Preserved: ${kept.length} critical messages.`);
+  if (toSummarize.length > 0) summaryParts.push(`Summarized: ${toSummarize.length} messages.`);
+  if (dropped > 0) summaryParts.push(`Dropped: ${dropped} redundant messages.`);
+  summaryParts.push(`Retained: ${recentMessages.length} recent messages.`);
+  compacted.push({ role: 'system', content: `[Compaction summary] ${summaryParts.join(' ')}` });
+
   // Inject scratchpad entries so they survive compaction
   const scratchpadCtx = formatScratchpadContext();
   if (scratchpadCtx) {
@@ -167,6 +181,9 @@ function classifyMessage(
   if (msg.role === 'user') return 'keep';
 
   const content = msg.content;
+
+  // [keep] prefix marks messages as compaction-resistant
+  if (content.startsWith('[keep]') || content.startsWith('[KEEP]')) return 'keep';
 
   // Keep error messages
   if (content.includes('Error:') || content.includes('error:') || content.includes('FAIL')) {


### PR DESCRIPTION
## Summary

- **getContextPercent()**: Returns context usage as 0-100%, enabling pre-compaction warnings
- **[keep] prefix**: Messages starting with `[keep]` are always preserved through compaction
- **Post-compaction summary**: System message injected after compaction: "Preserved: N critical. Summarized: M. Dropped: K redundant."

Wave 2 Core UX — PR 11 of 47.

## Test plan

- [ ] Build passes across all 15 packages
- [ ] Message with `[keep]` prefix survives compaction
- [ ] After compaction, summary message shows correct counts
- [ ] getContextPercent() returns reasonable percentage