### PR TITLE
feat: transaction rollback reporting with partial details (v3 PR 39/100)

### DIFF
--- a/packages/tools/src/builtin/transaction.ts
+++ b/packages/tools/src/builtin/transaction.ts
@@ -87,21 +87,41 @@ export const rollbackTransactionTool = defineTool({
     const cp = getCheckpointManager();
     const reverted: string[] = [];
 
+    const failed: Array<{ file: string; error: string }> = [];
+
     if (cp) {
       // Revert files in reverse order (last written first)
       for (const file of [...transactionFiles].reverse()) {
-        const result = cp.revertLast(file);
-        if (result) reverted.push(result);
+        try {
+          const result = cp.revertLast(file);
+          if (result) {
+            reverted.push(result);
+          } else {
+            failed.push({ file, error: 'No checkpoint snapshot available' });
+          }
+        } catch (e: any) {
+          failed.push({ file, error: e.message ?? String(e) });
+        }
+      }
+    } else {
+      // No checkpoint manager — all files fail
+      for (const file of transactionFiles) {
+        failed.push({ file, error: 'CheckpointManager not initialized' });
       }
     }
 
     transactionActive = false;
     transactionFiles = [];
 
+    const partialRollback = failed.length > 0 && reverted.length > 0;
+
     return {
-      success: true,
+      success: failed.length === 0,
       filesReverted: reverted,
+      filesFailed: failed,
       count: reverted.length,
+      total: reverted.length + failed.length,
+      partialRollback,
       reason,
     };
   },


### PR DESCRIPTION
## Summary
- Track per-file revert success/failure during `rollback_transaction`
- Return `filesFailed` array with file path and error message
- Add `partialRollback` flag when some files reverted but others failed
- Handle missing CheckpointManager (all files reported as failed)
- Wrap individual revert calls in try/catch for resilience

## Test plan
- [x] `npx turbo run build --force` passes (17/17)