### PR TITLE
feat: 1Password op read cache — 30min TTL (v3 PR 60/100)

### DIFF
--- a/packages/vault/src/backends/op-cli.ts
+++ b/packages/vault/src/backends/op-cli.ts
@@ -1,7 +1,7 @@
-import { execFileSync } from 'node:child_process';
+import { execFileSync } from "node:child_process";
 
 /** Default 1Password vault name. Override via config: vault.op_vault_name */
-const DEFAULT_OP_VAULT = 'Personal';
+const DEFAULT_OP_VAULT = "Personal";
 
 /** Cached result of op availability check (stable for process lifetime). */
 let opAvailableCache: boolean | null = null;
@@ -14,7 +14,7 @@ export function isOpAvailable(): boolean {
     return false;
   }
   try {
-    execFileSync('op', ['--version'], { timeout: 3000, stdio: 'pipe' });
+    execFileSync("op", ["--version"], { timeout: 3000, stdio: "pipe" });
     opAvailableCache = true;
   } catch {
     opAvailableCache = false;
@@ -22,22 +22,41 @@ export function isOpAvailable(): boolean {
   return opAvailableCache;
 }
 
+/** TTL cache for op read results — avoids shelling out on every call. */
+const OP_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const opCache = new Map<string, { value: string | null; fetchedAt: number }>();
+
 /**
  * Read a credential from 1Password via `op read`.
  * Maps key names to 1Password item paths:
  *   BRAINSTORM_API_KEY → op://vaultName/BRAINSTORM_API_KEY/credential
+ *
+ * Results are cached for 30 minutes to avoid repeated subprocess calls.
  */
 export function opRead(keyName: string, vaultName?: string): string | null {
   if (!isOpAvailable()) return null;
+
+  const cacheKey = `${vaultName ?? "_default"}:${keyName}`;
+  const cached = opCache.get(cacheKey);
+  if (cached && Date.now() - cached.fetchedAt < OP_CACHE_TTL_MS) {
+    return cached.value;
+  }
+
   try {
-    const vault = vaultName ?? process.env.BRAINSTORM_OP_VAULT ?? DEFAULT_OP_VAULT;
+    const vault =
+      vaultName ?? process.env.BRAINSTORM_OP_VAULT ?? DEFAULT_OP_VAULT;
     const ref = `op://${vault}/${keyName}/credential`;
-    const value = execFileSync('op', ['read', ref], {
+    const value = execFileSync("op", ["read", ref], {
       timeout: 10000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).toString().trim();
-    return value || null;
+      stdio: ["pipe", "pipe", "pipe"],
+    })
+      .toString()
+      .trim();
+    const result = value || null;
+    opCache.set(cacheKey, { value: result, fetchedAt: Date.now() });
+    return result;
   } catch {
+    opCache.set(cacheKey, { value: null, fetchedAt: Date.now() });
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- Cache `op read` results for 30 minutes (avoids subprocess per key lookup)
- Cache key: `vault:keyName` for multi-vault support
- Failed reads cached too (prevents retry storms on missing keys)