### PR TITLE
feat: prompt hook type handling with warning (v3 PR 42/100)

### DIFF
--- a/packages/hooks/src/manager.ts
+++ b/packages/hooks/src/manager.ts
@@ -125,8 +125,17 @@ export class HookManager {
 
           if (blocked) break; // Stop processing further hooks
         }
+      } else if (hook.type === 'prompt') {
+        // Prompt hooks require an LLM call — log warning until implemented
+        log.warn({ hookId, event }, 'Prompt hook type not yet implemented — skipping. Use "command" type instead.');
+        results.push({
+          hookId,
+          event,
+          success: false,
+          error: 'Prompt hook type not yet implemented. Use "command" type for now.',
+          durationMs: Date.now() - start,
+        });
       }
-      // 'prompt' type hooks would invoke an LLM — deferred to future PR
     }
 
     return results;


### PR DESCRIPTION
## Summary
- Replace silent comment with explicit `prompt` type handling in `fire()`
- Return structured error result with guidance to use `command` type
- Log warning via `createLogger('hooks')` on each prompt hook attempt
- Keep `prompt` in `HookType` union for forward compatibility

## Test plan
- [x] `npx turbo run build --force` passes (17/17)