### PR TITLE
refactor: extract shared edit logic into edit-common.ts (v3 PR 33/100)

### DIFF
--- a/packages/tools/src/builtin/edit-common.ts
+++ b/packages/tools/src/builtin/edit-common.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared edit logic used by file_edit, multi_edit, and batch_edit.
+ * Centralizes the find-count-replace pattern to avoid duplication.
+ */
+
+export interface EditResult {
+  applied: boolean;
+  content?: string;
+  error?: string;
+  occurrences?: number;
+}
+
+/**
+ * Apply a single string replacement to content.
+ * Returns the updated content if successful, or an error message if not.
+ */
+export function applyEdit(content: string, oldString: string, newString: string): EditResult {
+  const occurrences = content.split(oldString).length - 1;
+
+  if (occurrences === 0) {
+    return { applied: false, error: 'not found' };
+  }
+  if (occurrences > 1) {
+    return { applied: false, error: `${occurrences} occurrences (must be unique)`, occurrences };
+  }
+
+  return {
+    applied: true,
+    content: content.replace(oldString, newString),
+  };
+}
+
+/**
+ * Apply multiple edits to content sequentially.
+ * Returns the final content and per-edit results.
+ */
+export function applyEdits(
+  content: string,
+  edits: Array<{ old_string: string; new_string: string }>,
+): { content: string; results: Array<{ old: string; applied: boolean; reason?: string }>; appliedCount: number } {
+  let current = content;
+  const results: Array<{ old: string; applied: boolean; reason?: string }> = [];
+  let appliedCount = 0;
+
+  for (const edit of edits) {
+    const result = applyEdit(current, edit.old_string, edit.new_string);
+    if (result.applied && result.content) {
+      current = result.content;
+      results.push({ old: edit.old_string.slice(0, 40), applied: true });
+      appliedCount++;
+    } else {
+      results.push({ old: edit.old_string.slice(0, 40), applied: false, reason: result.error });
+    }
+  }
+
+  return { content: current, results, appliedCount };
+}

--- a/packages/tools/src/builtin/multi-edit.ts
+++ b/packages/tools/src/builtin/multi-edit.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { defineTool } from '../base.js';
+import { applyEdits } from './edit-common.js';
 
 export const multiEditTool = defineTool({
   name: 'multi_edit',
@@ -16,31 +17,16 @@ export const multiEditTool = defineTool({
   async execute({ path, edits }) {
     if (!existsSync(path)) return { error: `File not found: ${path}` };
 
-    let content = readFileSync(path, 'utf-8');
-    const results: Array<{ old: string; applied: boolean; reason?: string }> = [];
+    const original = readFileSync(path, 'utf-8');
+    const { content, results, appliedCount } = applyEdits(original, edits);
 
-    for (const edit of edits) {
-      const count = content.split(edit.old_string).length - 1;
-      if (count === 0) {
-        results.push({ old: edit.old_string.slice(0, 40), applied: false, reason: 'not found' });
-        continue;
-      }
-      if (count > 1) {
-        results.push({ old: edit.old_string.slice(0, 40), applied: false, reason: `${count} occurrences (must be unique)` });
-        continue;
-      }
-      content = content.replace(edit.old_string, edit.new_string);
-      results.push({ old: edit.old_string.slice(0, 40), applied: true });
-    }
-
-    const applied = results.filter((r) => r.applied).length;
-    if (applied > 0) {
+    if (appliedCount > 0) {
       const { getCheckpointManager } = await import('../checkpoint.js');
       const cp = getCheckpointManager();
       if (cp) cp.snapshot(path);
       writeFileSync(path, content, 'utf-8');
     }
 
-    return { path, applied, total: edits.length, results };
+    return { path, applied: appliedCount, total: edits.length, results };
   },
 });


### PR DESCRIPTION
## Summary
- New `edit-common.ts` with `applyEdit()` (single replacement) and `applyEdits()` (batch)
- Refactored `multi_edit` to use `applyEdits()` — removes duplicated logic
- `file_edit` and `batch_edit` can adopt in future PRs

## Test plan
- [x] `npx turbo run build --force` passes (17/17)