### PR TITLE
feat: diff preview after file writes (PR 25/47)

### DIFF
--- a/packages/tools/src/builtin/file-edit.ts
+++ b/packages/tools/src/builtin/file-edit.ts
@@ -61,10 +61,16 @@ export const fileEditTool = defineTool({
     const validation = preValidate(safePath, updated);
 
     writeFileSync(safePath, updated, 'utf-8');
+
+    // Diff preview (non-blocking)
+    const { getDiffSummary } = await import('../diff-preview.js');
+    const diff = getDiffSummary(safePath);
+
     return {
       success: true,
       path,
       ...(validation.warnings.length > 0 ? { preValidation: validation.warnings } : {}),
+      ...(diff ? { diff: diff.preview } : {}),
     };
   },
 });

--- a/packages/tools/src/builtin/file-write.ts
+++ b/packages/tools/src/builtin/file-write.ts
@@ -54,11 +54,16 @@ export const fileWriteTool = defineTool({
     const { getFileTracker } = await import('../file-tracker.js');
     getFileTracker().recordWrite(safePath);
 
+    // Diff preview (non-blocking)
+    const { getDiffSummary } = await import('../diff-preview.js');
+    const diff = getDiffSummary(safePath);
+
     return {
       success: true,
       path,
       bytesWritten: Buffer.byteLength(content),
       ...(validation.warnings.length > 0 ? { preValidation: validation.warnings } : {}),
+      ...(diff ? { diff: diff.preview } : {}),
     };
   },
 });

--- a/packages/tools/src/diff-preview.ts
+++ b/packages/tools/src/diff-preview.ts
@@ -1,0 +1,39 @@
+/**
+ * Diff Preview — get a compact git diff summary after file writes.
+ * Non-blocking, fails silently if not in a git repo.
+ */
+
+import { execFileSync } from 'node:child_process';
+
+export interface DiffSummary {
+  additions: number;
+  deletions: number;
+  preview: string;
+}
+
+/** Get a compact diff summary for a file. Returns null if not in git or no changes. */
+export function getDiffSummary(filePath: string): DiffSummary | null {
+  try {
+    const stat = execFileSync('git', ['diff', '--numstat', '--', filePath], {
+      encoding: 'utf-8',
+      timeout: 3000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+
+    if (!stat) return null;
+
+    const [add, del] = stat.split('\t');
+    const additions = parseInt(add, 10) || 0;
+    const deletions = parseInt(del, 10) || 0;
+
+    if (additions === 0 && deletions === 0) return null;
+
+    return {
+      additions,
+      deletions,
+      preview: `+${additions} -${deletions} lines`,
+    };
+  } catch {
+    return null; // Not in git, or git not available
+  }
+}


### PR DESCRIPTION
## Summary

- **getDiffSummary()** (`tools/src/diff-preview.ts`): Runs `git diff --numstat` via `execFileSync` (safe, no shell injection) and returns `{ additions, deletions, preview }`.
- **file_write + file_edit**: After writing, include `diff: "+3 -1 lines"` in the result. Agent sees the change summary and can self-correct.
- **Silent fallback**: Returns null if not in a git repo or no changes detected. 3s timeout.

Wave 3 — PR 25 of 47.

## Test plan

- [ ] Build passes across all 15 packages  
- [ ] Edit a tracked file → result includes `diff: "+N -M lines"`
- [ ] Write new file (untracked) → no diff field
- [ ] Run outside git repo → no diff field, no error