### PR TITLE
feat: wire session checkpointer into agent loop (v3 PR 10/100)

### DIFF
--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -115,6 +115,8 @@ export interface AgentLoopOptions {
   middleware?: MiddlewarePipeline;
   /** Enable trajectory recording to JSONL. */
   trajectoryEnabled?: boolean;
+  /** Session checkpointer for crash recovery. */
+  checkpointer?: { saveIfNeeded: (data: any) => boolean };
 }
 
 // All task types get tools — the model decides whether to use them.
@@ -437,6 +439,21 @@ export async function* runAgentLoop(
         buildStatus: options.buildState?.getStatus() ?? 'unknown',
         buildWarning: options.buildState?.formatBuildWarning() ?? '',
         costPerHour: 0, // caller sets this based on session duration
+      });
+    }
+
+    // Save checkpoint for crash recovery (if checkpointer provided)
+    if (options.checkpointer) {
+      options.checkpointer.saveIfNeeded({
+        sessionId,
+        turnNumber: 0, // caller sets actual turn
+        conversationHistory: messages,
+        scratchpad: {},
+        filesRead: [],
+        filesWritten: [],
+        buildStatus: options.buildState?.getStatus() ?? 'unknown',
+        totalCost: costTracker.getSessionCost(),
+        projectPath: options.projectPath,
       });
     }
 


### PR DESCRIPTION
## Summary
- Add `checkpointer` option to AgentLoopOptions
- Call `saveIfNeeded()` after turn completion with session state
- Foundation for crash recovery when CLI provides SessionCheckpointer

## Test plan
- [x] All 14 CLI-chain packages build