### PR TITLE
feat: Phase G+H — markdown retry, guardian indicator (v8)

### DIFF
--- a/packages/cli/src/components/App.tsx
+++ b/packages/cli/src/components/App.tsx
@@ -83,6 +83,7 @@ export function App(props: AppProps) {
   const [sessionStart] = useState(Date.now());
   const { data: brData, refresh: refreshBR } = useBRData(props.gateway ?? null);
   const [lastCtrlD, setLastCtrlD] = useState(0);
+  const [guardianStatus, setGuardianStatus] = useState<string | undefined>();
 
   // Global key handler for mode switching
   //
@@ -203,13 +204,15 @@ export function App(props: AppProps) {
               return next;
             });
           }
-          // Capture gateway feedback: request ID + live cost update
+          // Capture gateway feedback: request ID + live cost + guardian status
           if (event.type === "gateway-feedback") {
             lastRequestId = (event as any).feedback?.requestId;
             const actualCost = (event as any).feedback?.actualCost;
             if (typeof actualCost === "number" && actualCost > 0) {
               setSessionCost((prev) => Math.max(prev, actualCost));
             }
+            const guardian = (event as any).feedback?.guardianStatus;
+            if (guardian) setGuardianStatus(guardian);
           }
           if (event.type === "done") {
             setSessionCost(event.totalCost);
@@ -241,6 +244,7 @@ export function App(props: AppProps) {
         model={currentModel}
         cost={sessionCost}
         role={currentRole}
+        guardianStatus={guardianStatus}
       />
 
       {/* ChatApp is always mounted to preserve conversation state.

--- a/packages/cli/src/components/MarkdownRenderer.tsx
+++ b/packages/cli/src/components/MarkdownRenderer.tsx
@@ -4,6 +4,8 @@ import { Text } from "ink";
 // Lazy-loaded for performance — only loaded on first render
 let _markedRenderer: ((md: string) => string) | null = null;
 let _loadFailed = false;
+let _loadFailedAt = 0;
+const RETRY_AFTER_MS = 60_000; // Retry loading after 60s
 
 /**
  * Initialize marked-terminal renderer with syntax highlighting.
@@ -11,7 +13,8 @@ let _loadFailed = false;
  */
 async function getMarkedRenderer(): Promise<(md: string) => string> {
   if (_markedRenderer) return _markedRenderer;
-  if (_loadFailed) return renderTerminalMarkdownFallback;
+  if (_loadFailed && Date.now() - _loadFailedAt < RETRY_AFTER_MS)
+    return renderTerminalMarkdownFallback;
 
   try {
     const { Marked } = await import("marked");
@@ -77,6 +80,7 @@ async function getMarkedRenderer(): Promise<(md: string) => string> {
     return _markedRenderer;
   } catch {
     _loadFailed = true;
+    _loadFailedAt = Date.now();
     return renderTerminalMarkdownFallback;
   }
 }

--- a/packages/cli/src/components/ModeBar.tsx
+++ b/packages/cli/src/components/ModeBar.tsx
@@ -8,9 +8,16 @@ interface ModeBarProps {
   model?: string;
   cost?: number;
   role?: string;
+  guardianStatus?: string;
 }
 
-export function ModeBar({ activeMode, model, cost, role }: ModeBarProps) {
+export function ModeBar({
+  activeMode,
+  model,
+  cost,
+  role,
+  guardianStatus,
+}: ModeBarProps) {
   return (
     <Box flexDirection="row" justifyContent="space-between" paddingX={1}>
       <Box>
@@ -66,6 +73,22 @@ export function ModeBar({ activeMode, model, cost, role }: ModeBarProps) {
         <Text color={cost && cost > 0.01 ? "yellow" : "green"}>
           ${(cost ?? 0).toFixed(4)}
         </Text>
+        {guardianStatus && (
+          <>
+            <Text color="gray"> │ </Text>
+            <Text
+              color={
+                guardianStatus === "safe"
+                  ? "green"
+                  : guardianStatus === "flagged"
+                    ? "yellow"
+                    : "red"
+              }
+            >
+              {guardianStatus === "safe" ? "●" : "⚠"}
+            </Text>
+          </>
+        )}
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Summary

- MarkdownRenderer retries loading marked-terminal after 60s instead of permanent failure
- Guardian status indicator (● / ⚠) in ModeBar from gateway-feedback events
- Audit verified repo map cache and tool health are already bounded

## Test plan
- [x] Build clean (17/17)

🤖 Generated with [Claude Code](https://claude.ai/code)