### PR TITLE
feat: wire progressive tool loading into agent loop (v3 PR 5/100)

### DIFF
--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -4,7 +4,7 @@ import type { BrainstormConfig } from '@brainstorm/config';
 import type { ProviderRegistry } from '@brainstorm/providers';
 import { BrainstormRouter, CostTracker } from '@brainstorm/router';
 import type { ToolRegistry, PermissionCheckFn } from '@brainstorm/tools';
-import { setTaskEventHandler, clearTasks, setBackgroundEventHandler, getToolHealthTracker, setToolOutputHandler } from '@brainstorm/tools';
+import { setTaskEventHandler, clearTasks, setBackgroundEventHandler, getToolHealthTracker, setToolOutputHandler, getTierForComplexity, getToolsForTier } from '@brainstorm/tools';
 import type { AgentEvent, GatewayFeedbackData, ModelEntry, TurnContext } from '@brainstorm/shared';
 import type { BuildStateTracker } from './build-state.js';
 import { LoopDetector } from './loop-detector.js';
@@ -197,11 +197,16 @@ export async function* runAgentLoop(
   // Provide tools unless explicitly disabled by the caller (e.g., brainstorm run without --tools)
   const shouldUseTools = !options.disableTools;
 
+  // Progressive tool loading: select tool tier based on task complexity
+  const toolTier = getTierForComplexity(task.complexity);
+  const tierToolNames = getToolsForTier(toolTier);
+
   // Build tools with permission gating if a check function is provided
+  // Filter to tier-appropriate tools for token savings
   const aiTools = shouldUseTools
     ? (options.permissionCheck
-      ? tools.toAISDKToolsWithPermissions(options.permissionCheck)
-      : tools.toAISDKTools())
+      ? tools.toAISDKToolsWithPermissions(options.permissionCheck, tierToolNames)
+      : tools.toAISDKToolsFiltered(tierToolNames))
     : undefined;
 
   // Serialize task context for gateway telemetry (x-br-metadata header)

--- a/packages/tools/src/registry.ts
+++ b/packages/tools/src/registry.ts
@@ -88,9 +88,11 @@ export class ToolRegistry {
    * Return AI SDK tools with permission checks wrapping each execute.
    * Tools denied by the check return an error message instead of executing.
    */
-  toAISDKToolsWithPermissions(check: PermissionCheckFn): Record<string, any> {
+  toAISDKToolsWithPermissions(check: PermissionCheckFn, allowedNames?: string[]): Record<string, any> {
+    const allowed = allowedNames ? new Set(allowedNames) : null;
     const result: Record<string, any> = {};
     for (const [name, toolDef] of this.tools) {
+      if (allowed && !allowed.has(name)) continue;
       result[name] = tool({
         description: toolDef.description,
         inputSchema: toolDef.inputSchema,


### PR DESCRIPTION
## Summary
- Import `getTierForComplexity`, `getToolsForTier` into agent loop
- After task classification, determine tool tier and filter registry
- `toAISDKToolsWithPermissions()` gains optional `allowedNames` parameter
- Simple tasks: 5 tools. Standard: 20. Complex/expert: all 42.

## Test plan
- [x] All 14 CLI-chain packages build