### PR TITLE
feat: final hardening batch (v3 PRs 91-100/100)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,32 @@
+name: E2E Tests
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Weekly on Monday at 6 AM UTC
+  workflow_dispatch: # Manual trigger
+
+jobs:
+  e2e:
+    if: github.event_name == 'workflow_dispatch' || github.event.schedule
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - run: npm ci
+
+      - run: npx turbo run build
+
+      - name: Run E2E tests
+        run: npx turbo run test -- --reporter=verbose
+        env:
+          E2E: "1"
+          BRAINSTORM_API_KEY: ${{ secrets.BRAINSTORM_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -939,13 +939,31 @@ program
         switch (event.type) {
           case "thinking":
             if (!opts.json) {
+              const spinnerFrames = [
+                "⠋",
+                "⠙",
+                "⠹",
+                "⠸",
+                "⠼",
+                "⠴",
+                "⠦",
+                "⠧",
+                "⠇",
+                "⠏",
+              ];
+              const frame =
+                spinnerFrames[
+                  Math.floor(Date.now() / 100) % spinnerFrames.length
+                ];
               const phases: Record<string, string> = {
                 classifying: "Classifying task...",
                 routing: "Selecting model...",
                 connecting: `Connecting...`,
                 streaming: "Streaming...",
               };
-              process.stderr.write(`\r${phases[event.phase] ?? event.phase}`);
+              process.stderr.write(
+                `\r${frame} ${phases[event.phase] ?? event.phase}`,
+              );
             }
             break;
           case "routing":

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -38,6 +38,7 @@ const compactionSchema = z.object({
 const shellSchema = z.object({
   defaultTimeout: z.number().default(120_000),
   maxOutputBytes: z.number().default(50_000),
+  // none: no restrictions, restricted: block dangerous commands, container: Docker sandbox (future)
   sandbox: z.enum(["none", "restricted", "container"]).default("none"),
 });
 

--- a/packages/core/src/session/manager.ts
+++ b/packages/core/src/session/manager.ts
@@ -1,10 +1,14 @@
-import { SessionRepository, MessageRepository } from '@brainstorm/db';
-import type { Session, TurnContext } from '@brainstorm/shared';
-import { formatTurnContext } from '@brainstorm/shared';
-import { estimateTokenCount, needsCompaction, compactContext } from './compaction.js';
+import { SessionRepository, MessageRepository } from "@brainstorm/db";
+import type { Session, TurnContext } from "@brainstorm/shared";
+import { formatTurnContext } from "@brainstorm/shared";
+import {
+  estimateTokenCount,
+  needsCompaction,
+  compactContext,
+} from "./compaction.js";
 
 export interface ConversationMessage {
-  role: 'user' | 'assistant' | 'system';
+  role: "user" | "assistant" | "system";
   content: string;
 }
 
@@ -38,9 +42,9 @@ export class SessionManager {
     // Lazy load: only keep last 50 messages in memory (older available on demand via DB)
     const msgs = this.messages.listBySessionRecent(sessionId, 50);
     this.conversationHistory = msgs
-      .filter((m) => m.role !== 'tool')
+      .filter((m) => m.role !== "tool")
       .map((m) => ({
-        role: m.role as 'user' | 'assistant' | 'system',
+        role: m.role as "user" | "assistant" | "system",
         content: m.content,
       }));
     this.cachedTokenCount = null; // Force recount after resume
@@ -69,15 +73,21 @@ export class SessionManager {
 
     // Copy all messages to the new session
     for (const m of msgs) {
-      this.messages.create(forked.id, m.role, m.content, m.modelId, m.tokenCount);
+      this.messages.create(
+        forked.id,
+        m.role,
+        m.content,
+        m.modelId,
+        m.tokenCount,
+      );
     }
 
     // Set as current session
     this.currentSession = forked;
     this.conversationHistory = msgs
-      .filter((m) => m.role !== 'tool')
+      .filter((m) => m.role !== "tool")
       .map((m) => ({
-        role: m.role as 'user' | 'assistant' | 'system',
+        role: m.role as "user" | "assistant" | "system",
         content: m.content,
       }));
 
@@ -85,25 +95,25 @@ export class SessionManager {
   }
 
   addUserMessage(content: string): void {
-    if (!this.currentSession) throw new Error('No active session');
-    this.messages.create(this.currentSession.id, 'user', content);
+    if (!this.currentSession) throw new Error("No active session");
+    this.messages.create(this.currentSession.id, "user", content);
     this.sessions.incrementMessages(this.currentSession.id);
-    this.conversationHistory.push({ role: 'user', content });
+    this.conversationHistory.push({ role: "user", content });
     this.addTokenDelta(content);
   }
 
   addAssistantMessage(content: string, modelId?: string): void {
-    if (!this.currentSession) throw new Error('No active session');
-    this.messages.create(this.currentSession.id, 'assistant', content, modelId);
+    if (!this.currentSession) throw new Error("No active session");
+    this.messages.create(this.currentSession.id, "assistant", content, modelId);
     this.sessions.incrementMessages(this.currentSession.id);
-    this.conversationHistory.push({ role: 'assistant', content });
+    this.conversationHistory.push({ role: "assistant", content });
     this.addTokenDelta(content);
   }
 
   /** Inject turn context as an invisible system message the model sees but the user doesn't. */
   addTurnContext(ctx: TurnContext): void {
     const summary = formatTurnContext(ctx);
-    this.conversationHistory.push({ role: 'system', content: summary });
+    this.conversationHistory.push({ role: "system", content: summary });
     this.addTokenDelta(summary);
   }
 
@@ -112,6 +122,12 @@ export class SessionManager {
     if (this.cachedTokenCount !== null) {
       this.cachedTokenCount += Math.ceil((content.length + 20) / 4);
     }
+  }
+
+  /** Sync session cost to DB. Call after each tool to keep DB accurate. */
+  syncSessionCost(cost: number): void {
+    if (!this.currentSession) return;
+    this.sessions.updateCost(this.currentSession.id, cost);
   }
 
   getTurnCount(): number {
@@ -153,7 +169,13 @@ export class SessionManager {
     contextWindow: number;
     keepRecent?: number;
     summarizeModel?: any;
-  }): Promise<{ compacted: boolean; removed: number; tokensBefore: number; tokensAfter: number; summaryCost: number }> {
+  }): Promise<{
+    compacted: boolean;
+    removed: number;
+    tokensBefore: number;
+    tokensAfter: number;
+    summaryCost: number;
+  }> {
     const tokensBefore = estimateTokenCount(this.conversationHistory);
     const result = await compactContext(this.conversationHistory, options);
 
@@ -163,9 +185,21 @@ export class SessionManager {
       // Invalidate cache — full recount after compaction
       this.cachedTokenCount = null;
       const tokensAfter = this.getTokenEstimate();
-      return { compacted: true, removed, tokensBefore, tokensAfter, summaryCost: result.summaryCost };
+      return {
+        compacted: true,
+        removed,
+        tokensBefore,
+        tokensAfter,
+        summaryCost: result.summaryCost,
+      };
     }
 
-    return { compacted: false, removed: 0, tokensBefore, tokensAfter: tokensBefore, summaryCost: 0 };
+    return {
+      compacted: false,
+      removed: 0,
+      tokensBefore,
+      tokensAfter: tokensBefore,
+      summaryCost: 0,
+    };
   }
 }

--- a/packages/tools/src/builtin/shell.ts
+++ b/packages/tools/src/builtin/shell.ts
@@ -42,21 +42,28 @@ interface BackgroundTask {
 
 const backgroundTasks = new Map<string, BackgroundTask>();
 let nextTaskId = 0;
-let backgroundEventHandler:
-  | ((event: {
-      taskId: string;
-      command: string;
-      exitCode: number;
-      stdout: string;
-      stderr: string;
-    }) => void)
-  | null = null;
 
-/** Set a callback for background task completion events. */
+type BackgroundEvent = {
+  taskId: string;
+  command: string;
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+let backgroundEventHandler: ((event: BackgroundEvent) => void) | null = null;
+const pendingEvents: BackgroundEvent[] = [];
+
+/** Set a callback for background task completion events. Replays any queued events. */
 export function setBackgroundEventHandler(
   handler: typeof backgroundEventHandler,
 ): void {
   backgroundEventHandler = handler;
+  // Replay any events that arrived before handler was registered
+  if (handler && pendingEvents.length > 0) {
+    for (const event of pendingEvents) handler(event);
+    pendingEvents.length = 0;
+  }
 }
 
 // ── Tool Output Streaming ──────────────────────────────────────
@@ -244,14 +251,17 @@ export const shellTool = defineTool({
         completed = true;
         clearTimeout(bgTimer);
         backgroundTasks.delete(taskId);
+        const event: BackgroundEvent = {
+          taskId,
+          command,
+          exitCode,
+          stdout: bgStdout.toString(),
+          stderr: stderr ?? bgStderr.toString(),
+        };
         if (backgroundEventHandler) {
-          backgroundEventHandler({
-            taskId,
-            command,
-            exitCode,
-            stdout: bgStdout.toString(),
-            stderr: stderr ?? bgStderr.toString(),
-          });
+          backgroundEventHandler(event);
+        } else {
+          pendingEvents.push(event);
         }
       };
 


### PR DESCRIPTION
## Summary — v3 Complete!

Final batch completing the 100-PR v3 tech debt + hardening plan:

- **PR 92**: Document container sandbox enum as future Docker support
- **PR 94**: Background event queue — buffers events, replays on handler registration
- **PR 95**: `syncSessionCost()` for per-tool DB sync
- **PR 96**: Weekly E2E test workflow with API key secrets
- **PR 98**: Spinner animation during thinking phases

Skipped (already done): PR 91, 93, 97, 99, 100

## v3 Summary
- 100 PRs planned, all addressed
- Security: shell sandbox hardening, CSRF, credential scanning, path guards
- Performance: caching (provider, gateway, classifier), lazy loading, incremental tokens
- UX: metrics CLI, spinner, budget warnings, permission denial messages
- Reliability: compaction gate, transaction deps, memory recovery, loop escalation
- Testing: integration tests, shell sandbox tests, E2E workflow

## Test plan
- [ ] Verify build passes
- [ ] E2E workflow triggers on manual dispatch