### PR TITLE
fix: code review findings — trajectory reducer + progressive tools

### DIFF
--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -197,16 +197,18 @@ export async function* runAgentLoop(
   // Provide tools unless explicitly disabled by the caller (e.g., brainstorm run without --tools)
   const shouldUseTools = !options.disableTools;
 
-  // Progressive tool loading: select tool tier based on task complexity
+  // Progressive tool loading: select tool tier based on task complexity.
+  // Only restrict tools for trivial tasks (Q&A, simple reads). All other tasks
+  // get the full tool set until mid-session escalation is implemented.
   const toolTier = getTierForComplexity(task.complexity);
-  const tierToolNames = getToolsForTier(toolTier);
+  const useFullTools = toolTier !== 'minimal';
+  const tierToolNames = useFullTools ? undefined : getToolsForTier(toolTier);
 
   // Build tools with permission gating if a check function is provided
-  // Filter to tier-appropriate tools for token savings
   const aiTools = shouldUseTools
     ? (options.permissionCheck
       ? tools.toAISDKToolsWithPermissions(options.permissionCheck, tierToolNames)
-      : tools.toAISDKToolsFiltered(tierToolNames))
+      : (tierToolNames ? tools.toAISDKToolsFiltered(tierToolNames) : tools.toAISDKTools()))
     : undefined;
 
   // Serialize task context for gateway telemetry (x-br-metadata header)

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -52,7 +52,7 @@ export async function compactContext(
   const { contextWindow, keepRecent = 5, summarizeModel } = options;
 
   // Phase 1: Trajectory reduction — remove expired/redundant messages before compaction
-  const turnEstimate = Math.floor(messages.length / 2); // rough turn count
+  const turnEstimate = messages.length; // use message count as turn proxy for age-based expiry
   const reduction = reduceTrajectory(messages, turnEstimate);
   const workingMessages = reduction.removedCount > 0 ? reduction.reduced : messages;
 
@@ -70,7 +70,7 @@ export async function compactContext(
   const recentMessages = conversationMsgs.slice(recentStart);
 
   if (oldMessages.length === 0) {
-    return { messages, compacted: false, summaryCost: 0 };
+    return { messages: workingMessages, compacted: reduction.removedCount > 0, summaryCost: 0 };
   }
 
   // Classify messages into keep/summarize/drop buckets


### PR DESCRIPTION
## Summary
Fixes 3 bugs from code review of PRs #167 and #168:

1. **turnEstimate off by 2x** — `messages.length/2` → `messages.length` so staleness rules actually fire
2. **Early return discards reductions** — return `workingMessages` not `messages` when oldMessages is empty
3. **Tool tier frozen with no escalation** — only restrict to minimal tier for trivial tasks; all others get full tools

## Test plan
- [x] All 14 CLI-chain packages build