### PR TITLE
feat: compaction timeout — 30s abort for summarization (v3 PR 38/100)

### DIFF
--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -103,6 +103,7 @@ export async function compactContext(
         model: summarizeModel,
         system: 'Summarize this conversation concisely. Preserve: key decisions, file paths mentioned, errors encountered, and current task context. Be brief.',
         messages: [{ role: 'user' as const, content: oldText }],
+        abortSignal: AbortSignal.timeout(30_000),
       });
 
       let summaryText = '';


### PR DESCRIPTION
## Summary
- Add `abortSignal: AbortSignal.timeout(30_000)` to compaction `streamText()` call
- If summarization exceeds 30s, abort triggers catch block which falls back to `fallbackSummary()`
- Prevents compaction from hanging indefinitely on slow/unresponsive models

## Test plan
- [x] `npx turbo run build --force` passes (17/17)