### PR TITLE
feat: Phase B — tool icons, role show, per-turn cost, model persistence (v8)

### DIFF
--- a/packages/cli/src/commands/roles.ts
+++ b/packages/cli/src/commands/roles.ts
@@ -280,7 +280,7 @@ export function formatModelMenu(roleId: RoleId): string {
     return `  ${num}. ${m.label.padEnd(22)} (${m.cost} per 1M)${def}`;
   });
 
-  return `\n${header}\n${choices.join("\n")}\n\nModel [1-${role.modelChoices.length}, Enter=default]:`;
+  return `\n${header}\n${choices.join("\n")}\n\nUse: /${roleId} 1  (or 2, 3, etc.)`;
 }
 
 /**

--- a/packages/cli/src/commands/slash.ts
+++ b/packages/cli/src/commands/slash.ts
@@ -289,7 +289,19 @@ commands.push({
     const current = ctx.getActiveRole?.();
     if (current && ROLES[current as RoleId]) {
       const role = ROLES[current as RoleId];
-      return `Current: ${role.icon} ${role.displayName}\nSwitch: /architect, /product-manager, /sr-developer, /jr-developer, /qa\nReset: /default`;
+      const model = ctx.getModel?.() ?? "auto";
+      const lines = [
+        `${role.icon} ${role.displayName} (active)`,
+        `  Model:      ${model}`,
+        `  Tools:      ${role.permissionMode === "plan" ? "read-only" : "all"}`,
+        `  Style:      ${role.outputStyle}`,
+        `  Strategy:   ${role.routingStrategy}`,
+        `  Permission: ${role.permissionMode}`,
+        ``,
+        `Models: ${role.modelChoices.map((m, i) => `${i + 1}.${m.label}`).join(", ")}`,
+        `Switch: /${current} N │ /default to reset`,
+      ];
+      return lines.join("\n");
     }
     const lines = Object.values(ROLES).map(
       (r) =>

--- a/packages/cli/src/components/App.tsx
+++ b/packages/cli/src/components/App.tsx
@@ -236,6 +236,7 @@ export function App(props: AppProps) {
       {mode === "models" && (
         <ModelsMode
           models={props.models ?? []}
+          currentModelId={currentModel}
           onSelectModel={(id) => {
             props.slashCallbacks?.setModel?.(id);
             const name = id.split("/").pop() ?? id;

--- a/packages/cli/src/components/ChatApp.tsx
+++ b/packages/cli/src/components/ChatApp.tsx
@@ -193,6 +193,7 @@ export function ChatApp({
       let fullResponse = "";
       let model: string | undefined;
       let cost = 0;
+      const costBefore = sessionCost;
 
       try {
         for await (const event of onSendMessage(text.trim())) {
@@ -351,7 +352,7 @@ export function ChatApp({
               ]);
               break;
             case "done":
-              cost = event.totalCost;
+              cost = event.totalCost - costBefore; // Per-turn cost delta
               setSessionCost(event.totalCost);
               if (event.totalTokens) setTokenCount(event.totalTokens);
               break;

--- a/packages/cli/src/components/modes/DashboardMode.tsx
+++ b/packages/cli/src/components/modes/DashboardMode.tsx
@@ -185,7 +185,7 @@ export function DashboardMode({
                 return (
                   <Box key={tool.name}>
                     <Text color={color}>
-                      {rate >= 90 ? "●" : rate >= 70 ? "●" : "●"}{" "}
+                      {rate >= 90 ? "●" : rate >= 70 ? "◐" : "○"}{" "}
                     </Text>
                     <Text>{tool.name.padEnd(16)}</Text>
                     <Text color="gray">

--- a/packages/cli/src/components/modes/ModelsMode.tsx
+++ b/packages/cli/src/components/modes/ModelsMode.tsx
@@ -15,6 +15,7 @@ interface ModelInfo {
 
 interface ModelsModeProps {
   models: ModelInfo[];
+  currentModelId?: string;
   onSelectModel?: (modelId: string) => void;
 }
 
@@ -30,8 +31,20 @@ const SPEED_BARS: Record<number, { label: string; value: number }> = {
   3: { label: "Slow", value: 33 },
 };
 
-export function ModelsMode({ models, onSelectModel }: ModelsModeProps) {
-  const [selectedIdx, setSelectedIdx] = useState(0);
+export function ModelsMode({
+  models,
+  currentModelId,
+  onSelectModel,
+}: ModelsModeProps) {
+  const initialIdx = currentModelId
+    ? Math.max(
+        0,
+        models.findIndex(
+          (m) => m.id === currentModelId || m.name === currentModelId,
+        ),
+      )
+    : 0;
+  const [selectedIdx, setSelectedIdx] = useState(initialIdx);
 
   useInput((input, key) => {
     if (key.downArrow || input === "j") {


### PR DESCRIPTION
## Summary

**Fixes:**
- Tool health icons now differentiated: ● (90%+), ◐ (70%+), ○ (<70%)
- Role menu removed misleading interactive prompt text
- Model selection in Models mode persists when switching tabs

**Improvements:**
- Per-turn cost display shows delta, not cumulative session total
- `/role` shows full active role details (model, tools, style, strategy, permission)

## Test plan
- [x] Build clean (17/17)

🤖 Generated with [Claude Code](https://claude.ai/code)