### PR TITLE
feat: BR-powered Dashboard — leaderboard, waste, audit, forecast, trends (v8 Phase C)

### DIFF
--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -1903,6 +1903,8 @@ program
         status: m.status ?? "available",
       }));
 
+      const brGateway = createGatewayClient();
+
       render(
         React.createElement(App, {
           strategy: config.general.defaultStrategy,
@@ -1910,6 +1912,7 @@ program
           onSendMessage: handleSendMessage,
           onAbort: handleAbort,
           models: modelData,
+          gateway: brGateway,
           configInfo: {
             strategy: config.general.defaultStrategy,
             permissionMode: config.general.defaultPermissionMode ?? "confirm",

--- a/packages/cli/src/components/App.tsx
+++ b/packages/cli/src/components/App.tsx
@@ -8,6 +8,7 @@
 import React, { useState } from "react";
 import { Box, useApp, useInput } from "ink";
 import { useMode, type TUIMode } from "../hooks/useMode.js";
+import { useBRData } from "../hooks/useBRData.js";
 import { ModeBar } from "./ModeBar.js";
 import { KeyHint } from "./KeyHint.js";
 import { ChatApp } from "./ChatApp.js";
@@ -48,6 +49,8 @@ interface AppProps {
     opAvailable: boolean;
     resolvedKeys: string[];
   };
+  /** BrainstormRouter gateway client for dashboard data */
+  gateway?: any;
 }
 
 interface RoutingEntry {
@@ -76,6 +79,7 @@ export function App(props: AppProps) {
   const [toolStats, setToolStats] = useState<Map<string, ToolStat>>(new Map());
   const [turnCount, setTurnCount] = useState(0);
   const [sessionStart] = useState(Date.now());
+  const { data: brData, refresh: refreshBR } = useBRData(props.gateway ?? null);
 
   // Global key handler for mode switching
   //
@@ -101,11 +105,15 @@ export function App(props: AppProps) {
       return;
     }
 
-    // In non-chat modes: number keys switch modes, Tab cycles
+    // In non-chat modes: number keys switch modes, Tab cycles, r refreshes
     if (mode !== "chat") {
       if (setModeByKey(input)) return;
       if (key.tab) {
         cycleMode();
+        return;
+      }
+      if (input === "r" && mode === "dashboard") {
+        refreshBR();
         return;
       }
     }
@@ -230,6 +238,8 @@ export function App(props: AppProps) {
           toolStats={Array.from(toolStats.values())}
           turnCount={turnCount}
           sessionStart={sessionStart}
+          brData={brData}
+          onRefreshBR={refreshBR}
         />
       )}
 

--- a/packages/cli/src/components/modes/DashboardMode.tsx
+++ b/packages/cli/src/components/modes/DashboardMode.tsx
@@ -1,8 +1,9 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Box, Text } from "ink";
 import { Gauge } from "../viz/Gauge.js";
 import { Sparkline } from "../viz/Sparkline.js";
 import { getProviderColor } from "../../theme.js";
+import type { BRDashboardData } from "../../hooks/useBRData.js";
 
 interface RoutingEntry {
   model: string;
@@ -25,6 +26,8 @@ interface DashboardModeProps {
   toolStats: ToolStat[];
   turnCount: number;
   sessionStart: number;
+  brData?: BRDashboardData;
+  onRefreshBR?: () => void;
 }
 
 function formatElapsed(ms: number): string {
@@ -54,9 +57,18 @@ export function DashboardMode({
   toolStats,
   turnCount,
   sessionStart,
+  brData,
+  onRefreshBR,
 }: DashboardModeProps) {
   const elapsed = Date.now() - sessionStart;
   const costPerHour = elapsed > 60000 ? (sessionCost / elapsed) * 3600000 : 0;
+
+  // Auto-fetch BR data on first mount
+  useEffect(() => {
+    if (onRefreshBR && (!brData || brData.lastFetched === 0)) {
+      onRefreshBR();
+    }
+  }, []);
 
   return (
     <Box flexDirection="column" flexGrow={1} paddingX={1}>
@@ -69,7 +81,7 @@ export function DashboardMode({
         justifyContent="space-between"
       >
         <Box flexDirection="column">
-          <Text color="gray">Session Cost</Text>
+          <Text color="gray">Session</Text>
           <Text color="yellow" bold>
             ${sessionCost.toFixed(4)}
           </Text>
@@ -100,19 +112,19 @@ export function DashboardMode({
             ${costPerHour.toFixed(2)}
           </Text>
         </Box>
-        <Box flexDirection="column">
-          <Text color="gray">Models</Text>
-          <Text>
-            {modelCount.local}
-            <Text color="gray">L</Text>/{modelCount.cloud}
-            <Text color="gray">C</Text>
-          </Text>
-        </Box>
+        {brData?.forecast && (
+          <Box flexDirection="column">
+            <Text color="gray">Forecast</Text>
+            <Text color={brData.forecast.will_exceed ? "red" : "green"} bold>
+              ${brData.forecast.projected_spend.toFixed(2)}
+            </Text>
+          </Box>
+        )}
       </Box>
 
-      {/* Middle: Two panels side by side */}
+      {/* Middle row: 3 panels */}
       <Box marginTop={1} flexDirection="row" flexGrow={1}>
-        {/* Left: Routing Log */}
+        {/* Left: Routing Log + Leaderboard */}
         <Box
           borderStyle="round"
           borderColor="gray"
@@ -127,33 +139,48 @@ export function DashboardMode({
           {routingHistory.length === 0 ? (
             <Text color="gray" dimColor>
               {" "}
-              No routing decisions yet. Send a message to start.
+              Send a message to start.
             </Text>
           ) : (
-            routingHistory.slice(0, 8).map((entry, i) => (
+            routingHistory.slice(0, 6).map((entry, i) => (
               <Box key={i}>
                 <Text color="gray" dimColor>
                   {timeAgo(entry.timestamp).padEnd(8)}
                 </Text>
                 <Text color={getProviderColor(entry.model)} bold>
-                  {entry.model.padEnd(20)}
+                  {entry.model.padEnd(18)}
                 </Text>
                 <Text color="gray">{entry.strategy}</Text>
               </Box>
             ))
           )}
-          {routingHistory.length > 0 && (
-            <Box marginTop={1}>
-              <Text color="gray" dimColor>
+
+          {/* BR Leaderboard */}
+          {brData && brData.leaderboard.length > 0 && (
+            <>
+              <Text> </Text>
+              <Text bold color="yellow">
                 {" "}
-                {routingHistory.length} decision
-                {routingHistory.length > 1 ? "s" : ""} this session
+                Leaderboard
               </Text>
-            </Box>
+              {brData.leaderboard.slice(0, 5).map((entry, i) => (
+                <Box key={i}>
+                  <Text color="gray">{String(i + 1).padStart(2)}. </Text>
+                  <Text color={getProviderColor(entry.provider)} bold>
+                    {entry.model.split("/").pop()?.padEnd(18) ??
+                      entry.model.padEnd(18)}
+                  </Text>
+                  <Text color="gray">
+                    Q{entry.quality_rank} S{entry.speed_rank} V
+                    {entry.value_rank}
+                  </Text>
+                </Box>
+              ))}
+            </>
           )}
         </Box>
 
-        {/* Right: Tool Health */}
+        {/* Center: Tool Health */}
         <Box
           borderStyle="round"
           borderColor="gray"
@@ -174,7 +201,7 @@ export function DashboardMode({
           ) : (
             toolStats
               .sort((a, b) => b.calls - a.calls)
-              .slice(0, 10)
+              .slice(0, 8)
               .map((tool) => {
                 const rate =
                   tool.calls > 0
@@ -187,17 +214,110 @@ export function DashboardMode({
                     <Text color={color}>
                       {rate >= 90 ? "●" : rate >= 70 ? "◐" : "○"}{" "}
                     </Text>
-                    <Text>{tool.name.padEnd(16)}</Text>
-                    <Text color="gray">
-                      {String(tool.calls).padStart(3)} calls{" "}
-                    </Text>
-                    <Gauge value={rate} width={10} showPercent={false} />
+                    <Text>{tool.name.padEnd(14)}</Text>
+                    <Text color="gray">{String(tool.calls).padStart(3)} </Text>
+                    <Gauge value={rate} width={8} showPercent={false} />
                     <Text color={color}> {rate}%</Text>
                   </Box>
                 );
               })
           )}
+
+          {/* BR Waste Detection */}
+          {brData?.waste && brData.waste.total_waste_usd > 0 && (
+            <>
+              <Text> </Text>
+              <Text bold color="red">
+                {" "}
+                Waste: ${brData.waste.total_waste_usd.toFixed(2)}
+              </Text>
+              {brData.waste.suggestions.slice(0, 3).map((s, i) => (
+                <Text key={i} color="gray" dimColor>
+                  {" "}
+                  {s.description.slice(0, 50)}
+                </Text>
+              ))}
+            </>
+          )}
         </Box>
+
+        {/* Right: Audit + Daily Trend */}
+        <Box
+          borderStyle="round"
+          borderColor="gray"
+          flexGrow={1}
+          paddingX={1}
+          marginLeft={1}
+          flexDirection="column"
+        >
+          <Text bold color="magenta">
+            {" "}
+            Guardian Audit
+          </Text>
+          {!brData || brData.audit.length === 0 ? (
+            <Text color="gray" dimColor>
+              {" "}
+              No audit data. Press r to refresh.
+            </Text>
+          ) : (
+            brData.audit.slice(0, 6).map((entry, i) => {
+              const statusColor =
+                entry.guardian_status === "safe"
+                  ? "green"
+                  : entry.guardian_status === "flagged"
+                    ? "yellow"
+                    : "red";
+              return (
+                <Box key={i}>
+                  <Text color={statusColor}>
+                    {entry.guardian_status === "safe" ? "●" : "⚠"}{" "}
+                  </Text>
+                  <Text color={getProviderColor(entry.model)}>
+                    {entry.model.split("/").pop()?.padEnd(14) ?? ""}
+                  </Text>
+                  <Text color="gray">${entry.cost_usd.toFixed(4)}</Text>
+                </Box>
+              );
+            })
+          )}
+
+          {/* Daily Cost Trend */}
+          {brData && brData.dailyTrend.length > 0 && (
+            <>
+              <Text> </Text>
+              <Text bold color="blue">
+                {" "}
+                7-Day Trend
+              </Text>
+              <Box>
+                <Sparkline
+                  data={brData.dailyTrend.map((d) => d.cost_usd)}
+                  color="yellow"
+                  width={20}
+                />
+                <Text color="gray">
+                  {" "}
+                  $
+                  {brData.dailyTrend
+                    .reduce((s, d) => s + d.cost_usd, 0)
+                    .toFixed(2)}{" "}
+                  total
+                </Text>
+              </Box>
+            </>
+          )}
+        </Box>
+      </Box>
+
+      {/* Bottom: Status */}
+      <Box paddingX={1}>
+        <Text color="gray" dimColor>
+          {brData?.loading
+            ? "Loading BR data..."
+            : brData?.error
+              ? `BR: ${brData.error}`
+              : `r refresh │ ${modelCount.local}L/${modelCount.cloud}C`}
+        </Text>
       </Box>
     </Box>
   );

--- a/packages/cli/src/hooks/useBRData.ts
+++ b/packages/cli/src/hooks/useBRData.ts
@@ -1,0 +1,108 @@
+/**
+ * Hook to lazily fetch BrainstormRouter dashboard data.
+ * Caches results and refreshes on demand.
+ */
+
+import { useState, useCallback } from "react";
+
+export interface BRDashboardData {
+  leaderboard: Array<{
+    model: string;
+    provider: string;
+    quality_rank: number;
+    speed_rank: number;
+    value_rank: number;
+    request_count: number;
+    avg_latency_ms: number;
+  }>;
+  waste: {
+    total_waste_usd: number;
+    suggestions: Array<{
+      description: string;
+      savings_usd: number;
+      action: string;
+    }>;
+  } | null;
+  forecast: {
+    current_spend: number;
+    budget_limit: number;
+    projected_spend: number;
+    will_exceed: boolean;
+    days_remaining: number;
+  } | null;
+  audit: Array<{
+    request_id: string;
+    timestamp: string;
+    model: string;
+    cost_usd: number;
+    latency_ms: number;
+    guardian_status: string;
+  }>;
+  dailyTrend: Array<{
+    date: string;
+    cost_usd: number;
+    request_count: number;
+  }>;
+  lastFetched: number;
+  loading: boolean;
+  error: string | null;
+}
+
+const EMPTY_DATA: BRDashboardData = {
+  leaderboard: [],
+  waste: null,
+  forecast: null,
+  audit: [],
+  dailyTrend: [],
+  lastFetched: 0,
+  loading: false,
+  error: null,
+};
+
+/**
+ * Fetch BR dashboard data using the gateway client.
+ * Pass null if no gateway is available (no BR key).
+ */
+export function useBRData(gateway: any | null) {
+  const [data, setData] = useState<BRDashboardData>(EMPTY_DATA);
+
+  const refresh = useCallback(async () => {
+    if (!gateway) {
+      setData((prev) => ({
+        ...prev,
+        error: "No BrainstormRouter API key configured",
+      }));
+      return;
+    }
+
+    setData((prev) => ({ ...prev, loading: true, error: null }));
+
+    try {
+      // Fetch all endpoints in parallel (best-effort for each)
+      const [leaderboard, waste, forecast, audit, daily] =
+        await Promise.allSettled([
+          gateway.getLeaderboard(),
+          gateway.getWasteInsights(),
+          gateway.getForecast(),
+          gateway.getCompletionAudit("24h"),
+          gateway.getDailyInsights(),
+        ]);
+
+      setData({
+        leaderboard:
+          leaderboard.status === "fulfilled" ? leaderboard.value : [],
+        waste: waste.status === "fulfilled" ? waste.value : null,
+        forecast: forecast.status === "fulfilled" ? forecast.value : null,
+        audit: audit.status === "fulfilled" ? audit.value.slice(0, 10) : [],
+        dailyTrend: daily.status === "fulfilled" ? daily.value.slice(0, 7) : [],
+        lastFetched: Date.now(),
+        loading: false,
+        error: null,
+      });
+    } catch (err: any) {
+      setData((prev) => ({ ...prev, loading: false, error: err.message }));
+    }
+  }, [gateway]);
+
+  return { data, refresh };
+}


### PR DESCRIPTION
## Summary

Dashboard mode [2] now pulls live data from BrainstormRouter API:

| Panel | Endpoint | Data |
|-------|----------|------|
| Leaderboard | `/v1/models/leaderboard` | Top 5 models by quality/speed/value rank |
| Waste Detection | `/v1/insights/waste` | Total waste + optimization suggestions |
| Guardian Audit | `/v1/governance/completion-audit` | Last 10 requests with safety status |
| Budget Forecast | `/v1/insights/forecast` | Projected spend + will_exceed flag |
| 7-Day Trend | `/v1/insights/daily` | Sparkline of daily costs |

All fetched in parallel via `useBRData` hook. Auto-fetches on mount, `r` to refresh.

## Test plan
- [x] Build clean (17/17)
- [ ] Dashboard shows leaderboard when BR key is set
- [ ] Dashboard shows "No BrainstormRouter API key" when not set

🤖 Generated with [Claude Code](https://claude.ai/code)