### PR TITLE
test: shell sandbox tests — 19 cases (v3 PR 54/100)

### DIFF
--- a/packages/tools/src/__tests__/shell-sandbox.test.ts
+++ b/packages/tools/src/__tests__/shell-sandbox.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { checkSandbox } from "../builtin/sandbox";
+
+describe("checkSandbox", () => {
+  describe("none level", () => {
+    it("allows everything", () => {
+      expect(checkSandbox("rm -rf /", "none").allowed).toBe(true);
+    });
+  });
+
+  describe("restricted — blocked patterns", () => {
+    it("blocks rm -rf /", () => {
+      expect(checkSandbox("rm -rf /", "restricted").allowed).toBe(false);
+    });
+    it("blocks sudo", () => {
+      expect(checkSandbox("sudo apt install foo", "restricted").allowed).toBe(
+        false,
+      );
+    });
+    it("blocks shutdown", () => {
+      expect(checkSandbox("shutdown -h now", "restricted").allowed).toBe(false);
+    });
+    it("blocks reboot", () => {
+      expect(checkSandbox("reboot", "restricted").allowed).toBe(false);
+    });
+    it("blocks mkfs", () => {
+      expect(checkSandbox("mkfs.ext4 /dev/sda1", "restricted").allowed).toBe(
+        false,
+      );
+    });
+    it("blocks chmod 777", () => {
+      expect(checkSandbox("chmod 777 /tmp/file", "restricted").allowed).toBe(
+        false,
+      );
+    });
+    it("blocks git filter-branch", () => {
+      expect(
+        checkSandbox("git filter-branch --force HEAD", "restricted").allowed,
+      ).toBe(false);
+    });
+    it("blocks dd if=", () => {
+      expect(
+        checkSandbox("dd if=/dev/zero of=/dev/sda", "restricted").allowed,
+      ).toBe(false);
+    });
+  });
+
+  describe("restricted — chained commands", () => {
+    it("blocks sudo after semicolon", () => {
+      expect(checkSandbox("echo hi; sudo whoami", "restricted").allowed).toBe(
+        false,
+      );
+    });
+    it("blocks sudo after &&", () => {
+      expect(
+        checkSandbox("npm install && sudo whoami", "restricted").allowed,
+      ).toBe(false);
+    });
+    it("blocks sudo in $() subshell", () => {
+      expect(checkSandbox("echo $(sudo whoami)", "restricted").allowed).toBe(
+        false,
+      );
+    });
+    it("blocks sudo in backticks", () => {
+      expect(checkSandbox("echo `sudo whoami`", "restricted").allowed).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("restricted — allowed commands", () => {
+    it("allows ls", () => {
+      expect(checkSandbox("ls -la", "restricted").allowed).toBe(true);
+    });
+    it("allows npm install", () => {
+      expect(checkSandbox("npm install", "restricted").allowed).toBe(true);
+    });
+    it("allows git status", () => {
+      expect(checkSandbox("git status", "restricted").allowed).toBe(true);
+    });
+    it("allows git commit", () => {
+      expect(checkSandbox('git commit -m "test"', "restricted").allowed).toBe(
+        true,
+      );
+    });
+    it("allows node execution", () => {
+      expect(
+        checkSandbox("node dist/brainstorm.js", "restricted").allowed,
+      ).toBe(true);
+    });
+  });
+
+  describe("container level falls back to restricted", () => {
+    it("blocks sudo in container mode", () => {
+      expect(checkSandbox("sudo whoami", "container").allowed).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- 19 test cases for `checkSandbox()` function
- Blocked patterns: rm -rf, sudo, shutdown, reboot, mkfs, chmod 777, dd, git filter-branch
- Chained commands: semicolons, &&, $() subshells, backticks
- Allowed: ls, npm, git status/commit, node
- Container mode fallback to restricted

## Test plan
- [x] `npx vitest run` — 19/19 pass
- [x] `npx turbo run build --force` — 17/17 pass