### PR TITLE
feat: routing control tool — agent self-selects model preference (PR 24/47)

### DIFF
--- a/packages/tools/src/builtin/routing-hint.ts
+++ b/packages/tools/src/builtin/routing-hint.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+import { defineTool } from '../base.js';
+
+/**
+ * Routing Hint — agent self-selects routing preference for the next turn.
+ * The hint is consumed once by the agent loop, then reset.
+ */
+
+export type RoutingPreference = 'cheap' | 'quality' | 'fast' | 'auto';
+
+let currentHint: RoutingPreference = 'auto';
+
+export function getRoutingHint(): RoutingPreference {
+  return currentHint;
+}
+
+/** Consume the hint (read once, then reset to auto). */
+export function consumeRoutingHint(): RoutingPreference {
+  const hint = currentHint;
+  currentHint = 'auto';
+  return hint;
+}
+
+export function resetRoutingHint(): void {
+  currentHint = 'auto';
+}
+
+export const routingHintTool = defineTool({
+  name: 'set_routing_hint',
+  description: 'Set your preference for the NEXT model selection. Use "cheap" for simple reads, "quality" for complex refactors, "fast" for latency-sensitive work, "auto" to let the router decide. Hint is consumed once.',
+  permission: 'auto',
+  inputSchema: z.object({
+    preference: z.enum(['cheap', 'quality', 'fast', 'auto']).describe('Routing preference for the next turn'),
+    reason: z.string().optional().describe('Brief reason for the choice'),
+  }),
+  async execute({ preference, reason }) {
+    currentHint = preference;
+    return { success: true, preference, message: `Next turn will prefer "${preference}" routing.${reason ? ` Reason: ${reason}` : ''}` };
+  },
+});

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -5,6 +5,7 @@ export { CheckpointManager, initCheckpointManager, getCheckpointManager } from '
 export { undoTool } from './builtin/undo.js';
 export { scratchpadWriteTool, scratchpadReadTool, getScratchpadEntries, clearScratchpad, formatScratchpadContext } from './builtin/scratchpad.js';
 export { askUserTool, resolveAskUser, hasPendingQuestion } from './builtin/ask-user.js';
+export { routingHintTool, getRoutingHint, consumeRoutingHint, resetRoutingHint, type RoutingPreference } from './builtin/routing-hint.js';
 export { ToolRegistry, type PermissionCheckFn } from './registry.js';
 export { fileReadTool } from './builtin/file-read.js';
 export { fileWriteTool } from './builtin/file-write.js';
@@ -60,6 +61,7 @@ import { taskCreateTool, taskUpdateTool, taskListTool } from './builtin/task-man
 import { undoTool } from './builtin/undo.js';
 import { scratchpadWriteTool, scratchpadReadTool } from './builtin/scratchpad.js';
 import { askUserTool } from './builtin/ask-user.js';
+import { routingHintTool } from './builtin/routing-hint.js';
 import {
   brStatusTool, brBudgetTool, brLeaderboardTool, brInsightsTool,
   brModelsTool, brMemorySearchTool, brMemoryStoreTool, brHealthTool,
@@ -104,6 +106,8 @@ export function createDefaultToolRegistry(): ToolRegistry {
   registry.register(scratchpadReadTool);
   // Ask user (1)
   registry.register(askUserTool);
+  // Routing (1)
+  registry.register(routingHintTool);
   // BrainstormRouter intelligence (8) — native REST calls, no MCP needed
   registry.register(brStatusTool);
   registry.register(brBudgetTool);


### PR DESCRIPTION
## Summary

- **set_routing_hint tool**: Agent calls with `"cheap"`, `"quality"`, `"fast"`, or `"auto"` to influence next turn's model selection
- **consumeRoutingHint()**: Read-once getter — resets to auto after consumption
- **Permission**: auto (no confirmation — it's just a preference signal)
- **37 tools** total now registered

Wave 3 — PR 24 of 47.

## Test plan

- [ ] Build passes across all 15 packages
- [ ] set_routing_hint("cheap") → consumeRoutingHint() returns "cheap" → next call returns "auto"