### PR TITLE
feat: Phase A wire dead code — Docker sandbox, subagent isolation, memory middleware (v4 PRs 2-4)

### DIFF
--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -20,6 +20,7 @@ import {
   PermissionManager,
   createSubagentTool,
   spawnSubagent,
+  createDefaultMiddlewarePipeline,
   type CompactionCallbacks,
 } from "@brainstorm/core";
 import type { OutputStyle } from "@brainstorm/core";
@@ -926,6 +927,7 @@ program
         process.stdout.write("\n");
       }
 
+      const middleware = createDefaultMiddlewarePipeline(projectPath);
       for await (const event of runAgentLoop(sessionManager.getHistory(), {
         config,
         registry,
@@ -941,6 +943,7 @@ program
         maxSteps: parseInt(opts.maxSteps ?? "1"),
         compaction: buildCompactionCallbacks(sessionManager),
         permissionCheck: (tool, args) => permissionManager.check(tool, args),
+        middleware,
       })) {
         switch (event.type) {
           case "thinking":
@@ -1497,6 +1500,7 @@ program
         (config.general.outputStyle as OutputStyle) ?? "concise";
 
       const sessionManager = new SessionManager(db);
+      const middleware = createDefaultMiddlewarePipeline(projectPath);
       let { prompt: systemPrompt, frontmatter } = buildSystemPrompt(
         projectPath,
         currentOutputStyle,
@@ -1673,6 +1677,7 @@ program
             permissionCheck: (name, perm) =>
               permissionManager.check(name, perm),
             preferredModelId,
+            middleware,
             onTurnComplete: (ctx) => {
               ctx.turn = sessionManager.incrementTurn();
               ctx.sessionMinutes = sessionManager.getSessionMinutes();
@@ -1785,6 +1790,7 @@ program
           compaction: buildCompactionCallbacks(sessionManager),
           signal: currentAbortController.signal,
           permissionCheck: (name, perm) => permissionManager.check(name, perm),
+          middleware,
           preferredModelId,
         });
         // Wrap to capture assistant message after completion

--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -7,7 +7,11 @@ import {
   isCommunityKey,
 } from "@brainstorm/providers";
 import { BrainstormRouter, CostTracker } from "@brainstorm/router";
-import { createDefaultToolRegistry, configureSandbox } from "@brainstorm/tools";
+import {
+  createDefaultToolRegistry,
+  configureSandbox,
+  stopDockerSandbox,
+} from "@brainstorm/tools";
 import {
   runAgentLoop,
   buildSystemPrompt,
@@ -884,6 +888,8 @@ program
         config.shell.sandbox as any,
         projectPath,
         config.shell.maxOutputBytes,
+        config.shell.containerImage,
+        config.shell.containerTimeout,
       );
       const { prompt: rawPrompt, frontmatter } = buildSystemPrompt(projectPath);
       const systemPrompt =
@@ -1476,6 +1482,8 @@ program
         config.shell.sandbox as any,
         projectPath,
         config.shell.maxOutputBytes,
+        config.shell.containerImage,
+        config.shell.containerTimeout,
       );
 
       // Permission manager — gates tool execution
@@ -1912,8 +1920,13 @@ program
   );
 
 export function run() {
-  // Graceful shutdown: finalize session, close DB, kill background tasks
+  // Graceful shutdown: stop Docker sandbox, close DB
   const cleanup = () => {
+    try {
+      stopDockerSandbox();
+    } catch {
+      // Best effort — container may already be stopped
+    }
     try {
       closeDb();
     } catch {

--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -1528,6 +1528,7 @@ program
         tools,
         projectPath,
         permissionCheck: (name, perm) => permissionManager.check(name, perm),
+        containerIsolation: config.shell.sandbox === "container",
       });
       tools.register(subagentTool);
 

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -38,8 +38,10 @@ const compactionSchema = z.object({
 const shellSchema = z.object({
   defaultTimeout: z.number().default(120_000),
   maxOutputBytes: z.number().default(50_000),
-  // none: no restrictions, restricted: block dangerous commands, container: Docker sandbox (future)
+  // none: no restrictions, restricted: block dangerous commands, container: Docker sandbox
   sandbox: z.enum(["none", "restricted", "container"]).default("none"),
+  containerImage: z.string().default("node:22-slim"),
+  containerTimeout: z.number().default(120_000),
 });
 
 // ── Budget Config ────────────────────────────────────────────────────

--- a/packages/core/src/agent/subagent.ts
+++ b/packages/core/src/agent/subagent.ts
@@ -2,7 +2,11 @@ import { streamText, stepCountIs } from "ai";
 import type { BrainstormConfig } from "@brainstorm/config";
 import type { ProviderRegistry } from "@brainstorm/providers";
 import { BrainstormRouter, CostTracker } from "@brainstorm/router";
-import type { ToolRegistry } from "@brainstorm/tools";
+import {
+  type ToolRegistry,
+  setDockerSandbox,
+  DockerSandbox,
+} from "@brainstorm/tools";
 import { serializeRoutingMetadata } from "@brainstorm/shared";
 
 // ── Subagent Types ──────────────────────────────────────────────────
@@ -157,6 +161,8 @@ export interface SubagentOptions {
     toolName: string,
     toolPermission: any,
   ) => "allow" | "confirm" | "deny";
+  /** When true and container mode is active, code subagents get their own DockerSandbox. */
+  containerIsolation?: boolean;
 }
 
 export interface SubagentResult {
@@ -232,6 +238,21 @@ export async function spawnSubagent(
   const budgetLimit = options.budgetLimit ?? costTracker.getSubagentBudget();
   const costBefore = costTracker.getSessionCost();
 
+  // Docker isolation: code subagents get their own container
+  let ownSandbox: DockerSandbox | null = null;
+  let prevSandbox: DockerSandbox | null = null;
+  if (
+    options.containerIsolation &&
+    type === "code" &&
+    DockerSandbox.isAvailable()
+  ) {
+    ownSandbox = new DockerSandbox({
+      hostWorkspace: projectPath,
+    });
+    ownSandbox.start();
+    prevSandbox = setDockerSandbox(ownSandbox);
+  }
+
   // Fire SubagentStart hook
   if (options.onHook) {
     await options.onHook("SubagentStart", {
@@ -301,6 +322,12 @@ export async function spawnSubagent(
   } catch (err: any) {
     // AbortError from budget enforcement is expected — not an error
     if (err.name !== "AbortError") throw err;
+  } finally {
+    // Clean up subagent's Docker sandbox and restore parent's
+    if (ownSandbox) {
+      ownSandbox.stop();
+      setDockerSandbox(prevSandbox);
+    }
   }
 
   if (budgetExceeded) {

--- a/packages/core/src/middleware/builtin/memory-extract.ts
+++ b/packages/core/src/middleware/builtin/memory-extract.ts
@@ -1,0 +1,172 @@
+import type { AgentMiddleware, MiddlewareMessage } from "../types.js";
+import { MemoryManager, type MemoryEntry } from "../../memory/manager.js";
+
+type MemoryType = MemoryEntry["type"];
+
+interface ExtractedFact {
+  type: MemoryType;
+  name: string;
+  description: string;
+  content: string;
+}
+
+// Patterns that signal user preferences (type: feedback)
+const PREFERENCE_PATTERNS: Array<{ pattern: RegExp; extract: string }> = [
+  {
+    pattern:
+      /(?:always|never|prefer|don't|do not)\s+(use|add|include|create|write)\s+(.{5,60})/i,
+    extract: "preference",
+  },
+  {
+    pattern: /(?:I|we)\s+(?:always|never|prefer to)\s+(.{5,60})/i,
+    extract: "preference",
+  },
+  {
+    pattern: /(?:please|going forward|from now on),?\s+(.{5,60})/i,
+    extract: "directive",
+  },
+];
+
+// Patterns that signal project conventions (type: project)
+const CONVENTION_PATTERNS: Array<{ pattern: RegExp; extract: string }> = [
+  {
+    pattern:
+      /(?:this project|codebase|repo)\s+(?:uses|requires|follows|has)\s+(.{5,60})/i,
+    extract: "convention",
+  },
+  {
+    pattern: /(?:convention|pattern|standard)\s+(?:is|here is)\s+(.{5,60})/i,
+    extract: "convention",
+  },
+  {
+    pattern: /(?:configured|set up)\s+(?:with|to use|for)\s+(.{5,60})/i,
+    extract: "setup",
+  },
+];
+
+// Patterns that signal error-fix pairs (type: reference)
+const ERROR_FIX_PATTERNS: Array<{ pattern: RegExp }> = [
+  { pattern: /(?:fixed|resolved|solved)\s+(?:by|with|via)\s+(.{10,100})/i },
+  {
+    pattern: /(?:the (?:fix|solution|workaround))\s+(?:is|was)\s+(.{10,100})/i,
+  },
+  {
+    pattern:
+      /error[:\s]+(.{10,80}).*?(?:fix|solution|resolved)[:\s]+(.{10,80})/is,
+  },
+];
+
+// Avoid extracting from these contexts (code blocks, tool calls, etc.)
+const SKIP_PATTERNS = [
+  /^```/m, // Inside code blocks
+  /^\s*[-*]\s+\*\*/m, // Markdown list with bold (likely tool output)
+];
+
+// Deduplicate: skip facts we've already extracted this session
+const extractedThisSession = new Set<string>();
+
+/**
+ * Create memory extraction middleware.
+ * Scans assistant responses for extractable facts via regex heuristics (no LLM call).
+ */
+export function createMemoryExtractionMiddleware(
+  projectPath: string,
+): AgentMiddleware {
+  let manager: MemoryManager | null = null;
+
+  const getManager = (): MemoryManager => {
+    if (!manager) manager = new MemoryManager(projectPath);
+    return manager;
+  };
+
+  return {
+    name: "memory-extraction",
+
+    afterModel(message: MiddlewareMessage): void {
+      const { text } = message;
+      if (!text || text.length < 20) return;
+
+      const facts = extractFacts(text);
+      if (facts.length === 0) return;
+
+      const mem = getManager();
+      for (const fact of facts) {
+        const key = `${fact.type}:${fact.name}`;
+        if (extractedThisSession.has(key)) continue;
+        extractedThisSession.add(key);
+
+        mem.save({
+          type: fact.type,
+          name: fact.name,
+          description: fact.description,
+          content: fact.content,
+        });
+      }
+    },
+  };
+}
+
+function extractFacts(text: string): ExtractedFact[] {
+  const facts: ExtractedFact[] = [];
+
+  // Strip code blocks to avoid false positives
+  const cleaned = text.replace(/```[\s\S]*?```/g, "");
+
+  // Extract user preferences
+  for (const { pattern } of PREFERENCE_PATTERNS) {
+    const match = cleaned.match(pattern);
+    if (match) {
+      const detail = (match[2] ?? match[1]).trim();
+      if (detail.length >= 5 && detail.length <= 100) {
+        facts.push({
+          type: "feedback",
+          name: `pref-${slugify(detail.slice(0, 30))}`,
+          description: `User preference: ${detail.slice(0, 80)}`,
+          content: detail,
+        });
+      }
+    }
+  }
+
+  // Extract project conventions
+  for (const { pattern } of CONVENTION_PATTERNS) {
+    const match = cleaned.match(pattern);
+    if (match) {
+      const detail = match[1].trim();
+      if (detail.length >= 5 && detail.length <= 100) {
+        facts.push({
+          type: "project",
+          name: `conv-${slugify(detail.slice(0, 30))}`,
+          description: `Project convention: ${detail.slice(0, 80)}`,
+          content: detail,
+        });
+      }
+    }
+  }
+
+  // Extract error-fix pairs
+  for (const { pattern } of ERROR_FIX_PATTERNS) {
+    const match = cleaned.match(pattern);
+    if (match) {
+      const detail = match[0].trim();
+      if (detail.length >= 15) {
+        facts.push({
+          type: "reference",
+          name: `fix-${slugify(detail.slice(0, 30))}`,
+          description: `Error fix: ${detail.slice(0, 80)}`,
+          content: detail,
+        });
+      }
+    }
+  }
+
+  return facts;
+}
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 30);
+}

--- a/packages/core/src/middleware/index.ts
+++ b/packages/core/src/middleware/index.ts
@@ -6,36 +6,41 @@ export type {
   MiddlewareToolCall,
   MiddlewareToolResult,
   MiddlewareBlock,
-} from './types.js';
-export { isBlocked } from './types.js';
+} from "./types.js";
+export { isBlocked } from "./types.js";
 
 // Pipeline
-export { MiddlewarePipeline } from './pipeline.js';
+export { MiddlewarePipeline } from "./pipeline.js";
 
 // Built-in middleware
-export { turnContextMiddleware } from './builtin/turn-context.js';
-export { toolHealthMiddleware } from './builtin/tool-health.js';
-export { buildStateMiddleware } from './builtin/build-state.js';
-export { loopDetectionMiddleware } from './builtin/loop-detection.js';
-export { sentimentMiddleware } from './builtin/sentiment.js';
-export { subagentLimitMiddleware } from './builtin/subagent-limit.js';
-export { trajectoryReductionMiddleware } from './builtin/trajectory-reduction.js';
-export { autoLintMiddleware } from './builtin/auto-lint.js';
+export { turnContextMiddleware } from "./builtin/turn-context.js";
+export { toolHealthMiddleware } from "./builtin/tool-health.js";
+export { buildStateMiddleware } from "./builtin/build-state.js";
+export { loopDetectionMiddleware } from "./builtin/loop-detection.js";
+export { sentimentMiddleware } from "./builtin/sentiment.js";
+export { subagentLimitMiddleware } from "./builtin/subagent-limit.js";
+export { trajectoryReductionMiddleware } from "./builtin/trajectory-reduction.js";
+export { autoLintMiddleware } from "./builtin/auto-lint.js";
+export { createMemoryExtractionMiddleware } from "./builtin/memory-extract.js";
 
 /**
  * Create a default middleware pipeline with all built-in middleware.
+ * @param projectPath - Required for memory extraction middleware.
  */
-import { MiddlewarePipeline } from './pipeline.js';
-import { turnContextMiddleware } from './builtin/turn-context.js';
-import { toolHealthMiddleware } from './builtin/tool-health.js';
-import { buildStateMiddleware } from './builtin/build-state.js';
-import { loopDetectionMiddleware } from './builtin/loop-detection.js';
-import { sentimentMiddleware } from './builtin/sentiment.js';
-import { subagentLimitMiddleware } from './builtin/subagent-limit.js';
-import { trajectoryReductionMiddleware } from './builtin/trajectory-reduction.js';
-import { autoLintMiddleware } from './builtin/auto-lint.js';
+import { MiddlewarePipeline } from "./pipeline.js";
+import { turnContextMiddleware } from "./builtin/turn-context.js";
+import { toolHealthMiddleware } from "./builtin/tool-health.js";
+import { buildStateMiddleware } from "./builtin/build-state.js";
+import { loopDetectionMiddleware } from "./builtin/loop-detection.js";
+import { sentimentMiddleware } from "./builtin/sentiment.js";
+import { subagentLimitMiddleware } from "./builtin/subagent-limit.js";
+import { trajectoryReductionMiddleware } from "./builtin/trajectory-reduction.js";
+import { autoLintMiddleware } from "./builtin/auto-lint.js";
+import { createMemoryExtractionMiddleware } from "./builtin/memory-extract.js";
 
-export function createDefaultMiddlewarePipeline(): MiddlewarePipeline {
+export function createDefaultMiddlewarePipeline(
+  projectPath?: string,
+): MiddlewarePipeline {
   const pipeline = new MiddlewarePipeline();
   pipeline.use(turnContextMiddleware);
   pipeline.use(toolHealthMiddleware);
@@ -45,5 +50,8 @@ export function createDefaultMiddlewarePipeline(): MiddlewarePipeline {
   pipeline.use(subagentLimitMiddleware);
   pipeline.use(trajectoryReductionMiddleware);
   pipeline.use(autoLintMiddleware);
+  if (projectPath) {
+    pipeline.use(createMemoryExtractionMiddleware(projectPath));
+  }
   return pipeline;
 }

--- a/packages/tools/src/builtin/sandbox.ts
+++ b/packages/tools/src/builtin/sandbox.ts
@@ -4,7 +4,7 @@
  * Three levels:
  * - none: no restrictions (current default)
  * - restricted: block dangerous patterns, warn on risky ones
- * - container: (future) Docker isolation
+ * - container: Docker isolation (routes commands through DockerSandbox)
  */
 
 export type SandboxLevel = "none" | "restricted" | "container";
@@ -116,8 +116,8 @@ export function checkSandbox(
   }
 
   if (level === "container") {
-    // Container mode not yet implemented — fall back to restricted
-    return checkRestricted(command, projectPath);
+    // Container mode: Docker provides isolation, allow all commands
+    return { allowed: true };
   }
 
   return checkRestricted(command, projectPath);

--- a/packages/tools/src/builtin/shell.ts
+++ b/packages/tools/src/builtin/shell.ts
@@ -52,6 +52,15 @@ export function stopDockerSandbox(): void {
   }
 }
 
+/** Swap the Docker sandbox instance. Returns the previous instance for restore. */
+export function setDockerSandbox(
+  instance: DockerSandbox | null,
+): DockerSandbox | null {
+  const prev = dockerSandbox;
+  dockerSandbox = instance;
+  return prev;
+}
+
 // ── Background Task Management ──────────────────────────────────────
 
 interface BackgroundTask {

--- a/packages/tools/src/builtin/shell.ts
+++ b/packages/tools/src/builtin/shell.ts
@@ -7,6 +7,7 @@ import {
   hasHardBlock,
 } from "./git-safety.js";
 import { checkSandbox, type SandboxLevel } from "./sandbox.js";
+import { DockerSandbox } from "../sandbox/docker-sandbox.js";
 
 const DEFAULT_TIMEOUT = 120_000;
 const BACKGROUND_TIMEOUT = 600_000; // 10 minutes max for background tasks
@@ -17,11 +18,20 @@ let TAIL_BYTES = 20_000;
 let currentSandboxLevel: SandboxLevel = "none";
 let currentProjectPath: string | undefined;
 
+// Docker sandbox — lazy-started on first container-mode shell call
+let dockerSandbox: DockerSandbox | null = null;
+let dockerConfig: { image: string; timeout: number } = {
+  image: "node:22-slim",
+  timeout: 120_000,
+};
+
 /** Configure the shell sandbox level and output limits. Call once during CLI startup. */
 export function configureSandbox(
   level: SandboxLevel,
   projectPath?: string,
   maxOutputBytes?: number,
+  containerImage?: string,
+  containerTimeout?: number,
 ): void {
   currentSandboxLevel = level;
   currentProjectPath = projectPath;
@@ -29,6 +39,16 @@ export function configureSandbox(
     // Split output budget: 40% head, 60% tail (tail is more useful for errors)
     HEAD_BYTES = Math.floor(maxOutputBytes * 0.4);
     TAIL_BYTES = Math.floor(maxOutputBytes * 0.6);
+  }
+  if (containerImage) dockerConfig.image = containerImage;
+  if (containerTimeout) dockerConfig.timeout = containerTimeout;
+}
+
+/** Stop and clean up the Docker sandbox container, if running. */
+export function stopDockerSandbox(): void {
+  if (dockerSandbox) {
+    dockerSandbox.stop();
+    dockerSandbox = null;
   }
 }
 
@@ -212,6 +232,34 @@ export const shellTool = defineTool({
           blocked: true,
         };
       }
+    }
+
+    // Container mode: route through Docker sandbox
+    if (currentSandboxLevel === "container" && currentProjectPath) {
+      if (!dockerSandbox) {
+        if (!DockerSandbox.isAvailable()) {
+          return {
+            stdout: "",
+            stderr:
+              "Docker is not available. Install Docker or switch to sandbox = 'restricted'.",
+            exitCode: 1,
+            blocked: true,
+          };
+        }
+        dockerSandbox = new DockerSandbox({
+          hostWorkspace: currentProjectPath,
+          image: dockerConfig.image,
+          timeout: dockerConfig.timeout,
+        });
+        dockerSandbox.start();
+      }
+
+      const result = dockerSandbox.exec(command);
+      return {
+        stdout: result.output,
+        stderr: "",
+        exitCode: result.exitCode,
+      };
     }
 
     // Background mode: spawn and return immediately, notify on completion

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -96,6 +96,7 @@ export {
 export { checkSandbox, type SandboxLevel } from "./builtin/sandbox.js";
 export {
   configureSandbox,
+  stopDockerSandbox,
   setBackgroundEventHandler,
   getBackgroundTasks,
   setToolOutputHandler,

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -97,6 +97,7 @@ export { checkSandbox, type SandboxLevel } from "./builtin/sandbox.js";
 export {
   configureSandbox,
   stopDockerSandbox,
+  setDockerSandbox,
   setBackgroundEventHandler,
   getBackgroundTasks,
   setToolOutputHandler,


### PR DESCRIPTION
## Summary

- **PR 2**: Wire Docker sandbox to container mode — lazy-start container on first shell call, route exec through DockerSandbox, stop on session exit. Added `containerImage` and `containerTimeout` config.
- **PR 3**: Subagent Docker isolation — code-type subagents get their own DockerSandbox when container mode enabled. Swap/restore pattern with `setDockerSandbox()`.
- **PR 4**: Automatic memory extraction middleware — `afterModel` middleware scans assistant responses for user preferences, project conventions, and error-fix pairs via regex heuristics (no LLM call). Wired into all 3 `runAgentLoop` call sites.

## Test plan

- [x] Full monorepo build (17/17 packages clean)
- [ ] Manual: `brainstorm chat` with `sandbox = "container"` routes through Docker
- [ ] Manual: memory extraction saves facts from assistant responses

🤖 Generated with [Claude Code](https://claude.ai/code)