### PR TITLE
feat: add typecheck step to CI pipeline (v3 PR 51/100)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Type check
+        run: npx turbo run typecheck
+
       - name: Build all packages
         run: npx turbo run build
 


### PR DESCRIPTION
## Summary
- Add `npx turbo run typecheck` step to `.github/workflows/ci.yml`
- Runs before build step to catch type errors early
- Turbo task and `tsc --noEmit` scripts already exist in all packages

## Test plan
- [x] `npx turbo run build --force` passes (17/17)