### PR TITLE
feat: MCP re-enabled with validated schemas (v3 PR 72/100)

### DIFF
--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -107,9 +107,9 @@ async function connectMCPServers(
     );
   }
 
-  // BrainstormRouter intelligence tools are now built-in natively
-  // (br_status, br_budget, br_leaderboard, etc.) — no MCP needed.
-  // MCP connection disabled to avoid schema compatibility issues.
+  // BrainstormRouter intelligence tools are built-in natively
+  // (br_status, br_budget, etc.). MCP is used for user-configured servers.
+  // Tool definitions are validated before registration (see mcp/client.ts).
 
   const { connected, errors } = await mcp.connectAll(tools);
   if (connected.length > 0) {


### PR DESCRIPTION
## Summary
- Clarify MCP is fully re-enabled with Zod-validated tool definitions (from PR 16)
- Remove misleading "MCP connection disabled" comment
- User-configured servers and toolFilter config fully wired through

## Test plan
- [ ] Verify build passes
- [ ] MCP servers from config.toml connect successfully