### PR TITLE
feat: file read cache with LRU eviction and TTL (v3 PR 24/100)

### DIFF
--- a/packages/tools/src/builtin/file-edit.ts
+++ b/packages/tools/src/builtin/file-edit.ts
@@ -116,6 +116,10 @@ export const fileEditTool = defineTool({
 
     writeFileSync(safePath, updated, 'utf-8');
 
+    // Invalidate read cache for this file
+    const { getFileReadCache } = await import('../file-cache.js');
+    getFileReadCache().invalidate(safePath);
+
     // Diff preview (non-blocking)
     const { getDiffSummary } = await import('../diff-preview.js');
     const diff = getDiffSummary(safePath);

--- a/packages/tools/src/builtin/file-read.ts
+++ b/packages/tools/src/builtin/file-read.ts
@@ -47,7 +47,14 @@ export const fileReadTool = defineTool({
     const { getFileTracker } = await import('../file-tracker.js');
     getFileTracker().recordRead(safePath);
 
-    const content = readFileSync(safePath, 'utf-8');
+    // Check cache first to avoid redundant disk reads
+    const { getFileReadCache } = await import('../file-cache.js');
+    const cache = getFileReadCache();
+    let content = cache.get(safePath);
+    if (content === null) {
+      content = readFileSync(safePath, 'utf-8');
+      cache.set(safePath, content);
+    }
     const lines = content.split('\n');
 
     const start = (offset ?? 1) - 1;

--- a/packages/tools/src/builtin/file-write.ts
+++ b/packages/tools/src/builtin/file-write.ts
@@ -61,6 +61,10 @@ export const fileWriteTool = defineTool({
       throw e;
     }
 
+    // Invalidate read cache for this file
+    const { getFileReadCache } = await import('../file-cache.js');
+    getFileReadCache().invalidate(safePath);
+
     // Track file access
     const { getFileTracker } = await import('../file-tracker.js');
     getFileTracker().recordWrite(safePath);

--- a/packages/tools/src/file-cache.ts
+++ b/packages/tools/src/file-cache.ts
@@ -1,0 +1,72 @@
+/**
+ * LRU file read cache with TTL-based expiry.
+ * Reduces redundant disk reads during agent loops that re-read the same files.
+ * Invalidated on write via invalidate().
+ */
+
+interface CacheEntry {
+  content: string;
+  cachedAt: number;
+}
+
+const DEFAULT_MAX_ENTRIES = 100;
+const DEFAULT_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+export class FileReadCache {
+  private cache = new Map<string, CacheEntry>();
+  private maxEntries: number;
+  private ttlMs: number;
+
+  constructor(maxEntries = DEFAULT_MAX_ENTRIES, ttlMs = DEFAULT_TTL_MS) {
+    this.maxEntries = maxEntries;
+    this.ttlMs = ttlMs;
+  }
+
+  get(path: string): string | null {
+    const entry = this.cache.get(path);
+    if (!entry) return null;
+    if (Date.now() - entry.cachedAt > this.ttlMs) {
+      this.cache.delete(path);
+      return null;
+    }
+    // Move to end for LRU ordering
+    this.cache.delete(path);
+    this.cache.set(path, entry);
+    return entry.content;
+  }
+
+  set(path: string, content: string): void {
+    // Evict oldest entry if at capacity
+    if (this.cache.size >= this.maxEntries) {
+      const oldest = this.cache.keys().next().value;
+      if (oldest) this.cache.delete(oldest);
+    }
+    this.cache.set(path, { content, cachedAt: Date.now() });
+  }
+
+  /** Invalidate a single path (e.g., after write/edit). */
+  invalidate(path: string): void {
+    this.cache.delete(path);
+  }
+
+  /** Clear the entire cache. */
+  clear(): void {
+    this.cache.clear();
+  }
+
+  get size(): number {
+    return this.cache.size;
+  }
+}
+
+let _instance: FileReadCache | null = null;
+
+export function getFileReadCache(): FileReadCache {
+  if (!_instance) _instance = new FileReadCache();
+  return _instance;
+}
+
+export function resetFileReadCache(): void {
+  _instance?.clear();
+  _instance = null;
+}

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -1,4 +1,5 @@
 export { defineTool, type BrainstormToolDef } from './base.js';
+export { FileReadCache, getFileReadCache, resetFileReadCache } from './file-cache.js';
 export { SessionFileTracker, getFileTracker, resetFileTracker } from './file-tracker.js';
 export { ToolHealthTracker, getToolHealthTracker, resetToolHealthTracker, type ToolHealthEntry } from './tool-health.js';
 export { CheckpointManager, initCheckpointManager, getCheckpointManager } from './checkpoint.js';


### PR DESCRIPTION
## Summary
- New `FileReadCache` class: LRU (max 100), TTL (5min), Map-based
- `file_read` checks cache before `readFileSync`
- `file_write` and `file_edit` invalidate cache on mutation
- Exported: `FileReadCache`, `getFileReadCache`, `resetFileReadCache`

## Test plan
- [x] `npx turbo run build --force` passes (17/17)