### PR TITLE
feat: stream timeout logging + trajectory recording (v3 PR 44/100)

### DIFF
--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -337,6 +337,17 @@ export async function* runAgentLoop(
         // Detect hung streams: if no event for 60s, break out
         const now = Date.now();
         if (now - lastEventTime > STREAM_TIMEOUT_MS && textDeltaCount === 0 && toolCallCount === 0) {
+          const elapsed = now - sessionStartTime;
+          log.warn({
+            model: decision.model.id,
+            elapsedMs: elapsed,
+            lastEventAgo: now - lastEventTime,
+            textDeltas: textDeltaCount,
+            toolCalls: toolCallCount,
+          }, 'Stream timeout — no events received, breaking out');
+          if (trajectory) {
+            trajectory.recordError({ message: `Stream timeout after ${elapsed}ms`, model: decision.model.id });
+          }
           break; // Fall through to empty detection + retry
         }
         lastEventTime = now;


### PR DESCRIPTION
## Summary
- Log structured warning on stream timeout: model, elapsed, lastEventAgo, counters
- Record timeout as trajectory error via `recordError()`
- Helps diagnose which models are hanging and how long before timeout fires

## Test plan
- [x] `npx turbo run build --force` passes (17/17)