### PR TITLE
feat: preserve memory + loop warnings in compaction (v3 PR 30/100)

### DIFF
--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -191,6 +191,12 @@ function classifyMessage(
   // [keep] prefix marks messages as compaction-resistant
   if (content.startsWith('[keep]') || content.startsWith('[KEEP]')) return 'keep';
 
+  // Preserve memory-injected context (survives compaction by design)
+  if (content.includes('[Memory]') || content.includes('[memory]') || content.includes('Memory context:')) return 'keep';
+
+  // Preserve loop warnings (critical for preventing repeated mistakes)
+  if (content.includes('[Loop warning]') || content.includes('loop-warning') || content.includes('Loop detected')) return 'keep';
+
   // Keep error messages
   if (content.includes('Error:') || content.includes('error:') || content.includes('FAIL')) {
     return 'keep';


### PR DESCRIPTION
## Summary
- Memory-injected messages (`[Memory]`, `Memory context:`) now classified as `keep`
- Loop warnings (`[Loop warning]`, `Loop detected`) now classified as `keep`
- Scratchpad already preserved (existing code)
- Ensures critical context survives compaction

## Test plan
- [x] `npx turbo run build --force` passes (17/17)