### PR TITLE
feat: user reaction signal tracking (PR 26/47)

### DIFF
--- a/packages/core/src/agent/reaction-tracker.ts
+++ b/packages/core/src/agent/reaction-tracker.ts
@@ -1,0 +1,88 @@
+/**
+ * User Reaction Signal Tracker — detect acceptance/rejection of agent responses.
+ * Analyzes user messages for satisfaction signals per session.
+ * Injected as context so the agent knows what worked and what didn't.
+ */
+
+export type ReactionSignal = 'accepted' | 'rejected' | 'neutral';
+
+export interface ReactionEntry {
+  turn: number;
+  signal: ReactionSignal;
+  userMessage: string;
+}
+
+const POSITIVE_PATTERNS = [
+  /^(perfect|great|thanks|good|nice|awesome|yes|ok|looks good|lgtm)/i,
+  /\bthat works\b/i, /\bthat's right\b/i, /\bexactly\b/i,
+];
+
+const NEGATIVE_PATTERNS = [
+  /^(no|wrong|undo|revert|fix|that's not|that isn't)/i,
+  /\bstill broken\b/i, /\bdoesn't work\b/i, /\btry again\b/i,
+  /\bnot what I\b/i, /\bwhat I asked\b/i,
+];
+
+export class ReactionTracker {
+  private reactions: ReactionEntry[] = [];
+
+  /** Analyze a user message and record the reaction signal. */
+  record(turn: number, userMessage: string): ReactionSignal {
+    const signal = classifyReaction(userMessage);
+    this.reactions.push({ turn, signal, userMessage: userMessage.slice(0, 100) });
+
+    // Keep only last 20 reactions
+    if (this.reactions.length > 20) {
+      this.reactions = this.reactions.slice(-20);
+    }
+
+    return signal;
+  }
+
+  /** Get the last N reactions. */
+  getRecent(n = 5): ReactionEntry[] {
+    return this.reactions.slice(-n);
+  }
+
+  /** Format reaction context for system prompt injection. */
+  formatReactionContext(): string {
+    const recent = this.getRecent(5);
+    if (recent.length === 0) return '';
+
+    const accepted = recent.filter((r) => r.signal === 'accepted').length;
+    const rejected = recent.filter((r) => r.signal === 'rejected').length;
+
+    if (rejected === 0 && accepted === 0) return '';
+
+    const parts: string[] = [];
+    if (accepted > 0) parts.push(`${accepted} accepted`);
+    if (rejected > 0) parts.push(`${rejected} rejected`);
+
+    return `[Recent reactions: ${parts.join(', ')} out of last ${recent.length} responses]`;
+  }
+
+  clear(): void {
+    this.reactions = [];
+  }
+}
+
+function classifyReaction(message: string): ReactionSignal {
+  const trimmed = message.trim();
+
+  // Check positive patterns
+  for (const p of POSITIVE_PATTERNS) {
+    if (p.test(trimmed)) return 'accepted';
+  }
+
+  // Check negative patterns
+  for (const p of NEGATIVE_PATTERNS) {
+    if (p.test(trimmed)) return 'rejected';
+  }
+
+  // If message immediately follows with a new task (no comment on previous), treat as accepted
+  if (trimmed.length > 50 && !trimmed.includes('?')) {
+    return 'accepted'; // Long message with new instructions = moved on
+  }
+
+  return 'neutral';
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,3 +19,4 @@ export { createSubagentTool } from './agent/subagent-tool.js';
 export { BuildStateTracker, type BuildResult, type BuildStatus } from './agent/build-state.js';
 export { LoopDetector, type LoopWarning } from './agent/loop-detector.js';
 export { detectTone, toneGuidance, type UserTone, type ToneResult } from './agent/sentiment.js';
+export { ReactionTracker, type ReactionSignal, type ReactionEntry } from './agent/reaction-tracker.js';


### PR DESCRIPTION
## Summary

- **ReactionTracker**: Classifies user messages as accepted/rejected/neutral
- **formatReactionContext()**: Compact summary for system prompt injection
- **Keeps last 20 reactions**, formats last 5 for context

Wave 4 — PR 26 of 47.

## Test plan

- [ ] Build passes across all 15 packages
- [ ] "perfect" → accepted signal
- [ ] "no, that's wrong" → rejected signal
- [ ] Long new instructions → accepted (moved on)