### PR TITLE
feat: repository map — code knowledge graph (PR 21/47)

### DIFF
--- a/packages/core/src/agent/repo-map.ts
+++ b/packages/core/src/agent/repo-map.ts
@@ -1,0 +1,256 @@
+/**
+ * Repository Map — lightweight code knowledge graph.
+ *
+ * Parses project files using regex to extract exports, imports, and symbols.
+ * Builds a dependency graph and ranks files by connectivity (simplified PageRank).
+ * Injects the top files into the system prompt instead of raw file listings,
+ * dramatically reducing token usage.
+ *
+ * Uses regex parsing (no native addons). For deeper AST analysis,
+ * tree-sitter can be added as an optional dependency in the future.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
+import { join, relative, extname, basename } from 'node:path';
+
+export interface RepoMapEntry {
+  file: string;
+  exports: string[];
+  imports: string[];
+  symbols: string[];
+  lineCount: number;
+}
+
+export interface RepoMap {
+  entries: RepoMapEntry[];
+  edges: Array<{ from: string; to: string }>;
+  topFiles: string[];
+  totalFiles: number;
+  generated: number;
+}
+
+/**
+ * Build a repository map for the given project.
+ *
+ * @param projectPath - Root directory of the project
+ * @param maxFiles - Maximum number of top files to include (default: 15)
+ */
+export async function buildRepoMap(projectPath: string, maxFiles = 15): Promise<RepoMap> {
+  const files = findSourceFiles(projectPath);
+  const entries: RepoMapEntry[] = [];
+
+  for (const file of files) {
+    try {
+      const content = readFileSync(join(projectPath, file), 'utf-8');
+      const entry = parseFile(file, content);
+      entries.push(entry);
+    } catch {
+      // Skip unreadable files
+    }
+  }
+
+  // Build dependency edges from import statements
+  const edges = buildEdges(entries);
+
+  // Rank files by connectivity
+  const ranked = rankFiles(entries, edges);
+  const topFiles = ranked.slice(0, maxFiles);
+
+  return {
+    entries,
+    edges,
+    topFiles,
+    totalFiles: files.length,
+    generated: Date.now(),
+  };
+}
+
+/**
+ * Format the repo map as a compact context string for system prompt injection.
+ */
+export function repoMapToContext(map: RepoMap): string {
+  if (map.topFiles.length === 0) return '';
+
+  const lines = [`Project structure (${map.topFiles.length} key files of ${map.totalFiles}):`];
+
+  for (const file of map.topFiles) {
+    const entry = map.entries.find((e) => e.file === file);
+    if (!entry) continue;
+
+    const exports = entry.exports.length > 0
+      ? `: exports ${entry.exports.slice(0, 5).join(', ')}${entry.exports.length > 5 ? ` (+${entry.exports.length - 5} more)` : ''}`
+      : '';
+    lines.push(`  ${entry.file}${exports} (${entry.lineCount} lines)`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Find all source files in the project (TypeScript, JavaScript, Python).
+ * Excludes node_modules, dist, .next, .git, etc.
+ */
+function findSourceFiles(projectPath: string): string[] {
+  try {
+    const output = execFileSync('git', ['ls-files', '--cached', '--others', '--exclude-standard'], {
+      cwd: projectPath,
+      encoding: 'utf-8',
+      timeout: 10000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const sourceExtensions = new Set(['.ts', '.tsx', '.js', '.jsx', '.py', '.go', '.rs']);
+    const excludeDirs = ['node_modules', 'dist', '.next', '.git', 'build', 'coverage', '__pycache__'];
+
+    return output
+      .trim()
+      .split('\n')
+      .filter((f) => {
+        if (!f) return false;
+        const ext = extname(f);
+        if (!sourceExtensions.has(ext)) return false;
+        // Exclude declaration files
+        if (f.endsWith('.d.ts')) return false;
+        // Exclude common non-source directories
+        return !excludeDirs.some((d) => f.startsWith(d + '/') || f.includes('/' + d + '/'));
+      });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Parse a source file using regex to extract exports, imports, and symbols.
+ */
+function parseFile(filePath: string, content: string): RepoMapEntry {
+  const exports: string[] = [];
+  const imports: string[] = [];
+  const symbols: string[] = [];
+
+  const ext = extname(filePath);
+
+  if (['.ts', '.tsx', '.js', '.jsx'].includes(ext)) {
+    parseTypeScript(content, exports, imports, symbols);
+  } else if (ext === '.py') {
+    parsePython(content, exports, imports, symbols);
+  }
+
+  return {
+    file: filePath,
+    exports: [...new Set(exports)],
+    imports: [...new Set(imports)],
+    symbols: [...new Set(symbols)],
+    lineCount: content.split('\n').length,
+  };
+}
+
+function parseTypeScript(content: string, exports: string[], imports: string[], symbols: string[]): void {
+  // Export declarations
+  const exportMatches = content.matchAll(
+    /export\s+(?:default\s+)?(?:function|class|const|let|var|type|interface|enum)\s+(\w+)/g,
+  );
+  for (const m of exportMatches) {
+    exports.push(m[1]);
+    symbols.push(m[1]);
+  }
+
+  // Re-exports: export { Foo, Bar } from './module'
+  const reExportMatches = content.matchAll(/export\s*\{([^}]+)\}/g);
+  for (const m of reExportMatches) {
+    const names = m[1].split(',').map((n) => n.trim().split(/\s+as\s+/).pop()?.trim()).filter(Boolean);
+    exports.push(...(names as string[]));
+  }
+
+  // Import declarations
+  const importMatches = content.matchAll(/import\s+.*?from\s+['"]([^'"]+)['"]/g);
+  for (const m of importMatches) {
+    imports.push(m[1]);
+  }
+
+  // Non-exported functions and classes
+  const symbolMatches = content.matchAll(/(?:function|class)\s+(\w+)/g);
+  for (const m of symbolMatches) {
+    symbols.push(m[1]);
+  }
+}
+
+function parsePython(content: string, exports: string[], imports: string[], symbols: string[]): void {
+  // Def/class at module level (no indent)
+  const defMatches = content.matchAll(/^(?:def|class)\s+(\w+)/gm);
+  for (const m of defMatches) {
+    exports.push(m[1]);
+    symbols.push(m[1]);
+  }
+
+  // Import statements
+  const importMatches = content.matchAll(/(?:from\s+(\S+)\s+import|import\s+(\S+))/g);
+  for (const m of importMatches) {
+    imports.push(m[1] ?? m[2]);
+  }
+}
+
+/**
+ * Build dependency edges from import statements.
+ */
+function buildEdges(entries: RepoMapEntry[]): Array<{ from: string; to: string }> {
+  const edges: Array<{ from: string; to: string }> = [];
+  const fileMap = new Map<string, string>();
+
+  // Build a map of base names and relative paths to file paths
+  for (const entry of entries) {
+    const base = basename(entry.file, extname(entry.file));
+    fileMap.set(base, entry.file);
+    fileMap.set(entry.file, entry.file);
+  }
+
+  for (const entry of entries) {
+    for (const imp of entry.imports) {
+      // Try to resolve import to a known file
+      const importBase = basename(imp.replace(/\.js$/, '').replace(/\.ts$/, ''));
+      const target = fileMap.get(importBase);
+      if (target && target !== entry.file) {
+        edges.push({ from: entry.file, to: target });
+      }
+    }
+  }
+
+  return edges;
+}
+
+/**
+ * Rank files by connectivity (simplified PageRank).
+ * Files that are imported by many other files rank higher.
+ */
+function rankFiles(entries: RepoMapEntry[], edges: Array<{ from: string; to: string }>): string[] {
+  const scores = new Map<string, number>();
+
+  // Initialize all files with score 1
+  for (const entry of entries) {
+    scores.set(entry.file, 1);
+  }
+
+  // Add 1 point for each incoming edge (file is imported by another)
+  for (const edge of edges) {
+    scores.set(edge.to, (scores.get(edge.to) ?? 0) + 1);
+  }
+
+  // Boost index files (they're usually important entry points)
+  for (const entry of entries) {
+    if (basename(entry.file).startsWith('index.')) {
+      scores.set(entry.file, (scores.get(entry.file) ?? 0) + 2);
+    }
+  }
+
+  // Boost files with many exports (they're likely important)
+  for (const entry of entries) {
+    if (entry.exports.length > 5) {
+      scores.set(entry.file, (scores.get(entry.file) ?? 0) + 1);
+    }
+  }
+
+  // Sort by score descending
+  return [...scores.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([file]) => file);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,3 +26,4 @@ export { createWorktree, removeWorktree, checkBuild, getChangedFiles, pickWinner
 export { buildSelfReviewPrompt, parseSelfReviewResponse, type SelfReviewResult, type SelfReviewOptions } from './agent/self-review.js';
 export { FileWatcher, type FileChange } from './agent/file-watcher.js';
 export { collectProjectHealth, formatProjectHealth, type ProjectHealth } from './agent/project-health.js';
+export { buildRepoMap, repoMapToContext, type RepoMap, type RepoMapEntry } from './agent/repo-map.js';


### PR DESCRIPTION
## Summary
- `packages/core/src/agent/repo-map.ts` — Regex-based repository map builder
- Scans files via `git ls-files`, parses TS/JS/Python with regex
- Builds dependency graph from import statements
- Ranks files by connectivity (simplified PageRank) + boost for index files and many exports
- `repoMapToContext()` formats top 15 files as compact context string
- No native addons (tree-sitter can be added later for deeper AST analysis)

## Test plan
- [x] All 14 CLI-chain packages build
- [x] Exported from @brainstorm/core