### PR TITLE
feat: intent verification — plan preview before execution (PR 14/47)

### DIFF
--- a/packages/tools/src/builtin/plan-preview.ts
+++ b/packages/tools/src/builtin/plan-preview.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+import { defineTool } from '../base.js';
+
+/**
+ * Plan Preview Tool — format a multi-step plan for display.
+ * The agent calls this to structure its plan, then uses ask_user
+ * to present it and get approval.
+ */
+
+export const planPreviewTool = defineTool({
+  name: 'plan_preview',
+  description: 'Format a multi-step plan for presentation to the user. Returns a formatted plan string. After calling this, use ask_user to present the plan and get approval before executing.',
+  permission: 'auto',
+  inputSchema: z.object({
+    summary: z.string().describe('One-line summary of the overall task'),
+    steps: z.array(z.object({
+      description: z.string().describe('What this step does'),
+      tools: z.array(z.string()).describe('Tools that will be used'),
+    })).describe('Ordered list of planned steps'),
+    estimatedCost: z.string().optional().describe('Estimated total cost (e.g., "$0.08")'),
+  }),
+  async execute({ summary, steps, estimatedCost }) {
+    const lines = [`Plan: ${summary}`, ''];
+    steps.forEach((s, i) => {
+      lines.push(`  ${i + 1}. ${s.description}`);
+      lines.push(`     Tools: ${s.tools.join(', ')}`);
+    });
+    if (estimatedCost) {
+      lines.push('');
+      lines.push(`Estimated cost: ${estimatedCost}`);
+    }
+    lines.push('');
+    lines.push(`Total steps: ${steps.length}`);
+
+    return {
+      formattedPlan: lines.join('\n'),
+      stepCount: steps.length,
+      instruction: 'Present this plan to the user via ask_user with options ["Proceed", "Adjust", "Skip"]. If approved, execute the steps.',
+    };
+  },
+});

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -7,6 +7,7 @@ export { scratchpadWriteTool, scratchpadReadTool, getScratchpadEntries, clearScr
 export { askUserTool, resolveAskUser, hasPendingQuestion } from './builtin/ask-user.js';
 export { routingHintTool, getRoutingHint, consumeRoutingHint, resetRoutingHint, type RoutingPreference } from './builtin/routing-hint.js';
 export { costEstimateTool } from './builtin/cost-estimate.js';
+export { planPreviewTool } from './builtin/plan-preview.js';
 export { ToolRegistry, type PermissionCheckFn } from './registry.js';
 export { fileReadTool } from './builtin/file-read.js';
 export { fileWriteTool } from './builtin/file-write.js';
@@ -64,6 +65,7 @@ import { scratchpadWriteTool, scratchpadReadTool } from './builtin/scratchpad.js
 import { askUserTool } from './builtin/ask-user.js';
 import { routingHintTool } from './builtin/routing-hint.js';
 import { costEstimateTool } from './builtin/cost-estimate.js';
+import { planPreviewTool } from './builtin/plan-preview.js';
 import {
   brStatusTool, brBudgetTool, brLeaderboardTool, brInsightsTool,
   brModelsTool, brMemorySearchTool, brMemoryStoreTool, brHealthTool,
@@ -111,6 +113,7 @@ export function createDefaultToolRegistry(): ToolRegistry {
   // Routing + Cost (2)
   registry.register(routingHintTool);
   registry.register(costEstimateTool);
+  registry.register(planPreviewTool);
   // BrainstormRouter intelligence (8) — native REST calls, no MCP needed
   registry.register(brStatusTool);
   registry.register(brBudgetTool);


### PR DESCRIPTION
## Summary

- **plan_preview tool**: Formats multi-step plans with numbered steps, tools, and estimated cost
- **Workflow**: plan_preview → ask_user (with Proceed/Adjust/Skip) → execute
- **Returns**: `{ formattedPlan, stepCount, instruction }` — agent uses formattedPlan as ask_user question

Wave 2 Core UX — PR 14 of 47.

## Test plan

- [ ] Build passes across all 15 packages
- [ ] plan_preview with 5 steps → returns formatted plan string
- [ ] Agent uses plan with ask_user → user approves → execution proceeds