### PR TITLE
feat: progressive tool loading — task-aware tiers (v2 PR 2/12)

### DIFF
--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -8,6 +8,7 @@ export { askUserTool, resolveAskUser, hasPendingQuestion } from './builtin/ask-u
 export { routingHintTool, getRoutingHint, consumeRoutingHint, resetRoutingHint, type RoutingPreference } from './builtin/routing-hint.js';
 export { costEstimateTool } from './builtin/cost-estimate.js';
 export { isParallelSafe, classifyToolBatch, executeWithParallelism } from './parallel.js';
+export { getTierForComplexity, getToolsForTier, isToolInTier, escalateTier, getTierForTool, estimateTokenSavings, type ToolTier } from './progressive.js';
 export { planPreviewTool } from './builtin/plan-preview.js';
 export { beginTransactionTool, commitTransactionTool, rollbackTransactionTool, isTransactionActive, recordTransactionFile } from './builtin/transaction.js';
 export { ToolRegistry, type PermissionCheckFn } from './registry.js';

--- a/packages/tools/src/progressive.ts
+++ b/packages/tools/src/progressive.ts
@@ -1,0 +1,114 @@
+/**
+ * Progressive Tool Loading — load tools by tier based on task complexity.
+ *
+ * Instead of injecting all 42 tool descriptions into every system prompt (~3000 tokens),
+ * load tools progressively:
+ *   - minimal (5 tools): simple Q&A, file reads, basic edits
+ *   - standard (20 tools): code editing, git, search, tasks
+ *   - full (42 tools): transactions, undo, BR intelligence, web, batch ops
+ *
+ * Inspired by DeerFlow's progressive skill loading, but task-aware:
+ * the router's task classifier determines which tier to start with.
+ * If the model requests a tool not in the current tier, escalate automatically.
+ */
+
+import type { Complexity } from '@brainstorm/shared';
+
+export type ToolTier = 'minimal' | 'standard' | 'full';
+
+/** Tools included in each tier. */
+const TIER_TOOLS: Record<ToolTier, string[]> = {
+  minimal: [
+    'file_read',
+    'file_write',
+    'file_edit',
+    'shell',
+    'glob',
+  ],
+  standard: [
+    // All minimal tools
+    'file_read', 'file_write', 'file_edit', 'shell', 'glob',
+    // Git
+    'git_status', 'git_diff', 'git_log', 'git_commit', 'git_branch', 'git_stash',
+    // Search
+    'grep', 'list_dir',
+    // Multi-file
+    'multi_edit',
+    // Tasks
+    'task_create', 'task_update', 'task_list',
+    // Agent
+    'scratchpad_write', 'scratchpad_read', 'ask_user',
+  ],
+  full: [
+    // All standard tools
+    'file_read', 'file_write', 'file_edit', 'shell', 'glob',
+    'git_status', 'git_diff', 'git_log', 'git_commit', 'git_branch', 'git_stash',
+    'grep', 'list_dir', 'multi_edit',
+    'task_create', 'task_update', 'task_list',
+    'scratchpad_write', 'scratchpad_read', 'ask_user',
+    // Batch ops
+    'batch_edit',
+    // GitHub
+    'gh_pr', 'gh_issue',
+    // Web
+    'web_fetch', 'web_search',
+    // Process management
+    'process_spawn', 'process_kill',
+    // Undo + Transactions
+    'undo_last_write',
+    'begin_transaction', 'commit_transaction', 'rollback_transaction',
+    // Routing + Cost
+    'set_routing_hint', 'cost_estimate', 'plan_preview',
+    // BrainstormRouter intelligence
+    'br_status', 'br_budget', 'br_leaderboard', 'br_insights',
+    'br_models', 'br_memory_search', 'br_memory_store', 'br_health',
+  ],
+};
+
+/** Map task complexity to initial tool tier. */
+const COMPLEXITY_TO_TIER: Record<Complexity, ToolTier> = {
+  trivial: 'minimal',
+  simple: 'minimal',
+  moderate: 'standard',
+  complex: 'full',
+  expert: 'full',
+};
+
+/** Get the tool tier for a given task complexity. */
+export function getTierForComplexity(complexity: Complexity): ToolTier {
+  return COMPLEXITY_TO_TIER[complexity];
+}
+
+/** Get tool names for a given tier. */
+export function getToolsForTier(tier: ToolTier): string[] {
+  return TIER_TOOLS[tier];
+}
+
+/** Check if a tool is available in the current tier. */
+export function isToolInTier(toolName: string, tier: ToolTier): boolean {
+  return TIER_TOOLS[tier].includes(toolName);
+}
+
+/** Get the next tier up (for escalation). Returns null if already at full. */
+export function escalateTier(current: ToolTier): ToolTier | null {
+  if (current === 'minimal') return 'standard';
+  if (current === 'standard') return 'full';
+  return null;
+}
+
+/** Get tier that contains a specific tool (for escalation targeting). */
+export function getTierForTool(toolName: string): ToolTier | null {
+  if (TIER_TOOLS.minimal.includes(toolName)) return 'minimal';
+  if (TIER_TOOLS.standard.includes(toolName)) return 'standard';
+  if (TIER_TOOLS.full.includes(toolName)) return 'full';
+  return null; // Unknown tool (plugin or MCP)
+}
+
+/** Get token estimate saved by using a lower tier. */
+export function estimateTokenSavings(currentTier: ToolTier): { toolsOmitted: number; estimatedTokensSaved: number } {
+  const fullCount = TIER_TOOLS.full.length;
+  const currentCount = TIER_TOOLS[currentTier].length;
+  const omitted = fullCount - currentCount;
+  // Average tool description ~70 tokens (name + description + schema)
+  return { toolsOmitted: omitted, estimatedTokensSaved: omitted * 70 };
+}


### PR DESCRIPTION
## Summary
- `packages/tools/src/progressive.ts` — Tool tier system (minimal/standard/full)
- Maps task complexity to tool tier via `getTierForComplexity()`
- Auto-escalation via `escalateTier()` when model needs higher-tier tool
- Token savings estimation: ~2600 tokens saved on simple tasks (37 tools × 70 tokens/tool omitted)
- Inspired by DeerFlow's progressive skill loading, but task-classifier-aware

## Test plan
- [x] All 14 CLI-chain packages build
- [x] Exported from @brainstorm/tools