### PR TITLE
feat: wire cost predictor into agent loop (v3 PR 11/100)

### DIFF
--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -14,6 +14,7 @@ import { normalizeInsightMarkers } from './insights.js';
 import { parseGatewayHeaders } from '@brainstorm/gateway';
 import type { MiddlewarePipeline } from '../middleware/pipeline.js';
 import { TrajectoryRecorder } from '../session/trajectory.js';
+import { predictTaskCost } from './cost-predictor.js';
 
 /**
  * Enrich raw API errors with actionable user-facing messages.
@@ -199,6 +200,12 @@ export async function* runAgentLoop(
     taskType: task.type,
     complexity: task.complexity,
   });
+
+  // Cost prediction — yield estimate so CLI can display it
+  const costPrediction = predictTaskCost(task, [decision.model]);
+  if (costPrediction.estimated > 0.01) {
+    yield { type: 'cost-prediction', prediction: costPrediction } as any;
+  }
 
   // Phase: connecting
   yield { type: 'thinking' as const, phase: 'connecting' as const };


### PR DESCRIPTION
## Summary
- Import `predictTaskCost` into agent loop
- Yield `cost-prediction` event after routing, before LLM call
- Only emits when estimated cost > $0.01 (skip trivial predictions)
- CLI can display prediction in TUI

## Test plan
- [x] All 14 CLI-chain packages build