### PR TITLE
chore: GitHub profile, badges, community files (v2 PR 1/12)

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,27 @@
+# Code of Conduct
+
+## Our Pledge
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+**Positive behavior:**
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+
+**Unacceptable behavior:**
+- Trolling, insulting/derogatory comments, and personal attacks
+- Public or private harassment
+- Publishing others' private information without permission
+- Other conduct which could reasonably be considered inappropriate
+
+## Enforcement
+
+Instances of abusive behavior may be reported to the project maintainers. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: justinjilg

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug Report
+about: Report a bug in Brainstorm CLI
+title: "[Bug] "
+labels: bug
+---
+
+**Describe the bug**
+A clear description of what the bug is.
+
+**To reproduce**
+1. Run `storm ...`
+2. ...
+
+**Expected behavior**
+What you expected to happen.
+
+**Environment**
+- OS: [e.g., macOS 15, Ubuntu 24.04]
+- Node.js version: [e.g., 22.x]
+- Brainstorm version: [e.g., 0.1.0]
+- Model provider: [e.g., BrainstormRouter, Ollama]
+
+**Additional context**
+Any relevant logs, screenshots, or config.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature Request
+about: Suggest a feature for Brainstorm CLI
+title: "[Feature] "
+labels: enhancement
+---
+
+**Problem**
+What problem does this solve?
+
+**Proposed solution**
+How should this work?
+
+**Alternatives considered**
+Any other approaches you've thought about.
+
+**Additional context**
+Any relevant examples, links, or mockups.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+## Summary
+<!-- Brief description of changes -->
+
+## Test plan
+<!-- How to verify these changes work -->
+- [ ] `npx turbo run build` passes
+- [ ] `npx turbo run test` passes
+- [ ] Manual testing: ...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Brainstorm
 
+[![Build](https://github.com/justinjilg/brainstorm/actions/workflows/ci.yml/badge.svg)](https://github.com/justinjilg/brainstorm/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue.svg)](https://www.typescriptlang.org/)
+
 An open-source AI coding assistant with intelligent model routing. Routes tasks to the optimal model across 357+ models and 7 providers via [BrainstormRouter](https://brainstormrouter.com).
 
 ```bash


### PR DESCRIPTION
## Summary
- Set repo description: "Open-source AI coding assistant with intelligent model routing across 357+ models"
- Set homepage to brainstormrouter.com
- Added 8 topic tags for discoverability
- Added CI, license, TypeScript badges to README
- Created .github/FUNDING.yml, issue templates, PR template, Code of Conduct

## Test plan
- [x] All packages build
- [x] Badges render correctly in README