### PR TITLE
feat: atomic file writes via tmp+rename (v3 PR 22/100)

### DIFF
--- a/packages/tools/src/builtin/file-write.ts
+++ b/packages/tools/src/builtin/file-write.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
-import { writeFileSync, mkdirSync } from 'node:fs';
+import { writeFileSync, mkdirSync, renameSync, unlinkSync } from 'node:fs';
 import { dirname, resolve, relative } from 'node:path';
+import { randomUUID } from 'node:crypto';
 import { defineTool } from '../base.js';
 
 import { homedir } from 'node:os';
@@ -48,7 +49,17 @@ export const fileWriteTool = defineTool({
     const validation = preValidate(safePath, content);
 
     mkdirSync(dirname(safePath), { recursive: true });
-    writeFileSync(safePath, content, 'utf-8');
+
+    // Atomic write: write to temp file, then rename to target.
+    // Prevents partial writes on crash/interrupt.
+    const tmpPath = `${safePath}.${randomUUID().slice(0, 8)}.tmp`;
+    try {
+      writeFileSync(tmpPath, content, 'utf-8');
+      renameSync(tmpPath, safePath);
+    } catch (e) {
+      try { unlinkSync(tmpPath); } catch {}
+      throw e;
+    }
 
     // Track file access
     const { getFileTracker } = await import('../file-tracker.js');


### PR DESCRIPTION
## Summary
- Write content to `<path>.<uuid>.tmp` first, then `renameSync()` to target
- On error, clean up temp file before re-throwing
- Prevents partial/corrupt files on crash or interrupt

## Test plan
- [x] `npx turbo run build --force` passes (17/17)