### PR TITLE
feat: transaction tool calls — atomic multi-file edits (PR 30/47)

### DIFF
--- a/packages/tools/src/builtin/file-write.ts
+++ b/packages/tools/src/builtin/file-write.ts
@@ -54,6 +54,10 @@ export const fileWriteTool = defineTool({
     const { getFileTracker } = await import('../file-tracker.js');
     getFileTracker().recordWrite(safePath);
 
+    // Track in active transaction
+    const { recordTransactionFile } = await import('./transaction.js');
+    recordTransactionFile(safePath);
+
     // Diff preview (non-blocking)
     const { getDiffSummary } = await import('../diff-preview.js');
     const diff = getDiffSummary(safePath);

--- a/packages/tools/src/builtin/transaction.ts
+++ b/packages/tools/src/builtin/transaction.ts
@@ -1,0 +1,108 @@
+import { z } from 'zod';
+import { defineTool } from '../base.js';
+import { mkdirSync, copyFileSync, existsSync, unlinkSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+
+/**
+ * Transaction Tool Calls — atomic multi-file edits.
+ *
+ * Between begin and commit, all file writes are tracked.
+ * On rollback, all changes are reverted using checkpoint snapshots.
+ * On commit, changes are finalized (already written to disk by file tools).
+ *
+ * This uses the existing CheckpointManager for rollback capability.
+ */
+
+let transactionActive = false;
+let transactionFiles: string[] = [];
+
+export function isTransactionActive(): boolean {
+  return transactionActive;
+}
+
+export function getTransactionFiles(): string[] {
+  return [...transactionFiles];
+}
+
+export function recordTransactionFile(path: string): void {
+  if (transactionActive && !transactionFiles.includes(path)) {
+    transactionFiles.push(path);
+  }
+}
+
+export const beginTransactionTool = defineTool({
+  name: 'begin_transaction',
+  description: 'Start an atomic transaction for multi-file edits. All file writes between begin and commit/rollback are tracked. On rollback, all changes revert. Use for coordinated multi-file changes where partial application would break the build.',
+  permission: 'auto',
+  inputSchema: z.object({
+    description: z.string().optional().describe('What this transaction is for'),
+  }),
+  async execute({ description }) {
+    if (transactionActive) {
+      return { error: 'Transaction already active. Commit or rollback first.' };
+    }
+    transactionActive = true;
+    transactionFiles = [];
+    return {
+      success: true,
+      message: `Transaction started.${description ? ` Purpose: ${description}` : ''} All file writes are now tracked. Use commit_transaction to finalize or rollback_transaction to revert.`,
+    };
+  },
+});
+
+export const commitTransactionTool = defineTool({
+  name: 'commit_transaction',
+  description: 'Finalize a transaction. All file writes since begin_transaction are kept. Returns the list of files modified.',
+  permission: 'auto',
+  inputSchema: z.object({}),
+  async execute() {
+    if (!transactionActive) {
+      return { error: 'No active transaction to commit.' };
+    }
+    const files = [...transactionFiles];
+    transactionActive = false;
+    transactionFiles = [];
+    return {
+      success: true,
+      filesCommitted: files,
+      count: files.length,
+    };
+  },
+});
+
+export const rollbackTransactionTool = defineTool({
+  name: 'rollback_transaction',
+  description: 'Rollback a transaction. All file writes since begin_transaction are reverted using checkpoint snapshots. Returns the list of files reverted.',
+  permission: 'confirm',
+  inputSchema: z.object({
+    reason: z.string().optional().describe('Why the rollback is needed'),
+  }),
+  async execute({ reason }) {
+    if (!transactionActive) {
+      return { error: 'No active transaction to rollback.' };
+    }
+
+    const { getCheckpointManager } = await import('../checkpoint.js');
+    const cp = getCheckpointManager();
+    const reverted: string[] = [];
+
+    if (cp) {
+      // Revert files in reverse order (last written first)
+      for (const file of [...transactionFiles].reverse()) {
+        const result = cp.revertLast(file);
+        if (result) reverted.push(result);
+      }
+    }
+
+    transactionActive = false;
+    transactionFiles = [];
+
+    return {
+      success: true,
+      filesReverted: reverted,
+      count: reverted.length,
+      reason,
+    };
+  },
+});

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -9,6 +9,7 @@ export { routingHintTool, getRoutingHint, consumeRoutingHint, resetRoutingHint, 
 export { costEstimateTool } from './builtin/cost-estimate.js';
 export { isParallelSafe, classifyToolBatch, executeWithParallelism } from './parallel.js';
 export { planPreviewTool } from './builtin/plan-preview.js';
+export { beginTransactionTool, commitTransactionTool, rollbackTransactionTool, isTransactionActive, recordTransactionFile } from './builtin/transaction.js';
 export { ToolRegistry, type PermissionCheckFn } from './registry.js';
 export { fileReadTool } from './builtin/file-read.js';
 export { fileWriteTool } from './builtin/file-write.js';
@@ -67,6 +68,7 @@ import { askUserTool } from './builtin/ask-user.js';
 import { routingHintTool } from './builtin/routing-hint.js';
 import { costEstimateTool } from './builtin/cost-estimate.js';
 import { planPreviewTool } from './builtin/plan-preview.js';
+import { beginTransactionTool, commitTransactionTool, rollbackTransactionTool } from './builtin/transaction.js';
 import {
   brStatusTool, brBudgetTool, brLeaderboardTool, brInsightsTool,
   brModelsTool, brMemorySearchTool, brMemoryStoreTool, brHealthTool,
@@ -115,6 +117,10 @@ export function createDefaultToolRegistry(): ToolRegistry {
   registry.register(routingHintTool);
   registry.register(costEstimateTool);
   registry.register(planPreviewTool);
+  // Transactions (3)
+  registry.register(beginTransactionTool);
+  registry.register(commitTransactionTool);
+  registry.register(rollbackTransactionTool);
   // BrainstormRouter intelligence (8) — native REST calls, no MCP needed
   registry.register(brStatusTool);
   registry.register(brBudgetTool);


### PR DESCRIPTION
## Summary

- **begin_transaction**: Starts tracking file writes. Only one active at a time.
- **commit_transaction**: Finalizes — returns list of files modified.
- **rollback_transaction**: Reverts all files via CheckpointManager snapshots (reverse order).
- **file_write integration**: Calls recordTransactionFile() when transaction active.
- **42 tools** total now registered.

Wave 5 — PR 30 of 47.

## Test plan

- [ ] Build passes across all 15 packages
- [ ] begin → write 3 files → rollback → all 3 reverted
- [ ] begin → write 3 files → commit → returns file list
- [ ] Double begin → error