### PR TITLE
fix: auto-lint hook uses correct $FILE variable

### DIFF
--- a/packages/hooks/src/builtin/auto-lint.ts
+++ b/packages/hooks/src/builtin/auto-lint.ts
@@ -88,7 +88,7 @@ export function createAutoLintHooks(projectPath: string): HookDefinition[] {
       event: 'PostToolUse',
       matcher: 'file_write|file_edit|multi_edit|batch_edit',
       type: 'command' as const,
-      command: `${lintCommand} "$BRAINSTORM_FILE_PATH"`,
+      command: `${lintCommand} "$FILE"`,
       blocking: false,
       description: `Auto-lint with ${linter} after file writes`,
     },


### PR DESCRIPTION
## Summary

Fixes bug found in code review of PR #135: `createAutoLintHooks()` used `$BRAINSTORM_FILE_PATH` which `HookManager.fire()` never expands. Changed to `$FILE` which is the variable the manager actually substitutes (line 71).

## Test plan

- [ ] Build passes
- [ ] Auto-lint hook command now contains `$FILE` instead of `$BRAINSTORM_FILE_PATH`