### PR TITLE
feat: Brainstorm Plugin SDK — community extensibility (PR 47/47)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -345,6 +345,10 @@
       "resolved": "packages/mcp",
       "link": true
     },
+    "node_modules/@brainstorm/plugin-sdk": {
+      "resolved": "packages/plugin-sdk",
+      "link": true
+    },
     "node_modules/@brainstorm/providers": {
       "resolved": "packages/providers",
       "link": true
@@ -4527,6 +4531,18 @@
         "@ai-sdk/mcp": "^1",
         "@brainstorm/shared": "*",
         "@brainstorm/tools": "*"
+      },
+      "devDependencies": {
+        "tsup": "^8",
+        "typescript": "^5.7"
+      }
+    },
+    "packages/plugin-sdk": {
+      "name": "@brainstorm/plugin-sdk",
+      "version": "0.1.0",
+      "dependencies": {
+        "@brainstorm/shared": "*",
+        "zod": "^3"
       },
       "devDependencies": {
         "tsup": "^8",

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -1,0 +1,91 @@
+# @brainstorm/plugin-sdk
+
+SDK for building Brainstorm plugins. Plugins can provide custom tools, lifecycle hooks, and reusable skills.
+
+## Quick Start
+
+```typescript
+import { defineBrainstormPlugin, definePluginTool } from '@brainstorm/plugin-sdk';
+import { z } from 'zod';
+
+export default defineBrainstormPlugin({
+  name: 'my-plugin',
+  description: 'My custom Brainstorm plugin',
+  version: '1.0.0',
+
+  tools: [
+    definePluginTool({
+      name: 'my_tool',
+      description: 'Does something useful',
+      permission: 'confirm',
+      inputSchema: z.object({
+        input: z.string().describe('The input'),
+      }),
+      async execute({ input }) {
+        return { ok: true, data: { result: input.toUpperCase() } };
+      },
+    }),
+  ],
+
+  hooks: [
+    {
+      event: 'SessionStart',
+      command: 'echo "Plugin loaded!"',
+      description: 'Announce plugin load',
+    },
+  ],
+
+  skills: [
+    {
+      name: 'review',
+      description: 'Code review skill',
+      tools: ['file_read', 'grep', 'glob'],
+      modelPreference: 'quality',
+      content: 'Review the code for bugs and security issues.',
+    },
+  ],
+});
+```
+
+## Installation
+
+Plugins are installed to `~/.brainstorm/plugins/` (global) or `.brainstorm/plugins/` (project).
+
+```bash
+# Install a plugin from npm (future)
+brainstorm plugin install my-brainstorm-plugin
+
+# Or manually
+cd ~/.brainstorm/plugins
+git clone https://github.com/user/my-plugin.git
+cd my-plugin && npm install && npm run build
+```
+
+## Plugin Structure
+
+```
+my-plugin/
+├── package.json       (name, version, main)
+├── src/
+│   └── index.ts       (export default defineBrainstormPlugin({...}))
+├── tsup.config.ts
+└── dist/
+    └── index.js       (built entry point)
+```
+
+## API
+
+### `defineBrainstormPlugin(config)`
+Define a plugin with tools, hooks, and skills. Validates the configuration.
+
+### `definePluginTool(config)`
+Define a tool with Zod input schema and execute function.
+
+### `definePluginHook(config)`
+Define a lifecycle hook with event, command, and optional matcher.
+
+### `definePluginSkill(config)`
+Define a reusable skill with instructions, tool restrictions, and model preferences.
+
+### `discoverPlugins(projectPath)`
+Discover and load all installed plugins from global and project directories.

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@brainstorm/plugin-sdk",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@brainstorm/shared": "*",
+    "zod": "^3"
+  },
+  "devDependencies": {
+    "tsup": "^8",
+    "typescript": "^5.7"
+  }
+}

--- a/packages/plugin-sdk/src/define.ts
+++ b/packages/plugin-sdk/src/define.ts
@@ -1,0 +1,113 @@
+import { z } from 'zod';
+import type { ToolPermission } from '@brainstorm/shared';
+import type { BrainstormPlugin, PluginToolDef, PluginHookDef, PluginSkillDef } from './types.js';
+
+/**
+ * Define a Brainstorm plugin.
+ *
+ * @example
+ * ```typescript
+ * import { defineBrainstormPlugin, definePluginTool } from '@brainstorm/plugin-sdk';
+ * import { z } from 'zod';
+ *
+ * export default defineBrainstormPlugin({
+ *   name: 'docker',
+ *   description: 'Docker integration for Brainstorm',
+ *   version: '0.1.0',
+ *   tools: [
+ *     definePluginTool({
+ *       name: 'docker_build',
+ *       description: 'Build a Docker image',
+ *       permission: 'confirm',
+ *       inputSchema: z.object({
+ *         tag: z.string().describe('Image tag'),
+ *         dockerfile: z.string().optional().describe('Path to Dockerfile'),
+ *       }),
+ *       async execute({ tag, dockerfile }) {
+ *         // Implementation...
+ *         return { ok: true, data: { tag } };
+ *       },
+ *     }),
+ *   ],
+ *   hooks: [
+ *     {
+ *       event: 'SessionStart',
+ *       command: 'docker info > /dev/null 2>&1 || echo "Docker daemon not running"',
+ *       description: 'Check Docker daemon on session start',
+ *     },
+ *   ],
+ * });
+ * ```
+ */
+export function defineBrainstormPlugin(config: BrainstormPlugin): BrainstormPlugin {
+  validatePlugin(config);
+  return config;
+}
+
+/**
+ * Define a plugin tool with type-safe input schema.
+ */
+export function definePluginTool<T extends z.ZodObject<any>>(config: {
+  name: string;
+  description: string;
+  permission: ToolPermission;
+  inputSchema: T;
+  execute: (input: z.infer<T>) => Promise<unknown>;
+}): PluginToolDef<T> {
+  return config;
+}
+
+/**
+ * Define a plugin hook.
+ */
+export function definePluginHook(config: PluginHookDef): PluginHookDef {
+  return config;
+}
+
+/**
+ * Define a plugin skill.
+ */
+export function definePluginSkill(config: PluginSkillDef): PluginSkillDef {
+  return config;
+}
+
+/**
+ * Validate a plugin definition for common errors.
+ */
+function validatePlugin(plugin: BrainstormPlugin): void {
+  if (!plugin.name || !/^[a-z][a-z0-9-]*$/.test(plugin.name)) {
+    throw new Error(
+      `Plugin name "${plugin.name}" is invalid. Must be lowercase, start with a letter, and contain only letters, numbers, and hyphens.`
+    );
+  }
+
+  if (!plugin.description) {
+    throw new Error(`Plugin "${plugin.name}" is missing a description.`);
+  }
+
+  if (!plugin.version || !/^\d+\.\d+\.\d+/.test(plugin.version)) {
+    throw new Error(`Plugin "${plugin.name}" has invalid version "${plugin.version}". Use semver (e.g., 1.0.0).`);
+  }
+
+  // Validate tool names are unique
+  if (plugin.tools) {
+    const names = new Set<string>();
+    for (const tool of plugin.tools) {
+      if (names.has(tool.name)) {
+        throw new Error(`Plugin "${plugin.name}" has duplicate tool name "${tool.name}".`);
+      }
+      names.add(tool.name);
+    }
+  }
+
+  // Validate skill names are unique
+  if (plugin.skills) {
+    const names = new Set<string>();
+    for (const skill of plugin.skills) {
+      if (names.has(skill.name)) {
+        throw new Error(`Plugin "${plugin.name}" has duplicate skill name "${skill.name}".`);
+      }
+      names.add(skill.name);
+    }
+  }
+}

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -1,0 +1,15 @@
+// Plugin definition helpers
+export { defineBrainstormPlugin, definePluginTool, definePluginHook, definePluginSkill } from './define.js';
+
+// Plugin loader
+export { discoverPlugins, getGlobalPluginsDir, getProjectPluginsDir, type LoadedPlugin } from './loader.js';
+
+// Types
+export type {
+  BrainstormPlugin,
+  PluginToolDef,
+  PluginHookDef,
+  PluginHookEvent,
+  PluginSkillDef,
+  PluginManifest,
+} from './types.js';

--- a/packages/plugin-sdk/src/loader.ts
+++ b/packages/plugin-sdk/src/loader.ts
@@ -1,0 +1,108 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { pathToFileURL } from 'node:url';
+import type { BrainstormPlugin, PluginManifest } from './types.js';
+
+/**
+ * Discover and load installed plugins.
+ *
+ * Plugins are discovered from:
+ * 1. ~/.brainstorm/plugins/ — user-installed plugins
+ * 2. .brainstorm/plugins/ — project-local plugins
+ */
+export async function discoverPlugins(projectPath: string): Promise<LoadedPlugin[]> {
+  const plugins: LoadedPlugin[] = [];
+
+  // 1. Global plugins
+  const globalDir = join(homedir(), '.brainstorm', 'plugins');
+  plugins.push(...(await loadPluginsFromDir(globalDir, 'global')));
+
+  // 2. Project plugins
+  const projectDir = join(projectPath, '.brainstorm', 'plugins');
+  plugins.push(...(await loadPluginsFromDir(projectDir, 'project')));
+
+  return plugins;
+}
+
+export interface LoadedPlugin {
+  plugin: BrainstormPlugin;
+  source: 'global' | 'project';
+  path: string;
+}
+
+async function loadPluginsFromDir(dir: string, source: 'global' | 'project'): Promise<LoadedPlugin[]> {
+  if (!existsSync(dir)) return [];
+
+  const plugins: LoadedPlugin[] = [];
+  const entries = readdirSync(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+
+    const pluginDir = join(dir, entry.name);
+    try {
+      const plugin = await loadPlugin(pluginDir);
+      if (plugin) {
+        plugins.push({ plugin, source, path: pluginDir });
+      }
+    } catch (err: any) {
+      // Log but don't fail — bad plugins shouldn't crash the CLI
+      console.error(`Failed to load plugin from ${pluginDir}: ${err.message}`);
+    }
+  }
+
+  return plugins;
+}
+
+/**
+ * Load a single plugin from a directory.
+ *
+ * Expects either:
+ * - A package.json with a "main" field pointing to the entry
+ * - A dist/index.js as default entry
+ */
+async function loadPlugin(pluginDir: string): Promise<BrainstormPlugin | null> {
+  // Read manifest
+  const manifestPath = join(pluginDir, 'package.json');
+  if (!existsSync(manifestPath)) return null;
+
+  const manifest: PluginManifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+  const entryPoint = manifest.main ?? './dist/index.js';
+  const entryPath = join(pluginDir, entryPoint);
+
+  if (!existsSync(entryPath)) {
+    throw new Error(`Plugin entry point not found: ${entryPath}`);
+  }
+
+  // Dynamic import the plugin
+  const entryUrl = pathToFileURL(entryPath).href;
+  const mod = await import(entryUrl);
+  const plugin: BrainstormPlugin = mod.default ?? mod;
+
+  // Validate required fields
+  if (!plugin.name || !plugin.version) {
+    throw new Error(`Plugin at ${pluginDir} is missing required fields (name, version).`);
+  }
+
+  // Run onLoad if present
+  if (plugin.onLoad) {
+    await plugin.onLoad();
+  }
+
+  return plugin;
+}
+
+/**
+ * Get the global plugins directory path.
+ */
+export function getGlobalPluginsDir(): string {
+  return join(homedir(), '.brainstorm', 'plugins');
+}
+
+/**
+ * Get the project plugins directory path.
+ */
+export function getProjectPluginsDir(projectPath: string): string {
+  return join(projectPath, '.brainstorm', 'plugins');
+}

--- a/packages/plugin-sdk/src/types.ts
+++ b/packages/plugin-sdk/src/types.ts
@@ -1,0 +1,95 @@
+import type { z } from 'zod';
+import type { ToolPermission } from '@brainstorm/shared';
+
+/**
+ * Plugin tool definition — same shape as Brainstorm's built-in tools.
+ */
+export interface PluginToolDef<T extends z.ZodObject<any> = z.ZodObject<any>> {
+  name: string;
+  description: string;
+  permission: ToolPermission;
+  inputSchema: T;
+  execute: (input: z.infer<T>) => Promise<unknown>;
+}
+
+/**
+ * Plugin hook definition — lifecycle event handlers.
+ */
+export interface PluginHookDef {
+  event: PluginHookEvent;
+  /** Optional: only fire for specific tool names (regex pattern). */
+  matcher?: string;
+  /** Shell command to run. Use $FILE and $TOOL for variable expansion. */
+  command: string;
+  /** If true, a failing hook blocks the operation (PreToolUse only). */
+  blocking?: boolean;
+  /** Human-readable description. */
+  description?: string;
+}
+
+export type PluginHookEvent =
+  | 'PreToolUse'
+  | 'PostToolUse'
+  | 'SessionStart'
+  | 'SessionEnd'
+  | 'Stop'
+  | 'PreCompact'
+  | 'PreCommit'
+  | 'SubagentStart'
+  | 'SubagentStop';
+
+/**
+ * Plugin skill definition — reusable instruction bundles.
+ */
+export interface PluginSkillDef {
+  name: string;
+  description: string;
+  /** System prompt override for this skill. */
+  systemPrompt?: string;
+  /** Restrict which tools this skill can use. */
+  tools?: string[];
+  /** Routing preference when this skill is active. */
+  modelPreference?: 'cheap' | 'quality' | 'fast' | 'auto';
+  /** Max agentic steps for this skill. */
+  maxSteps?: number;
+  /** Content/instructions for the skill (markdown). */
+  content: string;
+}
+
+/**
+ * Full plugin definition — the main export of a Brainstorm plugin.
+ */
+export interface BrainstormPlugin {
+  /** Unique plugin name (lowercase, hyphens allowed). */
+  name: string;
+  /** Human-readable description. */
+  description: string;
+  /** Plugin version (semver). */
+  version: string;
+  /** Tools provided by this plugin. */
+  tools?: PluginToolDef[];
+  /** Lifecycle hooks provided by this plugin. */
+  hooks?: PluginHookDef[];
+  /** Skills (reusable instruction bundles) provided by this plugin. */
+  skills?: PluginSkillDef[];
+  /** Called when the plugin is loaded. Use for setup/validation. */
+  onLoad?: () => Promise<void> | void;
+  /** Called when the plugin is unloaded. Use for cleanup. */
+  onUnload?: () => Promise<void> | void;
+}
+
+/**
+ * Plugin manifest — metadata for plugin discovery.
+ */
+export interface PluginManifest {
+  name: string;
+  description: string;
+  version: string;
+  author?: string;
+  license?: string;
+  homepage?: string;
+  /** Main entry point (default: ./dist/index.js). */
+  main?: string;
+  /** Minimum Brainstorm CLI version required. */
+  brainstormVersion?: string;
+}

--- a/packages/plugin-sdk/tsconfig.json
+++ b/packages/plugin-sdk/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/plugin-sdk/tsup.config.ts
+++ b/packages/plugin-sdk/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+});


### PR DESCRIPTION
## Summary
- New `@brainstorm/plugin-sdk` package (16th package in the monorepo)
- `defineBrainstormPlugin()` — type-safe plugin definition with name/version/description validation
- `definePluginTool()` — custom tools with Zod schemas matching Brainstorm's built-in tool pattern
- `definePluginHook()` — lifecycle hooks (all 9 event types)
- `definePluginSkill()` — reusable instruction bundles with tool restrictions and model preferences
- `discoverPlugins()` — auto-load from `~/.brainstorm/plugins/` (global) and `.brainstorm/plugins/` (project)
- Plugin validation: name format, semver version, unique tool/skill names

## Test plan
- [x] All 16 packages build successfully (14 via CLI filter + plugin-sdk + eval)
- [x] Plugin SDK builds and exports types correctly
- [x] Package follows monorepo conventions (ESM, tsup, .js imports)