### PR TITLE
refactor: extract runGit() helper for git tools (v3 PR 34/100)

### DIFF
--- a/packages/tools/src/builtin/git-common.ts
+++ b/packages/tools/src/builtin/git-common.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared git command helper used by all git tools.
+ * Centralizes exec options and error handling.
+ */
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_TIMEOUT = 30_000;
+const MAX_OUTPUT = 1_000_000; // 1MB max
+
+export interface GitResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/**
+ * Run a git command with consistent options.
+ * Returns structured result instead of throwing on non-zero exit.
+ */
+export async function runGit(
+  args: string[],
+  cwd?: string,
+  timeout = DEFAULT_TIMEOUT,
+): Promise<GitResult> {
+  try {
+    const { stdout, stderr } = await execFileAsync('git', args, {
+      cwd: cwd ?? process.cwd(),
+      timeout,
+      maxBuffer: MAX_OUTPUT,
+    });
+    return { stdout, stderr, exitCode: 0 };
+  } catch (err: any) {
+    return {
+      stdout: err.stdout ?? '',
+      stderr: err.stderr ?? err.message,
+      exitCode: err.code ?? 1,
+    };
+  }
+}

--- a/packages/tools/src/builtin/git-status.ts
+++ b/packages/tools/src/builtin/git-status.ts
@@ -1,9 +1,6 @@
 import { z } from 'zod';
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
 import { defineTool } from '../base.js';
-
-const execFileAsync = promisify(execFile);
+import { runGit } from './git-common.js';
 
 export const gitStatusTool = defineTool({
   name: 'git_status',
@@ -13,11 +10,10 @@ export const gitStatusTool = defineTool({
     cwd: z.string().optional().describe('Working directory (default: current)'),
   }),
   async execute({ cwd }) {
-    try {
-      const { stdout } = await execFileAsync('git', ['status', '--short'], { cwd: cwd ?? process.cwd() });
-      return { status: stdout.trim() || '(clean working tree)', isGitRepo: true };
-    } catch {
+    const result = await runGit(['status', '--short'], cwd);
+    if (result.exitCode !== 0) {
       return { status: 'Not a git repository', isGitRepo: false };
     }
+    return { status: result.stdout.trim() || '(clean working tree)', isGitRepo: true };
   },
 });


### PR DESCRIPTION
## Summary
- New `git-common.ts` with `runGit()` — structured result, consistent options
- 30s timeout, 1MB max buffer, non-throwing (returns exitCode)
- Refactored `git_status` to use `runGit()` — removes `execFile` boilerplate
- Other git tools can adopt incrementally

## Test plan
- [x] `npx turbo run build --force` passes (17/17)