### PR TITLE
feat: live tool output streaming (PR 12/47)

### DIFF
--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -4,7 +4,7 @@ import type { BrainstormConfig } from '@brainstorm/config';
 import type { ProviderRegistry } from '@brainstorm/providers';
 import { BrainstormRouter, CostTracker } from '@brainstorm/router';
 import type { ToolRegistry, PermissionCheckFn } from '@brainstorm/tools';
-import { setTaskEventHandler, clearTasks, setBackgroundEventHandler, getToolHealthTracker } from '@brainstorm/tools';
+import { setTaskEventHandler, clearTasks, setBackgroundEventHandler, getToolHealthTracker, setToolOutputHandler } from '@brainstorm/tools';
 import type { AgentEvent, GatewayFeedbackData, ModelEntry, TurnContext } from '@brainstorm/shared';
 import type { BuildStateTracker } from './build-state.js';
 import { LoopDetector } from './loop-detector.js';
@@ -139,6 +139,15 @@ export async function* runAgentLoop(
       exitCode: event.exitCode,
       stdout: event.stdout,
       stderr: event.stderr,
+    } as AgentEvent);
+  });
+
+  // Wire tool output streaming into the same queue
+  setToolOutputHandler((event) => {
+    taskEventQueue.push({
+      type: 'tool-output-partial',
+      toolName: event.toolName,
+      chunk: event.chunk,
     } as AgentEvent);
   });
 
@@ -404,6 +413,7 @@ export async function* runAgentLoop(
     }
   } finally {
     setTaskEventHandler(null);
+    setToolOutputHandler(null);
     // Keep background handler alive — background tasks outlive individual agent loop runs
   }
 }

--- a/packages/tools/src/builtin/shell.ts
+++ b/packages/tools/src/builtin/shell.ts
@@ -36,6 +36,15 @@ export function setBackgroundEventHandler(handler: typeof backgroundEventHandler
   backgroundEventHandler = handler;
 }
 
+// ── Tool Output Streaming ──────────────────────────────────────
+
+let toolOutputHandler: ((event: { toolName: string; chunk: string }) => void) | null = null;
+
+/** Set a callback for streaming tool output chunks during foreground execution. */
+export function setToolOutputHandler(handler: typeof toolOutputHandler): void {
+  toolOutputHandler = handler;
+}
+
 /** Get list of currently running background tasks. */
 export function getBackgroundTasks(): BackgroundTask[] {
   return Array.from(backgroundTasks.values());
@@ -192,8 +201,14 @@ export const shellTool = defineTool({
       child.stdout.setEncoding('utf-8');
       child.stderr.setEncoding('utf-8');
 
-      child.stdout.on('data', (chunk: string) => stdout.append(chunk));
-      child.stderr.on('data', (chunk: string) => stderr.append(chunk));
+      child.stdout.on('data', (chunk: string) => {
+        stdout.append(chunk);
+        if (toolOutputHandler) toolOutputHandler({ toolName: 'shell', chunk });
+      });
+      child.stderr.on('data', (chunk: string) => {
+        stderr.append(chunk);
+        if (toolOutputHandler) toolOutputHandler({ toolName: 'shell', chunk });
+      });
 
       const timer = setTimeout(() => {
         child.kill('SIGTERM');

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -18,7 +18,7 @@ export { gitLogTool } from './builtin/git-log.js';
 export { gitCommitTool } from './builtin/git-commit.js';
 export { checkGitSafety, formatViolations, hasHardBlock, type GitSafetyViolation } from './builtin/git-safety.js';
 export { checkSandbox, type SandboxLevel } from './builtin/sandbox.js';
-export { configureSandbox, setBackgroundEventHandler, getBackgroundTasks } from './builtin/shell.js';
+export { configureSandbox, setBackgroundEventHandler, getBackgroundTasks, setToolOutputHandler } from './builtin/shell.js';
 export { ghPrTool } from './builtin/gh-pr.js';
 export { ghIssueTool } from './builtin/gh-issue.js';
 export { gitBranchTool } from './builtin/git-branch.js';


### PR DESCRIPTION
## Summary

- **setToolOutputHandler()**: New callback in shell tool that fires with `{ toolName, chunk }` for every stdout/stderr chunk during foreground execution
- **Agent loop wiring**: Tool output events queued alongside task events, yielded as `tool-output-partial` (event type already existed but was never emitted)
- **Cleanup**: Handler cleared in finally block to prevent leaks

Wave 2 Core UX — PR 12 of 47.

## Test plan

- [ ] Build passes across all 15 packages
- [ ] Run `npm test` via shell → see streaming output chunks
- [ ] Handler is null after agent loop completes