### PR TITLE
feat: provider discovery cache with 10min TTL (v3 PR 26/100)

### DIFF
--- a/packages/providers/src/local/discovery.ts
+++ b/packages/providers/src/local/discovery.ts
@@ -1,14 +1,54 @@
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
 import type { ProviderConfig } from '@brainstorm/config';
 import type { ModelEntry } from '@brainstorm/shared';
+import { createLogger } from '@brainstorm/shared';
 import { discoverOllamaModels } from './ollama.js';
 import { discoverOpenAICompatModels } from './openai-compat.js';
+
+const log = createLogger('discovery');
 
 export interface DiscoveryResult {
   models: ModelEntry[];
   errors: Array<{ provider: string; error: string }>;
 }
 
+const CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const CACHE_DIR = join(homedir(), '.brainstorm');
+const CACHE_FILE = join(CACHE_DIR, '.providers.cache.json');
+
+interface DiscoveryCache {
+  timestamp: number;
+  result: DiscoveryResult;
+}
+
+function readCache(): DiscoveryResult | null {
+  if (process.env.BRAINSTORM_SKIP_DISCOVERY_CACHE) return null;
+  try {
+    if (!existsSync(CACHE_FILE)) return null;
+    const raw: DiscoveryCache = JSON.parse(readFileSync(CACHE_FILE, 'utf-8'));
+    if (Date.now() - raw.timestamp > CACHE_TTL_MS) return null;
+    return raw.result;
+  } catch (e) {
+    log.warn({ err: e }, 'Failed to read provider discovery cache');
+    return null;
+  }
+}
+
+function writeCache(result: DiscoveryResult): void {
+  try {
+    mkdirSync(CACHE_DIR, { recursive: true });
+    const cache: DiscoveryCache = { timestamp: Date.now(), result };
+    writeFileSync(CACHE_FILE, JSON.stringify(cache), 'utf-8');
+  } catch (e) {
+    log.warn({ err: e }, 'Failed to write provider discovery cache');
+  }
+}
+
 export async function discoverLocalModels(config: ProviderConfig): Promise<DiscoveryResult> {
+  const cached = readCache();
+  if (cached) return cached;
   const models: ModelEntry[] = [];
   const errors: Array<{ provider: string; error: string }> = [];
 
@@ -39,5 +79,7 @@ export async function discoverLocalModels(config: ProviderConfig): Promise<Disco
   }
 
   await Promise.all(tasks);
-  return { models, errors };
+  const result = { models, errors };
+  if (models.length > 0) writeCache(result);
+  return result;
 }


### PR DESCRIPTION
## Summary
- Cache discovery results to `~/.brainstorm/.providers.cache.json` with 10min TTL
- Skip cache with `BRAINSTORM_SKIP_DISCOVERY_CACHE` env var
- Only writes cache when models were found (avoids caching empty results)
- Logged warnings on cache failures via `createLogger('discovery')`

## Test plan
- [x] `npx turbo run build --force` passes (17/17)