### PR TITLE
fix: replace silent catch blocks with logged warnings (v3 PR 18/100)

### DIFF
--- a/packages/config/src/loader.ts
+++ b/packages/config/src/loader.ts
@@ -2,8 +2,11 @@ import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import TOML from '@iarna/toml';
+import { createLogger } from '@brainstorm/shared';
 import { brainstormConfigSchema, type BrainstormConfig } from './schema.js';
 import { loadStormFile } from './storm-loader.js';
+
+const log = createLogger('config');
 
 const GLOBAL_CONFIG_DIR = join(homedir(), '.brainstorm');
 const GLOBAL_CONFIG_FILE = join(GLOBAL_CONFIG_DIR, 'config.toml');
@@ -49,7 +52,8 @@ function readJsonSafe(path: string): Record<string, unknown> {
   if (!existsSync(path)) return {};
   try {
     return JSON.parse(readFileSync(path, 'utf-8'));
-  } catch {
+  } catch (e) {
+    log.warn({ err: e, path }, 'Failed to parse JSON config file');
     return {};
   }
 }

--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -5,7 +5,7 @@ import type { ProviderRegistry } from '@brainstorm/providers';
 import { BrainstormRouter, CostTracker } from '@brainstorm/router';
 import type { ToolRegistry, PermissionCheckFn } from '@brainstorm/tools';
 import { setTaskEventHandler, clearTasks, setBackgroundEventHandler, getToolHealthTracker, setToolOutputHandler, getTierForComplexity, getToolsForTier } from '@brainstorm/tools';
-import type { AgentEvent, GatewayFeedbackData, ModelEntry, TurnContext } from '@brainstorm/shared';
+import { createLogger, type AgentEvent, type GatewayFeedbackData, type ModelEntry, type TurnContext } from '@brainstorm/shared';
 import type { BuildStateTracker } from './build-state.js';
 import { LoopDetector } from './loop-detector.js';
 import { serializeRoutingMetadata } from '@brainstorm/shared';
@@ -17,6 +17,8 @@ import { TrajectoryRecorder } from '../session/trajectory.js';
 import { predictTaskCost } from './cost-predictor.js';
 import { detectTone, toneGuidance } from './sentiment.js';
 import { shouldUseEnsemble } from './ensemble.js';
+
+const log = createLogger('agent-loop');
 
 /**
  * Enrich raw API errors with actionable user-facing messages.
@@ -509,7 +511,9 @@ export async function* runAgentLoop(
       });
 
       // Async submission — don't block session exit
-      import('../session/trajectory.js').catch(() => {});
+      import('../session/trajectory.js').catch((e) => {
+        log.warn({ err: e }, 'Failed to load trajectory module for intelligence submission');
+      });
     }
   }
 }

--- a/packages/core/src/memory/manager.ts
+++ b/packages/core/src/memory/manager.ts
@@ -2,7 +2,10 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, unlink
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { createHash } from 'node:crypto';
+import { createLogger } from '@brainstorm/shared';
 import type { BrainstormGateway } from '@brainstorm/gateway';
+
+const log = createLogger('memory');
 
 export interface MemoryEntry {
   id: string;
@@ -69,7 +72,9 @@ export class MemoryManager {
 
     // Fire-and-forget push to gateway
     if (this.gateway) {
-      this.gateway.storeMemory(memory.type, `[${memory.name}] ${memory.content}`).catch(() => {});
+      this.gateway.storeMemory(memory.type, `[${memory.name}] ${memory.content}`).catch((e) => {
+        log.warn({ err: e, memoryId: id }, 'Failed to push memory to gateway');
+      });
     }
 
     return memory;
@@ -90,7 +95,7 @@ export class MemoryManager {
     if (!this.entries.has(id)) return false;
     this.entries.delete(id);
     const filePath = join(this.memoryDir, `${id}.md`);
-    try { unlinkSync(filePath); } catch {}
+    try { unlinkSync(filePath); } catch (e) { log.warn({ err: e, filePath }, 'Failed to delete memory file'); }
     this.updateIndex();
     return true;
   }
@@ -138,7 +143,7 @@ export class MemoryManager {
         const content = readFileSync(join(this.memoryDir, file), 'utf-8');
         const entry = this.parseMemoryFile(file, content);
         if (entry) this.entries.set(entry.id, entry);
-      } catch {}
+      } catch (e) { log.warn({ err: e, file }, 'Failed to parse memory file'); }
     }
   }
 

--- a/packages/hooks/src/manager.ts
+++ b/packages/hooks/src/manager.ts
@@ -1,8 +1,10 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { createLogger } from '@brainstorm/shared';
 import type { HookDefinition, HookEvent, HookResult } from './types.js';
 
 const execFileAsync = promisify(execFile);
+const log = createLogger('hooks');
 
 /**
  * HookManager — registers and fires hooks at lifecycle events.
@@ -52,7 +54,7 @@ export class HookManager {
         if (matchTarget) {
           try {
             return new RegExp(h.matcher).test(matchTarget);
-          } catch { return false; }
+          } catch (e) { log.warn({ err: e, matcher: h.matcher }, 'Invalid hook matcher regex'); return false; }
         }
       }
       return true;

--- a/packages/tools/src/builtin/git-commit.ts
+++ b/packages/tools/src/builtin/git-commit.ts
@@ -1,9 +1,11 @@
 import { z } from 'zod';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { createLogger } from '@brainstorm/shared';
 import { defineTool } from '../base.js';
 
 const execFileAsync = promisify(execFile);
+const log = createLogger('git-commit');
 
 /**
  * Smart git commit tool with two modes:
@@ -52,7 +54,9 @@ export const gitCommitTool = defineTool({
       const credentialHits = scanDiffForCredentials(diff);
       if (credentialHits.length > 0) {
         // Unstage and abort
-        await execFileAsync('git', ['reset', 'HEAD', ...files], opts).catch(() => {});
+        await execFileAsync('git', ['reset', 'HEAD', ...files], opts).catch((e) => {
+          log.warn({ err: e }, 'Failed to unstage files after credential detection');
+        });
         return {
           error: `Credential detected in staged changes — commit blocked.\n${credentialHits.map((h) => `  ${h.file}: ${h.pattern} (${h.preview})`).join('\n')}\n\nRemove the credential before committing.`,
         };


### PR DESCRIPTION
## Summary
- Add `createLogger()` from `@brainstorm/shared` to 5 modules that had silent error swallowing
- Replace all `catch {}` and `.catch(() => {})` with `catch (e) { log.warn({...}) }`
- Affected modules: core/memory manager, core/agent loop, tools/git-commit, config/loader, hooks/manager
- Preserves existing behavior (errors don't crash) but now surfaces diagnostics via pino

## Files changed
- `packages/core/src/memory/manager.ts` — 3 silent catches → logged warnings
- `packages/core/src/agent/loop.ts` — 1 silent catch → logged warning
- `packages/tools/src/builtin/git-commit.ts` — 1 silent catch → logged warning
- `packages/config/src/loader.ts` — 1 silent catch → logged warning
- `packages/hooks/src/manager.ts` — 1 silent catch → logged warning

## Test plan
- [x] `npx turbo run build --force` passes (17/17 packages)
- Warnings only appear at `BRAINSTORM_LOG_LEVEL=debug` or higher