### PR TITLE
feat: NL parser suggestions on failure (v3 PR 66/100)

### DIFF
--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -1,5 +1,23 @@
-export { AgentRepository } from './repository.js';
-export { AgentManager } from './manager.js';
-export { implementationSpec, codeChanges, reviewResult, debugResult, OUTPUT_SCHEMAS, getOutputSchema } from './schemas.js';
-export { buildAgentSystemPrompt, DECOMPOSITION_PROMPT, decompositionToWorkflow, type Subtask, type DecompositionResult } from './prompts.js';
-export { parseAgentNL, resolveModelAlias, type AgentCreationIntent } from './nl-parser.js';
+export { AgentRepository } from "./repository.js";
+export { AgentManager } from "./manager.js";
+export {
+  implementationSpec,
+  codeChanges,
+  reviewResult,
+  debugResult,
+  OUTPUT_SCHEMAS,
+  getOutputSchema,
+} from "./schemas.js";
+export {
+  buildAgentSystemPrompt,
+  DECOMPOSITION_PROMPT,
+  decompositionToWorkflow,
+  type Subtask,
+  type DecompositionResult,
+} from "./prompts.js";
+export {
+  parseAgentNL,
+  resolveModelAlias,
+  type AgentCreationIntent,
+  type ParseResult,
+} from "./nl-parser.js";

--- a/packages/agents/src/nl-parser.ts
+++ b/packages/agents/src/nl-parser.ts
@@ -1,4 +1,4 @@
-import type { AgentRole } from '@brainstorm/shared';
+import type { AgentRole } from "@brainstorm/shared";
 
 /** Parsed agent creation intent from natural language. */
 export interface AgentCreationIntent {
@@ -14,31 +14,31 @@ export interface AgentCreationIntent {
 
 // Model name shortcuts → full model IDs
 const MODEL_ALIASES: Record<string, string> = {
-  'opus': 'anthropic/claude-opus-4-6',
-  'sonnet': 'anthropic/claude-sonnet-4-5-20250620',
-  'haiku': 'anthropic/claude-haiku-4-5-20251001',
-  'gpt': 'openai/gpt-4.1',
-  'gpt-5': 'openai/gpt-5.4',
-  'gpt-5.4': 'openai/gpt-5.4',
-  'gpt-4.1': 'openai/gpt-4.1',
-  'gpt-4.1-mini': 'openai/gpt-4.1-mini',
-  'gemini': 'google/gemini-2.5-flash',
-  'flash': 'google/gemini-2.5-flash',
-  'deepseek': 'deepseek/deepseek-chat',
-  'o3': 'openai/o3-mini',
-  'local': 'auto:local',
-  'cheap': 'auto:price',
-  'best': 'auto:quality',
+  opus: "anthropic/claude-opus-4-6",
+  sonnet: "anthropic/claude-sonnet-4-5-20250620",
+  haiku: "anthropic/claude-haiku-4-5-20251001",
+  gpt: "openai/gpt-4.1",
+  "gpt-5": "openai/gpt-5.4",
+  "gpt-5.4": "openai/gpt-5.4",
+  "gpt-4.1": "openai/gpt-4.1",
+  "gpt-4.1-mini": "openai/gpt-4.1-mini",
+  gemini: "google/gemini-2.5-flash",
+  flash: "google/gemini-2.5-flash",
+  deepseek: "deepseek/deepseek-chat",
+  o3: "openai/o3-mini",
+  local: "auto:local",
+  cheap: "auto:price",
+  best: "auto:quality",
 };
 
 // Role detection patterns
 const ROLE_PATTERNS: Array<{ pattern: RegExp; role: AgentRole }> = [
-  { pattern: /\b(architect|planner|designer)\b/i, role: 'architect' },
-  { pattern: /\b(coder|developer|programmer|implementer)\b/i, role: 'coder' },
-  { pattern: /\b(reviewer|auditor|checker)\b/i, role: 'reviewer' },
-  { pattern: /\b(debugger|fixer|troubleshooter)\b/i, role: 'debugger' },
-  { pattern: /\b(analyst|explainer|advisor)\b/i, role: 'analyst' },
-  { pattern: /\b(marketer|writer|copywriter|content)\b/i, role: 'custom' },
+  { pattern: /\b(architect|planner|designer)\b/i, role: "architect" },
+  { pattern: /\b(coder|developer|programmer|implementer)\b/i, role: "coder" },
+  { pattern: /\b(reviewer|auditor|checker)\b/i, role: "reviewer" },
+  { pattern: /\b(debugger|fixer|troubleshooter)\b/i, role: "debugger" },
+  { pattern: /\b(analyst|explainer|advisor)\b/i, role: "analyst" },
+  { pattern: /\b(marketer|writer|copywriter|content)\b/i, role: "custom" },
 ];
 
 /**
@@ -51,12 +51,17 @@ const ROLE_PATTERNS: Array<{ pattern: RegExp; role: AgentRole }> = [
  * - "marketer with $10 budget and PII guardrails"
  * - "reviewer using sonnet with $50 daily budget"
  */
-export function parseAgentNL(input: string): AgentCreationIntent | null {
+export interface ParseResult {
+  intent: AgentCreationIntent | null;
+  suggestion?: string;
+}
+
+export function parseAgentNL(input: string): ParseResult {
   const lower = input.toLowerCase().trim();
 
   // Extract role (first word or pattern match)
-  let role: AgentRole = 'custom';
-  let id = 'agent';
+  let role: AgentRole = "custom";
+  let id = "agent";
   for (const { pattern, role: r } of ROLE_PATTERNS) {
     const match = lower.match(pattern);
     if (match) {
@@ -67,8 +72,10 @@ export function parseAgentNL(input: string): AgentCreationIntent | null {
   }
 
   // Extract model
-  let modelId = 'auto:quality'; // default to best available
-  const modelMatch = lower.match(/\b(?:using|with model|model)\s+([a-z0-9._-]+)/);
+  let modelId = "auto:quality"; // default to best available
+  const modelMatch = lower.match(
+    /\b(?:using|with model|model)\s+([a-z0-9._-]+)/,
+  );
   if (modelMatch) {
     const alias = modelMatch[1];
     modelId = MODEL_ALIASES[alias] ?? alias;
@@ -76,7 +83,9 @@ export function parseAgentNL(input: string): AgentCreationIntent | null {
 
   // Extract budget (per-workflow)
   let budget: number | undefined;
-  const budgetMatch = lower.match(/\$(\d+(?:\.\d+)?)\s*(?:budget|per.?workflow)?/);
+  const budgetMatch = lower.match(
+    /\$(\d+(?:\.\d+)?)\s*(?:budget|per.?workflow)?/,
+  );
   if (budgetMatch) {
     budget = parseFloat(budgetMatch[1]);
   }
@@ -100,25 +109,36 @@ export function parseAgentNL(input: string): AgentCreationIntent | null {
 
   // Extract description (anything after "that" or "it should" or "to")
   let description: string | undefined;
-  const descMatch = input.match(/(?:that|it should|should|to)\s+(.+?)(?:\s+(?:with|using|and \$)|\s*$)/i);
+  const descMatch = input.match(
+    /(?:that|it should|should|to)\s+(.+?)(?:\s+(?:with|using|and \$)|\s*$)/i,
+  );
   if (descMatch) {
     description = descMatch[1].trim();
   }
 
   // Require at least a role or model to consider this a valid parse
-  if (role === 'custom' && modelId === 'auto:quality' && !budget) {
-    return null; // Not enough signal to parse
+  if (role === "custom" && modelId === "auto:quality" && !budget) {
+    const availableRoles = ROLE_PATTERNS.map((p) => p.role).filter(
+      (r) => r !== "custom",
+    );
+    const availableModels = Object.keys(MODEL_ALIASES).slice(0, 6);
+    return {
+      intent: null,
+      suggestion: `Try: "<role> using <model> with $<budget> budget"\n  Roles: ${availableRoles.join(", ")}\n  Models: ${availableModels.join(", ")}`,
+    };
   }
 
   return {
-    id,
-    role,
-    modelId,
-    budget,
-    budgetDaily,
-    description,
-    guardrailsPii,
-    expiresInDays,
+    intent: {
+      id,
+      role,
+      modelId,
+      budget,
+      budgetDaily,
+      description,
+      guardrailsPii,
+      expiresInDays,
+    },
   };
 }
 

--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -519,7 +519,15 @@ agentCmd
 
     // Try natural language first
     const nlInput = descWords.join(" ");
-    const parsed = nlInput ? parseAgentNL(nlInput) : null;
+    const parseResult = nlInput ? parseAgentNL(nlInput) : null;
+    const parsed = parseResult?.intent;
+
+    if (nlInput && !parsed && parseResult?.suggestion) {
+      console.log(
+        `  Could not parse agent definition.\n  ${parseResult.suggestion}`,
+      );
+      process.exit(1);
+    }
 
     const id = opts.id ?? parsed?.id ?? "agent-" + Date.now().toString(36);
     const role = opts.role ?? parsed?.role ?? "custom";


### PR DESCRIPTION
## Summary
- Return `ParseResult { intent, suggestion? }` instead of `AgentCreationIntent | null`
- On parse failure, include suggestion with available roles + model aliases
- CLI shows suggestion and exits instead of creating agent with defaults