### PR TITLE
docs: architecture guide, tool reference, config guide, per-package READMEs (PR 20/47)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,246 @@
+# Architecture
+
+Brainstorm is a Turborepo monorepo with 15 TypeScript packages. All packages use ESM (`"type": "module"`) with tsup bundling and `.js` import extensions.
+
+## Package Dependency Graph
+
+```
+                    ┌──────────┐
+                    │  shared   │  Types, errors, logger (pino)
+                    └────┬─────┘
+                         │
+              ┌──────────┼──────────┐
+              ▼          ▼          ▼
+         ┌────────┐ ┌────────┐ ┌────────┐
+         │ config │ │   db   │ │  eval  │
+         └───┬────┘ └───┬────┘ └────────┘
+             │          │
+         ┌───┴──────────┤
+         ▼              ▼
+    ┌───────────┐  ┌────────┐
+    │ providers │  │ vault  │
+    └─────┬─────┘  └────────┘
+          │
+     ┌────┴────┐
+     ▼         ▼
+┌────────┐ ┌─────────┐
+│ router │ │ gateway │
+└───┬────┘ └─────────┘
+    │
+    ▼
+┌────────┐   ┌────────┐   ┌────────┐
+│ tools  │──▶│  core  │──▶│  hooks │
+└────────┘   └───┬────┘   └────────┘
+                 │
+      ┌──────────┼──────────┐
+      ▼          ▼          ▼
+ ┌────────┐ ┌──────────┐ ┌────────┐
+ │ agents │ │ workflow │ │  mcp   │
+ └────────┘ └──────────┘ └────────┘
+                 │
+                 ▼
+            ┌────────┐
+            │  cli   │  Entry point
+            └────────┘
+```
+
+## Data Flow
+
+### Chat Request
+
+```
+User prompt
+  → CLI (Commander + Ink TUI)
+    → Core agent loop (streamText, AI SDK v6)
+      → Router (classify task → pick strategy → select model)
+        → Provider (AI Gateway / BrainstormRouter / Ollama)
+          → LLM API
+        ← Response stream (text-delta, tool-call, tool-result)
+      ← Tool execution (permission check → execute → normalize)
+    ← Agent events (text, tool-call, tool-result, compaction-warning)
+  → TUI rendering (streaming text, tool status, progress)
+```
+
+### Routing Decision
+
+```
+User prompt
+  → classifyTask(prompt)
+    → Returns: TaskProfile { complexity, category, needsCode, ... }
+  → Strategy selection (quality-first | cost-first | combined | capability | rule-based)
+    → Strategy scores all available models
+    → CostTracker checks budget
+    → Fallback chain if primary model fails
+  → Returns: { model, strategy, reasoning }
+```
+
+### Tool Execution
+
+```
+Model calls tool
+  → Permission check (auto | confirm | deny)
+    → If confirm: ask user
+  → Pre-validation (syntax check for .ts, .json, .yaml)
+  → Checkpoint snapshot (before file writes)
+  → Execute tool
+  → Post-execution: diff preview, lint check, build state update
+  → Normalize result to { ok, data?, error? }
+  → Record in file tracker + tool health tracker
+```
+
+## Package Details
+
+### `packages/shared`
+
+Foundation types shared across all packages.
+
+**Key exports:**
+- `TaskProfile` — Describes a classified task (complexity, category, tokens)
+- `ModelEntry` — A model with pricing, capabilities, provider info
+- `AgentProfile` — Configuration for a specialized agent
+- `TurnContext` — Per-turn state (model, tools, cost, files, build status)
+- `AgentEvent` — Union type for all events the agent loop yields
+- `formatTurnContext()` — Compact one-liner for context injection
+
+### `packages/config`
+
+Layered configuration with Zod validation.
+
+**Config resolution order:** defaults → `~/.brainstorm/config.toml` (global) → `./brainstorm.toml` (project) → environment variables.
+
+**Key exports:**
+- `loadConfig()` — Merges all config layers
+- `loadProjectContext()` — Parses `BRAINSTORM.md` frontmatter + body
+- `brainstormConfigSchema` — Zod schema for full config validation
+
+### `packages/db`
+
+SQLite persistence with WAL mode. Database lives at `~/.brainstorm/brainstorm.db`.
+
+**Tables:** sessions, messages, cost_records, agent_profiles, workflow_runs, eval_results, session_patterns.
+
+**Key exports:**
+- `getDatabase()` — Singleton database connection with auto-migrations
+- `PatternRepository` — Cross-session learning storage (UPSERT with confidence decay)
+
+### `packages/providers`
+
+Model discovery and AI SDK provider creation.
+
+**Cloud:** BrainstormRouter (357+ models via `api.brainstormrouter.com/v1`), direct Anthropic/OpenAI/Google.
+**Local:** Ollama (`:11434`), LM Studio (`:1234`), llama.cpp (`:8080`) — auto-discovered by probing localhost.
+
+**Key exports:**
+- `ProviderRegistry` — Manages all providers, creates AI SDK language models
+- `discoverLocalModels()` — Probes local endpoints with caching
+
+### `packages/router`
+
+Task classification and model routing.
+
+**Strategies:**
+| Strategy | Description |
+|----------|------------|
+| `quality-first` | Best model for the task (default with paid keys) |
+| `cost-first` | Cheapest viable model |
+| `combined` | Balances quality, cost, and speed |
+| `capability` | Routes by measured eval scores |
+| `rule-based` | Custom rules from config.toml |
+
+**Key exports:**
+- `BrainstormRouter` — Main router with `route(prompt, options)` method
+- `classifyTask()` — Heuristic classifier returning `TaskProfile`
+- `CostTracker` — Per-session and daily cost tracking
+
+### `packages/tools`
+
+42 built-in tools with Zod input schemas and consistent `{ ok, data, error }` output.
+
+**Categories:**
+- Filesystem (8): file_read, file_write, file_edit, multi_edit, batch_edit, list_dir, glob, grep
+- Shell (3): shell, process_spawn, process_kill
+- Git (6): git_status, git_diff, git_log, git_commit, git_branch, git_stash
+- GitHub (2): gh_pr, gh_issue
+- Web (2): web_fetch, web_search
+- Tasks (3): task_create, task_update, task_list
+- Agent (6): undo, scratchpad_write, scratchpad_read, ask_user, set_routing_hint, cost_estimate
+- Planning (1): plan_preview
+- Transactions (3): begin_transaction, commit_transaction, rollback_transaction
+- BrainstormRouter (8): br_status, br_budget, br_leaderboard, br_insights, br_models, br_memory_search, br_memory_store, br_health
+
+**Key systems:**
+- `ToolRegistry` — Registers tools, wraps with permission checks
+- `CheckpointManager` — Snapshots files before writes for undo support
+- `SessionFileTracker` — Tracks all file reads/writes per session
+- `ToolHealthTracker` — Records success/failure per tool, marks unhealthy tools
+
+### `packages/core`
+
+The brain — agent loop, session management, and intelligence features.
+
+**Key exports:**
+- `runAgentLoop()` — Main agent loop using AI SDK v6 `streamText`
+- `SessionManager` — Conversation history and turn tracking
+- `PermissionManager` — Three modes: strict, normal, permissive
+- `compactContext()` — Context window management with scratchpad preservation
+- `BuildStateTracker` — Tracks build/test results, injects warnings
+- `LoopDetector` — Detects repetitive tool call patterns
+- `SessionPatternLearner` — Cross-session learning from tool usage patterns
+- `FileWatcher` — Detects external file changes between turns
+- `ReactionTracker` — Classifies user satisfaction from messages
+
+### `packages/agents`
+
+Agent profiles and the subagent system.
+
+**5 subagent types:** research, code, review, refactor, test — each with filtered tool sets and role-specific prompts. Supports parallel execution via `spawnParallel()`.
+
+### `packages/workflow`
+
+State machine workflow engine with 4 preset workflows and context filtering.
+
+### `packages/hooks`
+
+Lifecycle automation with 10 event types: PreToolUse, PostToolUse, SessionStart, SessionEnd, UserPromptSubmit, PreCompact, Notification, SubagentStart, SubagentStop, PostShell.
+
+Built-in hooks include auto-lint on file writes.
+
+### `packages/mcp`
+
+MCP (Model Context Protocol) client for external tool integration via SSE/HTTP transports.
+
+### `packages/eval`
+
+Capability probes, eval runner, scorer, and scorecard for measuring model performance. Results feed back into the capability routing strategy.
+
+### `packages/gateway`
+
+Typed client for the BrainstormRouter SaaS API. Handles header parsing, cost reconciliation, and retry logic.
+
+### `packages/vault`
+
+Encrypted key storage using AES-256-GCM + Argon2id. Supports 1Password bridge for enterprise environments. Fallback to environment variables.
+
+### `packages/cli`
+
+Commander-based CLI with Ink TUI. Entry point: `packages/cli/src/bin/brainstorm.ts`.
+
+**Commands:** `chat` (default), `run`, `models`, `config`, `budget`, `agent`, `workflow`, `sessions`, `vault`, `eval`.
+
+## Intelligence Features
+
+Brainstorm includes several features that make the agent self-aware:
+
+| Feature | Description |
+|---------|------------|
+| **Turn Context** | Injected between turns: model, tools, cost, files, build status |
+| **File Tracking** | Agent knows every file it has read/written this session |
+| **Tool Health** | Unhealthy tools surfaced in context so agent avoids them |
+| **Build State** | Persistent warning when build is broken |
+| **Loop Detection** | Nudges agent out of repetitive read patterns |
+| **Scratchpad** | Key-value notes that survive context compaction |
+| **Sentiment** | Adapts response style based on detected user tone |
+| **Self-Review** | Optional cheap-model review of writes before finalizing |
+| **Cross-Session Learning** | Learns tool preferences and command timings per project |
+| **Error-Fix Pairs** | Tracks error → fix sequences for future reference |
+| **Speculative Execution** | Tries two approaches in parallel git worktrees |

--- a/docs/brainstormrouter-integration.md
+++ b/docs/brainstormrouter-integration.md
@@ -1,0 +1,108 @@
+# BrainstormRouter Integration
+
+[BrainstormRouter](https://brainstormrouter.com) is the intelligent AI gateway that powers Brainstorm's multi-model routing. It's an OpenAI-compatible API gateway with Thompson sampling across 357+ models from 7 providers.
+
+## How It Works
+
+```
+Brainstorm CLI
+  → BrainstormRouter API (api.brainstormrouter.com/v1)
+    → Provider selection (Anthropic, OpenAI, Google, etc.)
+      → LLM API
+    ← Response with routing metadata headers
+  ← Agent uses response + metadata for self-awareness
+```
+
+Every request to BrainstormRouter includes:
+- **Agent identity** — Who's calling (agent name, session ID)
+- **Task profile** — Classified task metadata (complexity, category)
+- **Routing hints** — Strategy preference, budget constraints
+
+Every response from BrainstormRouter includes custom headers:
+- `x-br-model` — Actual model used
+- `x-br-provider` — Provider that served the request
+- `x-br-cost` — Cost of this request
+- `x-br-latency` — End-to-end latency
+- `x-br-session-cost` — Cumulative session cost
+- `x-br-budget-remaining` — Budget remaining
+
+## Native Intelligence Tools
+
+Brainstorm ships 8 tools that call BrainstormRouter's REST API directly (no MCP needed):
+
+### `br_status`
+Full system check — returns agent identity, budget status, system health, and optimization suggestions.
+
+### `br_budget`
+Current budget status: daily spend, remaining budget, spend rate, and forecast for remaining capacity.
+
+### `br_leaderboard`
+Real performance rankings based on production data: which models are fastest, cheapest, and highest quality for each task type.
+
+### `br_insights`
+Cost optimization recommendations: which models to prefer/avoid, estimated savings from switching strategies.
+
+### `br_models`
+Lists all available models with pricing, capabilities, and provider info. Filterable by provider or capability.
+
+### `br_memory_search`
+Search persistent memory across sessions. Memories stored via `br_memory_store` persist indefinitely.
+
+### `br_memory_store`
+Save facts, decisions, or context that should persist across sessions. The agent can retrieve these later via `br_memory_search`.
+
+### `br_health`
+Quick connectivity test — checks if BrainstormRouter is reachable and authenticated.
+
+## API Endpoints Used
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/v1/chat/completions` | POST | Main inference (OpenAI-compatible) |
+| `/v1/models` | GET | List available models |
+| `/v1/agent/status` | GET | Agent identity and budget |
+| `/v1/agent/memory` | GET/POST | Persistent memory |
+| `/v1/intelligence/leaderboard` | GET | Model rankings |
+| `/v1/intelligence/insights` | GET | Optimization suggestions |
+| `/v1/health` | GET | Health check |
+
+## Authentication
+
+BrainstormRouter uses API keys. Store yours in the vault:
+
+```bash
+storm vault add BRAINSTORM_API_KEY
+```
+
+A free community key is included for zero-setup onboarding (rate-limited, shared budget).
+
+## Error Recovery
+
+BrainstormRouter sends structured recovery hints in error responses:
+
+```json
+{
+  "error": { "message": "Rate limit exceeded", "type": "rate_limit" },
+  "recovery": {
+    "action": "retry",
+    "message": "Rate limited. Retry in 30 seconds.",
+    "wait_ms": 30000,
+    "endpoint": null,
+    "docs_url": "https://docs.brainstormrouter.com/rate-limits"
+  }
+}
+```
+
+Brainstorm parses these hints automatically and shows actionable messages to the user.
+
+## MCP Integration
+
+BrainstormRouter also exposes 64 MCP tools via SSE transport. Brainstorm auto-connects to these on startup if configured:
+
+```toml
+[mcp.brainstormrouter]
+transport = "sse"
+url = "https://api.brainstormrouter.com/mcp/sse"
+```
+
+The native REST tools (8) are preferred over MCP tools for common operations due to lower latency.

--- a/docs/config-guide.md
+++ b/docs/config-guide.md
@@ -1,0 +1,148 @@
+# Configuration Guide
+
+Brainstorm uses layered configuration: defaults → global config → project config → environment variables.
+
+## config.toml
+
+Global: `~/.brainstorm/config.toml`
+Project: `./brainstorm.toml`
+
+Project config overrides global config. Environment variables override both.
+
+### Full Schema
+
+```toml
+[general]
+defaultStrategy = "quality-first"  # quality-first | cost-first | combined | capability | rule-based
+maxSteps = 10                      # Max tool calls per turn
+contextWindow = 128000             # Context window size (tokens)
+compactionThreshold = 0.8          # Compact at this % of context window
+permissionMode = "normal"          # strict | normal | permissive
+outputStyle = "concise"            # concise | detailed | learning | explanatory
+
+[budget]
+dailyLimit = 50.00                 # Daily spend limit (USD)
+sessionLimit = 5.00                # Per-session limit
+warningThreshold = 0.8             # Warn at this % of budget
+
+[providers.brainstormrouter]
+enabled = true
+baseUrl = "https://api.brainstormrouter.com/v1"
+
+[providers.ollama]
+enabled = true
+baseUrl = "http://localhost:11434"
+
+[providers.lmstudio]
+enabled = true
+baseUrl = "http://localhost:1234"
+
+[providers.llamacpp]
+enabled = false
+baseUrl = "http://localhost:8080"
+
+[providers.anthropic]
+enabled = false                    # Direct Anthropic (bypass BrainstormRouter)
+
+[providers.openai]
+enabled = false                    # Direct OpenAI (bypass BrainstormRouter)
+
+[routing]
+preferLocal = false                # Prefer local models when available
+fallbackToCloud = true             # Fall back to cloud if local fails
+
+[[routing.rules]]                  # Rule-based routing
+pattern = "simple question"
+model = "gpt-4.1-mini"
+
+[[routing.rules]]
+pattern = "complex refactor"
+model = "claude-sonnet-4.5"
+
+[hooks]
+auto_lint = false                  # Run linter after file writes
+
+[cost]
+negotiation_threshold = 0.10       # Ask user for model choice above this cost
+
+[quality]
+self_review = false                # Run cheap-model review after writes
+
+[confirmation]
+plan_preview = true                # Show plan for tasks with >3 tool calls
+
+[community]
+share_fixes = false                # Share anonymized error-fix pairs via BR
+```
+
+### Environment Variable Overrides
+
+| Env Var | Config Path | Description |
+|---------|------------|-------------|
+| `BRAINSTORM_API_KEY` | — | BrainstormRouter API key |
+| `BRAINSTORM_STRATEGY` | `general.defaultStrategy` | Override default strategy |
+| `BRAINSTORM_MAX_STEPS` | `general.maxSteps` | Override max tool calls |
+| `BRAINSTORM_BUDGET` | `budget.dailyLimit` | Override daily budget |
+| `BRAINSTORM_PERMISSION_MODE` | `general.permissionMode` | Override permission mode |
+
+## BRAINSTORM.md
+
+Project-level context file, placed at the project root. Similar to CLAUDE.md but for Brainstorm.
+
+### Format
+
+```markdown
+---
+build_command: npm run build
+test_command: npm test
+language: typescript
+framework: next
+lint_command: npx eslint --fix
+---
+
+# Project Name
+
+Project description and conventions for the AI assistant.
+
+## Conventions
+
+- Use Drizzle ORM for database queries
+- All components go in src/components/
+- Tests use vitest
+```
+
+### Frontmatter Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `build_command` | string | Command to build the project |
+| `test_command` | string | Command to run tests |
+| `language` | string | Primary language (typescript, python, etc.) |
+| `framework` | string | Framework in use (next, react, fastapi, etc.) |
+| `lint_command` | string | Linter command for auto-lint hook |
+
+### Hierarchical Loading
+
+BRAINSTORM.md files are loaded hierarchically — a monorepo can have a root BRAINSTORM.md and per-package BRAINSTORM.md files. Child files inherit and override parent settings.
+
+## Database
+
+SQLite database at `~/.brainstorm/brainstorm.db` (WAL mode). Stores:
+- Sessions and conversation messages
+- Cost records per request
+- Agent profiles
+- Workflow run history
+- Eval results and scorecards
+- Session patterns (cross-session learning)
+
+## Vault
+
+API keys can be stored in the encrypted vault:
+
+```bash
+storm vault add BRAINSTORM_API_KEY       # Add a key
+storm vault list                         # List stored keys
+storm vault status                       # Check vault health
+```
+
+Keys are resolved in order: vault → 1Password → environment variables.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,172 @@
+# Tools Reference
+
+Brainstorm ships with 42 built-in tools. All tools use Zod schemas for input validation and return a normalized `{ ok, data?, error? }` format.
+
+## Tool Categories
+
+### Filesystem (8)
+
+| Tool | Description | Permission |
+|------|------------|------------|
+| `file_read` | Read a file by path | auto |
+| `file_write` | Write content to a file (creates or overwrites) | confirm |
+| `file_edit` | Find-and-replace in a file | confirm |
+| `multi_edit` | Multiple find-and-replace edits in one file | confirm |
+| `batch_edit` | Edits across multiple files in one call | confirm |
+| `list_dir` | List directory contents | auto |
+| `glob` | Find files by glob pattern | auto |
+| `grep` | Search file contents by regex | auto |
+
+### Shell (3)
+
+| Tool | Description | Permission |
+|------|------------|------------|
+| `shell` | Execute a shell command (foreground or background) | confirm |
+| `process_spawn` | Spawn a long-running background process | confirm |
+| `process_kill` | Kill a background process by PID | confirm |
+
+### Git (6)
+
+| Tool | Description | Permission |
+|------|------------|------------|
+| `git_status` | Show working tree status | auto |
+| `git_diff` | Show diffs (staged, unstaged, or between refs) | auto |
+| `git_log` | Show commit history | auto |
+| `git_commit` | Create a commit with message | confirm |
+| `git_branch` | Create, switch, or delete branches | confirm |
+| `git_stash` | Stash or restore changes | confirm |
+
+### GitHub (2)
+
+| Tool | Description | Permission |
+|------|------------|------------|
+| `gh_pr` | Create, list, or view pull requests | confirm |
+| `gh_issue` | Create, list, or view issues | confirm |
+
+### Web (2)
+
+| Tool | Description | Permission |
+|------|------------|------------|
+| `web_fetch` | Fetch a URL and return content | confirm |
+| `web_search` | Search the web via DuckDuckGo | confirm |
+
+### Tasks (3)
+
+| Tool | Description | Permission |
+|------|------------|------------|
+| `task_create` | Create a progress-tracking task | auto |
+| `task_update` | Update task status (pending/in_progress/done/failed) | auto |
+| `task_list` | List current tasks | auto |
+
+### Agent (6)
+
+| Tool | Description | Permission |
+|------|------------|------------|
+| `undo_last_write` | Revert the last file write using checkpoint | confirm |
+| `scratchpad_write` | Save a compaction-resistant note | auto |
+| `scratchpad_read` | Read scratchpad entries | auto |
+| `ask_user` | Pause and ask the user a question | auto |
+| `set_routing_hint` | Hint the router for next turn (cheap/quality/fast) | auto |
+| `cost_estimate` | Show estimated costs across model tiers | auto |
+
+### Planning (1)
+
+| Tool | Description | Permission |
+|------|------------|------------|
+| `plan_preview` | Show a multi-step plan for user approval | auto |
+
+### Transactions (3)
+
+| Tool | Description | Permission |
+|------|------------|------------|
+| `begin_transaction` | Start an atomic multi-file edit session | auto |
+| `commit_transaction` | Finalize all tracked writes | auto |
+| `rollback_transaction` | Revert all writes since begin | confirm |
+
+### BrainstormRouter Intelligence (8)
+
+| Tool | Description | Permission |
+|------|------------|------------|
+| `br_status` | Full system check (identity, budget, health) | auto |
+| `br_budget` | Budget status and spend forecast | auto |
+| `br_leaderboard` | Real model performance rankings | auto |
+| `br_insights` | Cost optimization recommendations | auto |
+| `br_models` | Available models with pricing | auto |
+| `br_memory_search` | Search persistent memory across sessions | auto |
+| `br_memory_store` | Save facts that persist across sessions | auto |
+| `br_health` | Quick connectivity test | auto |
+
+## Permission Levels
+
+- **auto** — Runs without asking. Used for read-only tools and agent-internal state.
+- **confirm** — Asks the user before executing. Used for writes, shell commands, and destructive operations.
+- **deny** — Blocked. Can be set per-tool in config.
+
+Permission mode is set globally: `strict` (confirm everything), `normal` (default), `permissive` (auto-approve most).
+
+## Adding Custom Tools
+
+1. Create a new file in `packages/tools/src/builtin/`:
+
+```typescript
+import { z } from 'zod';
+import { defineTool } from '../base.js';
+
+export const myTool = defineTool({
+  name: 'my_tool',
+  description: 'What this tool does',
+  permission: 'confirm',  // 'auto' | 'confirm' | 'deny'
+  inputSchema: z.object({
+    param: z.string().describe('Parameter description'),
+  }),
+  async execute({ param }) {
+    // Implementation
+    return { ok: true, data: { result: 'done' } };
+  },
+});
+```
+
+2. Register in `packages/tools/src/index.ts`:
+
+```typescript
+import { myTool } from './builtin/my-tool.js';
+
+// In createDefaultToolRegistry():
+registry.register(myTool);
+```
+
+3. Export the tool:
+
+```typescript
+export { myTool } from './builtin/my-tool.js';
+```
+
+## Checkpoint System
+
+Every file write/edit automatically snapshots the original file before modifying it. The `undo_last_write` tool can revert to the last checkpoint for any file.
+
+Checkpoints are session-scoped and stored in a temp directory. They are cleaned up when the session ends.
+
+## Transaction System
+
+For atomic multi-file changes:
+
+```
+begin_transaction → file_write × N → commit_transaction
+                                    → rollback_transaction (reverts all)
+```
+
+Between `begin` and `commit/rollback`, all file writes are tracked. On rollback, files are reverted in reverse order using the checkpoint system.
+
+## Pre-Validation
+
+Before writing `.ts`, `.tsx`, `.json`, or `.yaml` files, Brainstorm runs a quick syntax check:
+- **TypeScript/JavaScript:** Bracket/brace balance check
+- **JSON:** `JSON.parse()` validation
+- **YAML:** Basic structural validation
+
+Pre-validation warnings are non-blocking — the write still happens, but the agent sees the warning.
+
+## Tool Health Tracking
+
+Every tool call's success/failure is recorded. A tool is marked "unhealthy" when it has 2+ failures and >50% failure rate. Unhealthy tools are surfaced in the turn context so the agent avoids retrying broken tools.

--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -1,0 +1,21 @@
+# @brainstorm/agents
+
+Agent profiles, natural language parser, and the subagent system.
+
+## Key Exports
+
+- `AgentProfileManager` — Load, create, and manage agent profiles
+- `parseAgentRequest()` — NL parser for agent-related commands
+- `spawnSubagent()` / `spawnParallel()` — Spawn specialized subagents
+
+## Subagent Types
+
+| Type | Tools | Purpose |
+|------|-------|---------|
+| research | file_read, glob, grep, web_fetch | Read-only exploration |
+| code | file_read, file_write, file_edit, shell | Implementation |
+| review | file_read, grep, git_diff | Code review |
+| refactor | file_read, file_write, file_edit, glob | Refactoring |
+| test | file_read, file_write, shell | Test writing |
+
+Subagents run with budget isolation and can execute in parallel.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,32 @@
+# @brainstorm/cli
+
+Commander-based CLI with Ink TUI. Entry point: `src/bin/brainstorm.ts`. Alias: `storm`.
+
+## Commands
+
+| Command | Description |
+|---------|------------|
+| `storm chat` | Interactive chat (default) |
+| `storm run "prompt"` | Non-interactive single prompt |
+| `storm models` | List available models |
+| `storm config` | Show current configuration |
+| `storm budget` | Show cost tracking |
+| `storm agent` | Manage agent profiles |
+| `storm workflow` | Run preset workflows |
+| `storm sessions` | List past sessions |
+| `storm vault` | Manage API keys |
+| `storm eval` | Run capability evaluations |
+
+## Flags
+
+| Flag | Description |
+|------|------------|
+| `--tools` | Enable tool calling |
+| `--lfg` | Auto-approve all tool calls |
+| `--model <id>` | Override model selection |
+| `--strategy <name>` | Override routing strategy |
+| `--simple` | Plain text mode (no TUI) |
+
+## Built-in Slash Commands
+
+`/model`, `/fast`, `/compact`, `/clear`, `/help`, `/dream`, `/vault`

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,0 +1,17 @@
+# @brainstorm/config
+
+Layered configuration with Zod validation. Loads and merges config from defaults, global TOML, project TOML, and environment variables.
+
+## Key Exports
+
+- `loadConfig()` — Load and merge all config layers
+- `loadProjectContext()` — Parse BRAINSTORM.md frontmatter + body
+- `brainstormConfigSchema` — Zod schema for full config validation
+- `loadStormFile()` — Load a BRAINSTORM.md file
+- `loadHierarchicalStormFiles()` — Load parent + child BRAINSTORM.md files
+
+## Config Resolution
+
+```
+defaults → ~/.brainstorm/config.toml → ./brainstorm.toml → env vars
+```

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,31 @@
+# @brainstorm/core
+
+The brain of Brainstorm — agent loop, session management, and intelligence features.
+
+## Key Exports
+
+- `runAgentLoop()` — Main loop using AI SDK v6 `streamText` with tool calling
+- `SessionManager` — Conversation history and turn tracking
+- `PermissionManager` — Permission modes (strict, normal, permissive)
+- `compactContext()` — Context window management with scratchpad preservation
+- `buildSystemPrompt()` — Construct system prompt with project context and tool awareness
+
+## Intelligence
+
+- `BuildStateTracker` — Tracks build/test results, injects persistent warnings
+- `LoopDetector` — Detects repetitive tool call patterns (4+ reads, duplicates)
+- `SessionPatternLearner` — Cross-session learning from tool usage patterns
+- `ErrorFixTracker` — Records error → fix sequences for future reference
+- `FileWatcher` — Detects external file changes via `fs.watch`
+- `ReactionTracker` — Classifies user satisfaction signals
+- `detectTone()` — Heuristic user sentiment detection
+
+## Usage
+
+```typescript
+import { runAgentLoop } from '@brainstorm/core';
+
+for await (const event of runAgentLoop(options)) {
+  // Handle: text, tool-call, tool-result, compaction-warning, loop-warning
+}
+```

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -1,0 +1,22 @@
+# @brainstorm/db
+
+SQLite persistence layer using better-sqlite3 with WAL mode. Database at `~/.brainstorm/brainstorm.db`.
+
+## Key Exports
+
+- `getDatabase()` — Singleton database connection with auto-migrations
+- `PatternRepository` — Cross-session learning storage with UPSERT and confidence decay
+
+## Tables
+
+sessions, messages, cost_records, agent_profiles, workflow_runs, eval_results, session_patterns
+
+## Usage
+
+```typescript
+import { getDatabase, PatternRepository } from '@brainstorm/db';
+
+const db = getDatabase();
+const patterns = new PatternRepository(db);
+patterns.record('/path', 'tool_success', 'file_edit', 'jsx files', 0.8);
+```

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -1,0 +1,15 @@
+# @brainstorm/eval
+
+Capability evaluation system — probes, runner, scorer, and scorecard.
+
+## Key Exports
+
+- `EvalRunner` — Execute capability probes against models
+- `Scorer` — Score model responses against rubrics
+- `Scorecard` — Aggregate eval results into a capability profile
+
+## Purpose
+
+Eval results feed into the `capability` routing strategy, enabling data-driven model selection based on measured performance rather than assumptions.
+
+Results are stored as JSONL in `~/.brainstorm/evals/` and in the SQLite database.

--- a/packages/gateway/README.md
+++ b/packages/gateway/README.md
@@ -1,0 +1,17 @@
+# @brainstorm/gateway
+
+Typed client for the BrainstormRouter SaaS API.
+
+## Key Exports
+
+- `GatewayClient` — Typed API client for all BrainstormRouter endpoints
+- `parseGatewayHeaders()` — Extract routing metadata from response headers
+
+## Headers Parsed
+
+- `x-br-model` — Actual model used
+- `x-br-provider` — Provider that served the request
+- `x-br-cost` — Cost of this request
+- `x-br-latency` — End-to-end latency
+- `x-br-session-cost` — Cumulative session cost
+- `x-br-budget-remaining` — Budget remaining

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -1,0 +1,26 @@
+# @brainstorm/hooks
+
+Lifecycle hook system for automation. Hooks fire on events and can run shell commands with variable expansion.
+
+## Key Exports
+
+- `HookManager` — Register and fire hooks
+- `createAutoLintHooks()` — Built-in auto-lint hook for file writes
+
+## Events
+
+PreToolUse, PostToolUse, SessionStart, SessionEnd, UserPromptSubmit, PreCompact, Notification, SubagentStart, SubagentStop, PostShell
+
+## Variable Expansion
+
+- `$FILE` — The file path being operated on
+- `$TOOL` — The tool name being called
+
+## Usage
+
+```typescript
+import { HookManager } from '@brainstorm/hooks';
+
+const hooks = new HookManager();
+hooks.register('PostToolUse', { command: 'eslint --fix $FILE', match: 'file_write' });
+```

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,20 @@
+# @brainstorm/mcp
+
+MCP (Model Context Protocol) client for external tool integration.
+
+## Key Exports
+
+- `MCPClient` — Connect to MCP servers via SSE or HTTP transport
+- Auto-connects to BrainstormRouter's 64 MCP tools on startup (if configured)
+
+## Configuration
+
+```toml
+[mcp.brainstormrouter]
+transport = "sse"
+url = "https://api.brainstormrouter.com/mcp/sse"
+
+[mcp.custom]
+transport = "http"
+url = "http://localhost:3001/mcp"
+```

--- a/packages/providers/README.md
+++ b/packages/providers/README.md
@@ -1,0 +1,22 @@
+# @brainstorm/providers
+
+AI provider discovery and AI SDK language model creation.
+
+## Key Exports
+
+- `ProviderRegistry` — Manages all providers, creates AI SDK language models
+- `discoverLocalModels()` — Auto-discover Ollama, LM Studio, llama.cpp
+
+## Supported Providers
+
+**Cloud:** BrainstormRouter (357+ models), Anthropic, OpenAI, Google, DeepSeek, xAI, Mistral
+**Local:** Ollama (`:11434`), LM Studio (`:1234`), llama.cpp (`:8080`)
+
+## Usage
+
+```typescript
+import { ProviderRegistry } from '@brainstorm/providers';
+
+const registry = new ProviderRegistry(config);
+const model = registry.createLanguageModel('claude-sonnet-4.5');
+```

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -1,0 +1,28 @@
+# @brainstorm/router
+
+Task classification and intelligent model routing with 5 strategies.
+
+## Key Exports
+
+- `BrainstormRouter` — Main router: `route(prompt, options)` → model selection
+- `classifyTask()` — Heuristic task classifier returning `TaskProfile`
+- `CostTracker` — Per-session and daily cost tracking with budget enforcement
+
+## Strategies
+
+| Strategy | Use Case |
+|----------|---------|
+| `quality-first` | Best model for the task (default) |
+| `cost-first` | Cheapest viable model |
+| `combined` | Balance quality, cost, speed |
+| `capability` | Route by measured eval scores |
+| `rule-based` | Custom rules from config |
+
+## Usage
+
+```typescript
+import { BrainstormRouter, classifyTask } from '@brainstorm/router';
+
+const router = new BrainstormRouter(config, providers);
+const { model, strategy } = await router.route('Refactor this component');
+```

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,0 +1,20 @@
+# @brainstorm/shared
+
+Foundation types, errors, and logging shared across all Brainstorm packages.
+
+## Key Exports
+
+- `TaskProfile` — Classified task descriptor (complexity, category, tokens)
+- `ModelEntry` — Model with pricing, capabilities, provider
+- `AgentProfile` — Agent configuration (role, tools, prompt)
+- `TurnContext` — Per-turn state for agent self-awareness
+- `AgentEvent` — Union type for all agent loop events
+- `formatTurnContext()` — Compact one-liner for context injection
+- `BrainstormError` — Typed error hierarchy
+- `logger` — Pino logger instance
+
+## Usage
+
+```typescript
+import { type TaskProfile, type ModelEntry, formatTurnContext } from '@brainstorm/shared';
+```

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -1,0 +1,36 @@
+# @brainstorm/tools
+
+42 built-in tools with Zod input schemas, permission levels, and consistent `{ ok, data, error }` output.
+
+## Key Exports
+
+- `createDefaultToolRegistry()` — Register all 42 built-in tools
+- `defineTool()` — Define a new tool with schema and execute function
+- `ToolRegistry` — Tool registration and permission-wrapped AI SDK conversion
+- `CheckpointManager` — File snapshots for undo support
+- `SessionFileTracker` — Track file reads/writes per session
+- `ToolHealthTracker` — Track tool success/failure rates
+
+## Tool Categories
+
+- Filesystem (8), Shell (3), Git (6), GitHub (2), Web (2), Tasks (3)
+- Agent (6), Planning (1), Transactions (3), BrainstormRouter (8)
+
+See [docs/tools.md](../../docs/tools.md) for full reference.
+
+## Adding a Tool
+
+```typescript
+import { z } from 'zod';
+import { defineTool } from '../base.js';
+
+export const myTool = defineTool({
+  name: 'my_tool',
+  description: 'What this tool does',
+  permission: 'confirm',
+  inputSchema: z.object({ param: z.string() }),
+  async execute({ param }) {
+    return { ok: true, data: { result: 'done' } };
+  },
+});
+```

--- a/packages/vault/README.md
+++ b/packages/vault/README.md
@@ -1,0 +1,18 @@
+# @brainstorm/vault
+
+Encrypted API key storage with AES-256-GCM + Argon2id key derivation.
+
+## Key Exports
+
+- `VaultStore` — Encrypted CRUD for API keys
+- `KeyResolver` — Resolution chain: vault → 1Password → environment variables
+
+## Usage
+
+```bash
+storm vault add BRAINSTORM_API_KEY    # Encrypt and store a key
+storm vault list                       # List stored keys
+storm vault status                     # Health check
+```
+
+Keys are stored in `~/.brainstorm/vault.enc` and encrypted at rest. The vault auto-locks after inactivity.

--- a/packages/workflow/README.md
+++ b/packages/workflow/README.md
@@ -1,0 +1,12 @@
+# @brainstorm/workflow
+
+State machine workflow engine with context filtering and confidence-based escalation.
+
+## Key Exports
+
+- `WorkflowEngine` — Execute multi-step workflows
+- Preset workflows: debug, refactor, feature, review
+
+## Usage
+
+Workflows define a sequence of steps, each with a prompt, tool restrictions, and success criteria. The engine manages state transitions and can escalate to a more capable model when confidence is low.


### PR DESCRIPTION
## Summary
- `docs/architecture.md` — 15-package dependency graph, data flow diagrams, routing system, intelligence features
- `docs/tools.md` — All 42 tools with descriptions, permissions, guide to adding custom tools
- `docs/config-guide.md` — Full config.toml schema, BRAINSTORM.md spec, env var overrides, vault usage
- `docs/brainstormrouter-integration.md` — API endpoints, response headers, error recovery, MCP integration
- 15 per-package README.md files with purpose, key exports, and usage examples

## Test plan
- [x] All 15 packages build successfully
- [x] Documentation is accurate against current codebase
- [x] Links between docs are correct