### PR TITLE
feat: cost per turn in TUI footer (v3 PR 49/100)

### DIFF
--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -1189,6 +1189,7 @@ program
 
         sessionManager.addUserMessage(input);
         let fullResponse = '';
+        const sessionTotalBefore = costTracker.getSessionCost();
         process.stdout.write('\nbrainstorm > ');
         simpleAbortController = new AbortController();
 
@@ -1239,9 +1240,12 @@ program
             case 'interrupted':
               process.stdout.write('\n  [interrupted]\n\n');
               break;
-            case 'done':
-              process.stdout.write(`\n  [$${event.totalCost.toFixed(4)}]\n\n`);
+            case 'done': {
+              const turn = sessionManager.getTurnCount();
+              const turnCost = event.totalCost - (sessionTotalBefore ?? 0);
+              process.stdout.write(`\n  [Turn ${turn}: $${turnCost.toFixed(4)} | Session: $${event.totalCost.toFixed(4)}]\n\n`);
               break;
+            }
             case 'error':
               process.stderr.write(`\n  Error: ${event.error.message}\n\n`);
               break;


### PR DESCRIPTION
## Summary
- Show `[Turn N: $X | Session: $Y]` after each response in simple mode
- Track `sessionTotalBefore` per turn to compute delta cost
- Replaces bare `[$0.0123]` with more informative turn + session breakdown

## Test plan
- [x] `npx turbo run build --force` passes (17/17)