### PR TITLE
feat: enhanced error messages with recovery guidance (v3 PR 43/100)

### DIFF
--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -51,7 +51,23 @@ function enrichError(error: any, modelId: string): Error {
     return error;
   }
   if (status === 401 || msg.includes('Unauthorized')) {
-    error.message = `Authentication failed. Check: storm vault status`;
+    error.message = `Authentication failed. Run: storm vault status\nThen: storm vault set BRAINSTORM_API_KEY <your-key>`;
+    return error;
+  }
+  if (msg.includes('No models available')) {
+    error.message = `No models available. Try:\n  1. storm models — check discovered models\n  2. Ensure Ollama/LM Studio is running for local models\n  3. Set BRAINSTORM_API_KEY for cloud models via BrainstormRouter`;
+    return error;
+  }
+  if (msg.includes('Budget exceeded') || error.name === 'BudgetExceededError') {
+    error.message = `${msg}\n\nTo continue:\n  1. storm budget — view current usage\n  2. Increase limit in ~/.brainstorm/config.toml [budget] section\n  3. Or start a new session: storm chat --new`;
+    return error;
+  }
+  if (msg.includes('blocked') || msg.includes('Sandbox blocked')) {
+    error.message = `${msg}\n\nIf this command is safe, adjust sandbox level in config.toml:\n  [shell]\n  sandbox = "none"`;
+    return error;
+  }
+  if (msg.includes('No active session')) {
+    error.message = `No active session. Start one with: storm chat\nOr resume the last session: storm chat --resume`;
     return error;
   }
 


### PR DESCRIPTION
## Summary
- **No models**: Lists 3 recovery steps (check models, start local provider, set API key)
- **Budget exceeded**: Shows budget command, config path, and new session option
- **Command blocked**: Points to sandbox config in config.toml
- **No active session**: Shows chat and resume commands
- **Auth failed**: Now includes vault set command in addition to status

## Test plan
- [x] `npx turbo run build --force` passes (17/17)