### PR TITLE
feat: budget warning at 80% usage (v3 PR 29/100)

### DIFF
--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -395,6 +395,20 @@ export async function* runAgentLoop(
     const remaining = streamFilter.flush();
     if (remaining) yield { type: 'text-delta', delta: normalizeInsightMarkers(remaining) };
 
+    // ── Budget warning at 80% ──
+    const budgetRemaining = costTracker.getRemainingBudget();
+    if (budgetRemaining !== null) {
+      const sessionLimit = (config.budget as any)?.perSession;
+      if (sessionLimit && budgetRemaining <= sessionLimit * 0.2) {
+        yield {
+          type: 'budget-warning' as const,
+          used: costTracker.getSessionCost(),
+          limit: sessionLimit,
+          remaining: budgetRemaining,
+        };
+      }
+    }
+
     // ── Empty/blocked response detection + retry with fallback model ──
     const isEmpty = textDeltaCount === 0 && toolCallCount === 0;
     // Build fallback list: use decision.fallbacks, or generate from registry if empty

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -200,6 +200,7 @@ export type AgentEvent =
   | { type: 'background-complete'; taskId: string; command: string; exitCode: number; stdout: string; stderr: string }
   | { type: 'model-retry'; fromModel: string; toModel: string; reason: string }
   | { type: 'fallback-exhausted'; modelsTried: string[]; reason: string }
+  | { type: 'budget-warning'; used: number; limit: number; remaining: number }
   | { type: 'empty-response'; modelId: string }
   | { type: 'context-budget'; used: number; limit: number; percent: number }
   | { type: 'loop-warning'; message: string }


### PR DESCRIPTION
## Summary
- Emit `budget-warning` event after each turn when session cost >= 80% of limit
- Event includes `used`, `limit`, `remaining` for TUI display
- Add `budget-warning` to `AgentEvent` union type in shared types

## Test plan
- [x] `npx turbo run build --force` passes (17/17)