### PR TITLE
feat: lazy message loading — last 50 on resume (v3 PR 28/100)

### DIFF
--- a/packages/core/src/session/manager.ts
+++ b/packages/core/src/session/manager.ts
@@ -35,7 +35,8 @@ export class SessionManager {
     if (!session) return null;
 
     this.currentSession = session;
-    const msgs = this.messages.listBySession(sessionId);
+    // Lazy load: only keep last 50 messages in memory (older available on demand via DB)
+    const msgs = this.messages.listBySessionRecent(sessionId, 50);
     this.conversationHistory = msgs
       .filter((m) => m.role !== 'tool')
       .map((m) => ({

--- a/packages/db/src/repositories.ts
+++ b/packages/db/src/repositories.ts
@@ -84,6 +84,30 @@ export class MessageRepository {
       timestamp: row.timestamp,
     }));
   }
+
+  /** Load only the most recent N messages for a session. Used for lazy loading. */
+  listBySessionRecent(sessionId: string, limit = 50): Message[] {
+    const rows = this.db
+      .prepare('SELECT * FROM (SELECT * FROM messages WHERE session_id = ? ORDER BY timestamp DESC LIMIT ?) ORDER BY timestamp ASC')
+      .all(sessionId, limit) as any[];
+    return rows.map((row) => ({
+      id: row.id,
+      sessionId: row.session_id,
+      role: row.role,
+      content: row.content,
+      modelId: row.model_id ?? undefined,
+      tokenCount: row.token_count ?? undefined,
+      timestamp: row.timestamp,
+    }));
+  }
+
+  /** Count total messages in a session. */
+  countBySession(sessionId: string): number {
+    const row = this.db
+      .prepare('SELECT COUNT(*) as count FROM messages WHERE session_id = ?')
+      .get(sessionId) as any;
+    return row?.count ?? 0;
+  }
 }
 
 // ── Cost Records ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `listBySessionRecent(sessionId, limit)` to `MessageRepository` — subquery with DESC LIMIT + ASC reorder
- Add `countBySession()` for total count access
- `SessionManager.resume()` loads last 50 messages instead of full history
- Reduces memory for long sessions with hundreds of messages

## Test plan
- [x] `npx turbo run build --force` passes (17/17)