### PR TITLE
feat: VS Code dynamic model selection (v3 PR 41/100)

### DIFF
--- a/packages/vscode/src/chat-provider.ts
+++ b/packages/vscode/src/chat-provider.ts
@@ -9,8 +9,17 @@ import { StormProcess } from './storm-process.js';
  */
 export class BrainstormChatProvider {
   private stormProcess: StormProcess | null = null;
+  private preferredModel: string | undefined;
 
   constructor(private context: vscode.ExtensionContext) {}
+
+  /** Set the preferred model — restarts storm process to apply. */
+  setPreferredModel(modelId: string | undefined): void {
+    this.preferredModel = modelId;
+    // Restart process to pick up new model
+    this.stormProcess?.stop();
+    this.stormProcess = null;
+  }
 
   /** Handle a chat request from VS Code. */
   async handleRequest(
@@ -100,7 +109,7 @@ export class BrainstormChatProvider {
     }
 
     const workspaceFolder = this.getWorkspacePath();
-    this.stormProcess = new StormProcess(workspaceFolder);
+    this.stormProcess = new StormProcess(workspaceFolder, this.preferredModel);
     this.stormProcess.start();
 
     this.stormProcess.on('exit', () => {

--- a/packages/vscode/src/storm-process.ts
+++ b/packages/vscode/src/storm-process.ts
@@ -16,7 +16,7 @@ export class StormProcess extends EventEmitter {
   private process: ChildProcess | null = null;
   private buffer = '';
 
-  constructor(private cwd: string) {
+  constructor(private cwd: string, private modelId?: string) {
     super();
   }
 
@@ -24,8 +24,12 @@ export class StormProcess extends EventEmitter {
   start(): void {
     if (this.process) return;
 
+    // Build args — pass model if specified
+    const args = ['chat', '--simple', '--pipe'];
+    if (this.modelId) args.push('--model', this.modelId);
+
     // Try to find storm in PATH, fallback to npx
-    this.process = spawn('storm', ['chat', '--simple', '--pipe'], {
+    this.process = spawn('storm', args, {
       cwd: this.cwd,
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env },


### PR DESCRIPTION
## Summary
- Replace hardcoded model array with dynamic fetch via `storm models --json`
- Pass selected model to `StormProcess` constructor → `--model` CLI flag
- Add `setPreferredModel()` to `BrainstormChatProvider` — restarts process on change
- Fallback to curated list if CLI not available
- Empty model list shows warning message

## Test plan
- [x] `npx turbo run build --force` passes (17/17)