### PR TITLE
feat: build state check in workflow engine (v3 PR 31/100)

### DIFF
--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -396,6 +396,7 @@ export type WorkflowEvent =
   | { type: 'model-fallback'; originalModel: string; fallbackModel: string; reason: string; costImpact: number }
   | { type: 'provider-degraded'; provider: string; errorCount: number; resumeAt: number }
   | { type: 'cost-forecast'; estimated: number; breakdown: Array<{ step: string; cost: number }> }
+  | { type: 'workflow-paused'; reason: string; run: WorkflowRun }
   | { type: 'workflow-completed'; run: WorkflowRun }
   | { type: 'workflow-failed'; run: WorkflowRun; error: Error };
 

--- a/packages/workflow/src/engine.ts
+++ b/packages/workflow/src/engine.ts
@@ -22,6 +22,8 @@ export interface WorkflowEngineOptions {
   projectPath: string;
   /** Per-step model overrides: stepId → modelId. Used for cross-model workflows. */
   stepModelOverrides?: Record<string, string>;
+  /** Build state tracker — if build is broken, workflow pauses before next step. */
+  buildState?: { isBroken(): boolean; getLastError(): string | null };
 }
 
 export async function* runWorkflow(
@@ -106,6 +108,17 @@ export async function* runWorkflow(
     run.steps.push(stepRun);
 
     yield { type: 'step-started', step: stepRun, agent };
+
+    // Check build state before executing step — pause if build is broken
+    if (options.buildState) {
+      const bs = options.buildState;
+      if (bs.isBroken()) {
+        yield { type: 'workflow-paused', reason: `Build is broken: ${bs.getLastError()}. Fix before continuing.`, run };
+        stepRun.status = 'skipped';
+        stepRun.error = 'Build broken — step skipped';
+        break;
+      }
+    }
 
     try {
       // Build context for this step


### PR DESCRIPTION
## Summary
- Add `buildState` option to `WorkflowEngineOptions`
- Check `buildState.isBroken()` before each step execution
- Yield `workflow-paused` event and skip step if build broken
- Add `workflow-paused` to `WorkflowEvent` union type

## Test plan
- [x] `npx turbo run build --force` passes (17/17)