### PR TITLE
feat: slash command autocomplete dropdown (v11 PR 11)

### DIFF
--- a/packages/cli/src/components/Autocomplete.tsx
+++ b/packages/cli/src/components/Autocomplete.tsx
@@ -1,0 +1,93 @@
+/**
+ * Autocomplete — dropdown suggestion list for slash commands and @file paths.
+ *
+ * Renders below the input box. Arrow keys navigate, Tab/Enter accepts,
+ * Esc dismisses. Filters suggestions as user types.
+ */
+
+import React, { useState, useMemo } from "react";
+import { Box, Text, useInput } from "ink";
+
+export interface AutocompleteItem {
+  label: string;
+  description?: string;
+  prefix?: string;
+}
+
+interface AutocompleteProps {
+  /** Current input text to match against */
+  query: string;
+  /** All possible suggestions */
+  items: AutocompleteItem[];
+  /** Called when user accepts a suggestion */
+  onAccept: (label: string) => void;
+  /** Called when user dismisses (Esc or type past suggestions) */
+  onDismiss: () => void;
+  /** Max items to show */
+  maxVisible?: number;
+}
+
+export function Autocomplete({
+  query,
+  items,
+  onAccept,
+  onDismiss,
+  maxVisible = 8,
+}: AutocompleteProps) {
+  const [cursor, setCursor] = useState(0);
+
+  const filtered = useMemo(() => {
+    const q = query.toLowerCase();
+    return items
+      .filter((item) => item.label.toLowerCase().includes(q))
+      .slice(0, maxVisible);
+  }, [query, items, maxVisible]);
+
+  useInput((input, key) => {
+    if (key.downArrow) {
+      setCursor((prev) => Math.min(prev + 1, filtered.length - 1));
+      return;
+    }
+    if (key.upArrow) {
+      setCursor((prev) => Math.max(prev - 1, 0));
+      return;
+    }
+    if (key.tab || key.return) {
+      if (filtered[cursor]) {
+        onAccept(filtered[cursor].label);
+      }
+      return;
+    }
+    if (key.escape) {
+      onDismiss();
+      return;
+    }
+  });
+
+  if (filtered.length === 0) return null;
+
+  return (
+    <Box flexDirection="column" paddingX={2} marginBottom={0}>
+      {filtered.map((item, i) => {
+        const isActive = i === cursor;
+        return (
+          <Box key={item.label}>
+            <Text color={isActive ? "cyan" : "gray"}>
+              {isActive ? "▸ " : "  "}
+            </Text>
+            <Text color={isActive ? "white" : "gray"} bold={isActive}>
+              {item.prefix ?? ""}
+              {item.label}
+            </Text>
+            {item.description && (
+              <Text color="gray" dimColor={!isActive}>
+                {" "}
+                {item.description}
+              </Text>
+            )}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/packages/cli/src/components/ChatApp.tsx
+++ b/packages/cli/src/components/ChatApp.tsx
@@ -7,6 +7,8 @@ import { TaskList } from "./TaskList.js";
 import { StreamingMessage } from "./StreamingMessage.js";
 import { ToolCallList, type ToolCallState } from "./ToolCallDisplay.js";
 import { SelectPrompt, type SelectOption } from "./SelectPrompt.js";
+import { Autocomplete, type AutocompleteItem } from "./Autocomplete.js";
+import { getSlashCommands } from "../commands/slash.js";
 import {
   isSlashCommand,
   executeSlashCommand,
@@ -79,7 +81,17 @@ export function ChatApp({
     question: string;
     options: SelectOption[];
   } | null>(null);
+  const [showAutocomplete, setShowAutocomplete] = useState(false);
   const [history] = useState(() => new InputHistory());
+
+  // Build slash command autocomplete items once
+  const slashItems = useMemo<AutocompleteItem[]>(() => {
+    return getSlashCommands().map((cmd) => ({
+      label: cmd.name,
+      description: cmd.description,
+      prefix: "/",
+    }));
+  }, []);
 
   // Listen for ask_user tool events
   useEffect(() => {
@@ -499,6 +511,19 @@ export function ChatApp({
       )}
       <ToolCallList tools={activeTools} />
       {tasks.length > 0 && <TaskList tasks={tasks} />}
+      {/* Slash command autocomplete */}
+      {showAutocomplete && !isProcessing && !askUserPrompt && (
+        <Autocomplete
+          query={input.slice(1)}
+          items={slashItems}
+          onAccept={(label) => {
+            setInput(`/${label} `);
+            setShowAutocomplete(false);
+          }}
+          onDismiss={() => setShowAutocomplete(false)}
+        />
+      )}
+
       {/* Interactive selection prompt (from ask_user tool) */}
       {askUserPrompt && (
         <SelectPrompt
@@ -531,9 +556,22 @@ export function ChatApp({
           </Text>
           <TextInput
             value={input}
-            onChange={setInput}
-            onSubmit={handleSubmit}
-            placeholder={isProcessing ? "Thinking..." : "Type a message..."}
+            onChange={(val) => {
+              setInput(val);
+              // Show autocomplete when typing a slash command
+              setShowAutocomplete(
+                val.startsWith("/") && val.length > 1 && !val.includes(" "),
+              );
+            }}
+            onSubmit={(val) => {
+              setShowAutocomplete(false);
+              handleSubmit(val);
+            }}
+            placeholder={
+              isProcessing
+                ? "Thinking..."
+                : "Type a message... (/ for commands)"
+            }
           />
         </Box>
         <Box paddingX={2}>


### PR DESCRIPTION
## Summary

Autocomplete dropdown when typing / commands:
- Filters matching commands as you type
- Arrow keys navigate, Tab/Enter accepts
- Shows description alongside command name
- Reusable Autocomplete component for future @file paths

## Test plan
- [x] Build clean (17/17)
- [ ] Type /bu → see /build, /budget suggestions

🤖 Generated with [Claude Code](https://claude.ai/code)