### PR TITLE
feat: auto-lint on file write (PR 22/47)

### DIFF
--- a/packages/hooks/src/builtin/auto-lint.ts
+++ b/packages/hooks/src/builtin/auto-lint.ts
@@ -1,0 +1,96 @@
+/**
+ * Auto-Lint Hook — runs the project linter after file writes.
+ * Detects eslint, biome, or prettier in the project and runs --fix.
+ * Non-blocking: reports lint results but doesn't prevent writes.
+ */
+
+import { existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import type { HookDefinition } from '../types.js';
+
+/** Detect which linter is configured in the project. */
+export function detectLinter(projectPath: string): 'eslint' | 'biome' | 'prettier' | null {
+  // Check for biome first (newer, faster)
+  if (existsSync(join(projectPath, 'biome.json')) || existsSync(join(projectPath, 'biome.jsonc'))) {
+    return 'biome';
+  }
+
+  // Check for eslint
+  const eslintConfigs = [
+    'eslint.config.js', 'eslint.config.mjs', 'eslint.config.ts',
+    '.eslintrc.js', '.eslintrc.json', '.eslintrc.yml', '.eslintrc',
+  ];
+  if (eslintConfigs.some((c) => existsSync(join(projectPath, c)))) {
+    return 'eslint';
+  }
+
+  // Check for prettier
+  const prettierConfigs = ['.prettierrc', '.prettierrc.json', '.prettierrc.yml', 'prettier.config.js'];
+  if (prettierConfigs.some((c) => existsSync(join(projectPath, c)))) {
+    return 'prettier';
+  }
+
+  return null;
+}
+
+/** Run the detected linter on a file. Returns lint output or null if not available. */
+export function runLint(filePath: string, projectPath: string): { output: string; fixed: boolean } | null {
+  const linter = detectLinter(projectPath);
+  if (!linter) return null;
+
+  try {
+    switch (linter) {
+      case 'biome': {
+        const output = execFileSync('npx', ['biome', 'check', '--fix', filePath], {
+          cwd: projectPath, encoding: 'utf-8', timeout: 10000,
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        return { output: output.trim(), fixed: true };
+      }
+      case 'eslint': {
+        const output = execFileSync('npx', ['eslint', '--fix', filePath], {
+          cwd: projectPath, encoding: 'utf-8', timeout: 15000,
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        return { output: output.trim(), fixed: true };
+      }
+      case 'prettier': {
+        const output = execFileSync('npx', ['prettier', '--write', filePath], {
+          cwd: projectPath, encoding: 'utf-8', timeout: 10000,
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        return { output: output.trim(), fixed: true };
+      }
+    }
+  } catch (err: any) {
+    // Linter found issues but couldn't auto-fix — return the error output
+    const stderr = err.stderr ?? err.message ?? '';
+    return { output: stderr.slice(0, 500), fixed: false };
+  }
+
+  return null;
+}
+
+/** Create auto-lint hook definitions for PostToolUse on file write tools. */
+export function createAutoLintHooks(projectPath: string): HookDefinition[] {
+  const linter = detectLinter(projectPath);
+  if (!linter) return [];
+
+  const lintCommand = linter === 'biome'
+    ? 'npx biome check --fix'
+    : linter === 'eslint'
+    ? 'npx eslint --fix'
+    : 'npx prettier --write';
+
+  return [
+    {
+      event: 'PostToolUse',
+      matcher: 'file_write|file_edit|multi_edit|batch_edit',
+      type: 'command' as const,
+      command: `${lintCommand} "$BRAINSTORM_FILE_PATH"`,
+      blocking: false,
+      description: `Auto-lint with ${linter} after file writes`,
+    },
+  ];
+}

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,2 +1,3 @@
 export { HookManager } from './manager.js';
 export type { HookDefinition, HookEvent, HookResult, HookType } from './types.js';
+export { detectLinter, runLint, createAutoLintHooks } from './builtin/auto-lint.js';


### PR DESCRIPTION
## Summary

- **detectLinter()**: Checks for biome.json, eslint.config.*, .prettierrc in project
- **runLint()**: Runs detected linter with --fix on a file, returns output
- **createAutoLintHooks()**: Generates PostToolUse HookDefinitions for file write tools
- **Non-blocking**: Lint output reported but doesn't block writes

Wave 3 Intelligence — PR 22 of 47.

## Test plan

- [ ] Build passes across all 15 packages
- [ ] Project with eslint.config.js → detectLinter returns "eslint"
- [ ] createAutoLintHooks generates PostToolUse hook for file_write|file_edit