### PR TITLE
feat: /undo, /insights, multi-line \, routing detail (v11 batch 2)

### DIFF
--- a/packages/cli/src/commands/slash.ts
+++ b/packages/cli/src/commands/slash.ts
@@ -48,6 +48,8 @@ export interface SlashContext {
   gateway?: any;
   /** Get the context window size of the current model */
   getContextWindow?: () => number;
+  /** Remove last user message + assistant response */
+  undoLastTurn?: () => number;
 }
 
 interface SlashCommand {
@@ -402,6 +404,71 @@ commands.push({
           ? "  Consider running /compact soon."
           : "  Context usage is healthy.",
     ];
+    return lines.join("\n");
+  },
+});
+
+commands.push({
+  name: "undo",
+  aliases: [],
+  description: "Remove the last user message and assistant response",
+  usage: "/undo",
+  execute: (_args, ctx) => {
+    const removed = ctx.undoLastTurn?.() ?? 0;
+    if (removed === 0) return "Nothing to undo.";
+    return `Removed ${removed} message${removed > 1 ? "s" : ""}.`;
+  },
+});
+
+commands.push({
+  name: "insights",
+  aliases: [],
+  description: "Session intelligence — what Brainstorm learned",
+  usage: "/insights",
+  execute: async (_args, ctx) => {
+    const cost = ctx.getSessionCost?.() ?? 0;
+    const tokens = ctx.getTokenCount?.() ?? { input: 0, output: 0 };
+    const model = ctx.getModel?.() ?? "auto";
+    const strategy = ctx.getStrategy?.() ?? "combined";
+    const role = ctx.getActiveRole?.();
+
+    const lines = [
+      "Session Insights",
+      "",
+      `  Model: ${model}`,
+      `  Strategy: ${strategy}`,
+      `  Cost: $${cost.toFixed(4)}`,
+      `  Tokens: ${tokens.input.toLocaleString()} in / ${tokens.output.toLocaleString()} out`,
+    ];
+
+    if (role) lines.push(`  Role: ${role}`);
+
+    // Cost efficiency
+    const totalTokens = tokens.input + tokens.output;
+    if (totalTokens > 0) {
+      const costPer1k = (cost / totalTokens) * 1000;
+      lines.push("");
+      lines.push(`  Cost efficiency: $${costPer1k.toFixed(4)} per 1K tokens`);
+    }
+
+    // Try BR insights
+    if (ctx.gateway) {
+      try {
+        const waste = await ctx.gateway.getWasteInsights();
+        if (waste?.suggestions?.length > 0) {
+          lines.push("");
+          lines.push("  Optimization suggestions:");
+          for (const s of waste.suggestions.slice(0, 3)) {
+            lines.push(
+              `    → ${s.description} (save ~$${s.savings_usd?.toFixed(2) ?? "?"})`,
+            );
+          }
+        }
+      } catch {
+        /* BR unavailable */
+      }
+    }
+
     return lines.join("\n");
   },
 });

--- a/packages/cli/src/components/ChatApp.tsx
+++ b/packages/cli/src/components/ChatApp.tsx
@@ -217,6 +217,17 @@ export function ChatApp({
       dream: slashCallbacks?.dream,
       vault: slashCallbacks?.vault,
       rebuildSystemPrompt: slashCallbacks?.rebuildSystemPrompt,
+      undoLastTurn: () => {
+        // Find last user message and remove it + everything after
+        let removed = 0;
+        setMessages((prev) => {
+          const lastUserIdx = prev.findLastIndex((m) => m.role === "user");
+          if (lastUserIdx < 0) return prev;
+          removed = prev.length - lastUserIdx;
+          return prev.slice(0, lastUserIdx);
+        });
+        return removed;
+      },
       getActiveRole: slashCallbacks?.getActiveRole,
       setActiveRole: slashCallbacks?.setActiveRole,
       gateway: slashCallbacks?.gateway,
@@ -275,11 +286,16 @@ export function ChatApp({
               model = event.decision.model.name;
               setCurrentModel(model);
               setThinkingPhase(undefined);
+              const est = event.decision.estimatedCost;
+              const estStr = est > 0 ? ` ~$${est.toFixed(3)}` : "";
+              const fb = event.decision.fallbacks?.length ?? 0;
+              const fbStr =
+                fb > 0 ? ` (${fb} fallback${fb > 1 ? "s" : ""})` : "";
               setMessages((prev) => [
                 ...prev,
                 {
                   role: "routing",
-                  content: `${event.decision.strategy} → ${model}`,
+                  content: `→ ${model} via ${event.decision.strategy}${estStr}${fbStr}`,
                 },
               ]);
               break;
@@ -565,12 +581,17 @@ export function ChatApp({
             }}
             onSubmit={(val) => {
               setShowAutocomplete(false);
+              // Backslash continuation: \ at end of line adds newline instead of submitting
+              if (val.endsWith("\\")) {
+                setInput(val.slice(0, -1) + "\n");
+                return;
+              }
               handleSubmit(val);
             }}
             placeholder={
               isProcessing
                 ? "Thinking..."
-                : "Type a message... (/ for commands)"
+                : "Type a message... (/ commands, @file to include)"
             }
           />
         </Box>


### PR DESCRIPTION
## Summary

- **/undo** — removes last user message + all responses after it
- **/insights** — session cost efficiency + BR waste suggestions
- **Multi-line** — type \ at end of line to continue
- **Routing detail** — shows model + strategy + est cost + fallbacks
- **@file hint** — placeholder mentions @ file inclusion

## Test plan
- [x] Build clean (17/17)

🤖 Generated with [Claude Code](https://claude.ai/code)