### PR TITLE
feat: wire ensemble generation gate into agent loop (v3 PR 13/100)

### DIFF
--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -16,6 +16,7 @@ import type { MiddlewarePipeline } from '../middleware/pipeline.js';
 import { TrajectoryRecorder } from '../session/trajectory.js';
 import { predictTaskCost } from './cost-predictor.js';
 import { detectTone, toneGuidance } from './sentiment.js';
+import { shouldUseEnsemble } from './ensemble.js';
 
 /**
  * Enrich raw API errors with actionable user-facing messages.
@@ -210,6 +211,14 @@ export async function* runAgentLoop(
     taskType: task.type,
     complexity: task.complexity,
   });
+
+  // Check if ensemble generation should be used for this task
+  const ensembleEnabled = (config as any).ensemble?.enabled ?? false;
+  if (shouldUseEnsemble(task.complexity, ensembleEnabled)) {
+    yield { type: 'ensemble-info', message: `Ensemble mode: task complexity "${task.complexity}" qualifies for multi-model generation` } as any;
+    // Full ensemble execution (parallel streamText calls + voting) is a future enhancement.
+    // For now, single-model path continues with the routing decision above.
+  }
 
   // Cost prediction — yield estimate so CLI can display it
   const costPrediction = predictTaskCost(task, [decision.model]);


### PR DESCRIPTION
## Summary
- Import `shouldUseEnsemble` into agent loop
- Check after routing: if task is complex/expert AND ensemble enabled in config, yield event
- Foundation for full parallel multi-model generation (future PR)

## Test plan
- [x] All 14 CLI-chain packages build