### PR TITLE
feat: semantic file watching — detect external changes (PR 18/47)

### DIFF
--- a/packages/core/src/agent/file-watcher.ts
+++ b/packages/core/src/agent/file-watcher.ts
@@ -1,0 +1,100 @@
+/**
+ * Semantic File Watcher — detect external file changes between turns.
+ * Uses fs.watch (no external dependencies) to track changes in the project.
+ * Filters out node_modules, .git, dist, .next, and other noise.
+ */
+
+import { watch, type FSWatcher } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const IGNORE_DIRS = new Set([
+  'node_modules', '.git', '.next', 'dist', '.turbo', '.cache',
+  'coverage', '.nyc_output', '__pycache__', '.pytest_cache',
+]);
+
+export interface FileChange {
+  path: string;
+  type: 'created' | 'modified' | 'deleted';
+}
+
+export class FileWatcher {
+  private watcher: FSWatcher | null = null;
+  private changes = new Map<string, FileChange['type']>();
+  private agentWrites = new Set<string>();
+
+  constructor(private projectPath: string) {}
+
+  /** Start watching the project directory. */
+  start(): void {
+    if (this.watcher) return; // Already watching
+
+    try {
+      this.watcher = watch(this.projectPath, { recursive: true }, (eventType, filename) => {
+        if (!filename) return;
+
+        // Filter out ignored directories
+        const parts = filename.split('/');
+        if (parts.some((p) => IGNORE_DIRS.has(p))) return;
+
+        // Filter out dot-files and common temp files
+        const base = parts[parts.length - 1];
+        if (base.startsWith('.') || base.endsWith('~') || base.endsWith('.swp')) return;
+
+        const fullPath = join(this.projectPath, filename);
+
+        // Skip changes made by the agent itself
+        if (this.agentWrites.has(fullPath)) {
+          this.agentWrites.delete(fullPath);
+          return;
+        }
+
+        // Record the change
+        const changeType = eventType === 'rename' ? 'created' : 'modified';
+        this.changes.set(filename, changeType);
+      });
+
+      // Don't let the watcher keep the process alive
+      this.watcher.unref();
+    } catch {
+      // fs.watch may not support recursive on all platforms — fail silently
+    }
+  }
+
+  /** Register a file as written by the agent (to distinguish from external changes). */
+  recordAgentWrite(filePath: string): void {
+    this.agentWrites.add(filePath);
+  }
+
+  /** Consume and return all changes since last call. Clears the buffer. */
+  consumeChanges(): FileChange[] {
+    const result: FileChange[] = [];
+    for (const [path, type] of this.changes) {
+      result.push({ path, type });
+    }
+    this.changes.clear();
+    return result;
+  }
+
+  /** Format changes as a context string for system prompt injection. */
+  formatChanges(): string {
+    const changes = this.consumeChanges();
+    if (changes.length === 0) return '';
+
+    const items = changes.slice(0, 10).map((c) => {
+      const icon = c.type === 'created' ? '+' : c.type === 'deleted' ? '-' : '~';
+      return `${icon} ${c.path}`;
+    });
+    const suffix = changes.length > 10 ? ` (and ${changes.length - 10} more)` : '';
+    return `[External changes since last turn${suffix}]\n${items.join('\n')}`;
+  }
+
+  /** Stop watching. */
+  stop(): void {
+    if (this.watcher) {
+      this.watcher.close();
+      this.watcher = null;
+    }
+    this.changes.clear();
+    this.agentWrites.clear();
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,3 +22,4 @@ export { detectTone, toneGuidance, type UserTone, type ToneResult } from './agen
 export { ReactionTracker, type ReactionSignal, type ReactionEntry } from './agent/reaction-tracker.js';
 export { SessionPatternLearner } from './learning/session-patterns.js';
 export { buildSelfReviewPrompt, parseSelfReviewResponse, type SelfReviewResult, type SelfReviewOptions } from './agent/self-review.js';
+export { FileWatcher, type FileChange } from './agent/file-watcher.js';


### PR DESCRIPTION
## Summary

- **FileWatcher**: Uses `fs.watch` with recursive option to track project directory changes
- **Filtering**: Ignores node_modules, .git, dist, dot-files, temp files, and agent's own writes
- **consumeChanges()**: Returns and clears accumulated changes
- **formatChanges()**: Context string for system prompt: "External changes since last turn"
- **Zero deps**: Uses Node.js built-in `fs.watch`, `.unref()` to not block process exit

Wave 4 — PR 18 of 47.

## Test plan

- [ ] Build passes across all 15 packages
- [ ] Start watcher → edit file externally → consumeChanges returns the change
- [ ] Agent writes recorded → those changes filtered out
- [ ] node_modules changes ignored