### PR TITLE
feat: universal inline prompts — /build and roles use SelectPrompt

### DIFF
--- a/packages/cli/src/commands/slash.ts
+++ b/packages/cli/src/commands/slash.ts
@@ -48,6 +48,16 @@ export interface SlashContext {
   gateway?: any;
   /** Get the context window size of the current model */
   getContextWindow?: () => number;
+  /** Push an inline interactive prompt (SelectPrompt). Returns user's selection. */
+  prompt?: (
+    question: string,
+    options: Array<{
+      label: string;
+      value: string;
+      description?: string;
+      recommended?: boolean;
+    }>,
+  ) => Promise<string>;
   /** Remove last user message + assistant response */
   undoLastTurn?: () => number;
 }
@@ -299,20 +309,30 @@ function createRoleCommand(roleId: RoleId): SlashCommand {
     aliases: [],
     description: role.description,
     usage: `/${roleId} [model-number]`,
-    execute: (args, ctx) => {
-      const modelIdx = args ? parseInt(args, 10) : 0;
-      if (
-        args &&
-        (isNaN(modelIdx) || modelIdx < 1 || modelIdx > role.modelChoices.length)
-      ) {
-        return formatModelMenu(roleId);
-      }
-      if (!args) {
+    execute: async (args, ctx) => {
+      let modelId: string;
+
+      if (args) {
+        // Direct: /architect 2
+        modelId = getModelForRole(roleId, parseInt(args, 10));
+      } else if (ctx.prompt) {
+        // Interactive: show inline SelectPrompt
+        const selected = await ctx.prompt(
+          `${role.icon} ${role.displayName} — pick model`,
+          role.modelChoices.map((m) => ({
+            label: m.label,
+            value: m.modelId,
+            description: `${m.cost} per 1M tokens`,
+            recommended: m.default,
+          })),
+        );
+        modelId = selected;
+      } else {
+        // Fallback: show text menu
         return formatModelMenu(roleId);
       }
 
-      // Apply role atomically: model, style, mode, strategy, system prompt
-      const modelId = getModelForRole(roleId, modelIdx);
+      // Apply role atomically
       ctx.setModel?.(modelId);
       ctx.setOutputStyle?.(role.outputStyle);
       ctx.setMode?.(role.permissionMode);
@@ -532,13 +552,7 @@ commands.push({
   usage: "/build [description]",
   execute: async (args, ctx) => {
     if (!args) {
-      return [
-        "Build Wizard",
-        "",
-        "/build add OAuth login",
-        "/build fix the auth bug",
-        "/build review the routing code",
-      ].join("\n");
+      return "Usage: /build <what you want to build>\nExample: /build add OAuth login";
     }
 
     // Process description and build the pipeline
@@ -546,23 +560,54 @@ commands.push({
     state = processDescription(state, args);
 
     if (!state.workflow) {
-      return `Could not detect workflow type for: "${args}". Try a clearer description.`;
+      return `Could not detect workflow type for: "${args}"`;
     }
 
-    // Show the pipeline and return it as the wizard output
-    const pipeline = formatPipeline(state);
-    const lines = [
-      pipeline,
-      "",
-      "/build-go to run",
-      "/build-set 1 2 to change step 1",
-      "/build-customize for all options",
-    ];
+    // If prompt() is available, use interactive inline selection
+    if (ctx.prompt) {
+      // Step 1: Confirm workflow type
+      const action = await ctx.prompt(
+        `Detected: ${state.detectedPreset} (${state.assignments.length} steps)`,
+        [
+          {
+            label: "Go with defaults",
+            value: "defaults",
+            description: formatPipeline(state),
+            recommended: true,
+          },
+          { label: "Customize models", value: "customize" },
+          { label: "Cancel", value: "cancel" },
+        ],
+      );
 
-    // Store wizard state in a module-level cache for /build-go
+      if (action === "cancel") return "Build cancelled.";
+
+      if (action === "customize") {
+        // Step 2: For each pipeline step, let user pick model
+        for (let i = 0; i < state.assignments.length; i++) {
+          const a = state.assignments[i];
+          const choices = getModelChoicesForStep(a.stepRole);
+          const selected = await ctx.prompt(
+            `Step ${i + 1}: ${a.stepRole}`,
+            choices.map((m) => ({
+              label: m.label,
+              value: m.modelId,
+              description: `${m.cost} per 1M tokens`,
+              recommended: m.modelId === a.modelId,
+            })),
+          );
+          const choice = choices.find((m) => m.modelId === selected);
+          if (choice) state = updateAssignment(state, i, choice);
+        }
+      }
+
+      // Show final pipeline
+      return `${formatPipeline(state)}\n\nReady to execute. Use /build-go to start.`;
+    }
+
+    // Fallback: text-based menu (no prompt() available)
     _pendingWizard = state;
-
-    return lines.join("\n");
+    return `${formatPipeline(state)}\n\n/build-go to run │ /build-customize for options`;
   },
 });
 

--- a/packages/cli/src/components/ChatApp.tsx
+++ b/packages/cli/src/components/ChatApp.tsx
@@ -82,7 +82,30 @@ export function ChatApp({
     options: SelectOption[];
   } | null>(null);
   const [showAutocomplete, setShowAutocomplete] = useState(false);
+
+  // Inline prompt queue — any command/tool can push interactive prompts
+  // Each prompt shows a SelectPrompt. User picks, callback fires, next prompt shows.
+  const [promptQueue, setPromptQueue] = useState<
+    Array<{
+      question: string;
+      options: SelectOption[];
+      resolve: (value: string) => void;
+    }>
+  >([]);
   const [history] = useState(() => new InputHistory());
+
+  /**
+   * Push an inline prompt and wait for the user's selection.
+   * Used by slash commands, tools, and any interactive flow.
+   */
+  const pushPrompt = useCallback(
+    (question: string, options: SelectOption[]): Promise<string> => {
+      return new Promise<string>((resolve) => {
+        setPromptQueue((prev) => [...prev, { question, options, resolve }]);
+      });
+    },
+    [],
+  );
 
   // Build slash command autocomplete items once
   const slashItems = useMemo<AutocompleteItem[]>(() => {
@@ -214,6 +237,7 @@ export function ChatApp({
       getBudget: slashCallbacks?.getBudget,
       compact: slashCallbacks?.compact,
       getContextWindow: slashCallbacks?.getContextWindow,
+      prompt: pushPrompt,
       dream: slashCallbacks?.dream,
       vault: slashCallbacks?.vault,
       rebuildSystemPrompt: slashCallbacks?.rebuildSystemPrompt,
@@ -558,6 +582,27 @@ export function ChatApp({
             const { resolveAskUser } = await import("@brainstorm/tools");
             resolveAskUser(askUserPrompt.options[0]?.value ?? "");
             setAskUserPrompt(null);
+          }}
+        />
+      )}
+      {/* Inline prompt queue (from slash commands, /build, etc.) */}
+      {promptQueue.length > 0 && !askUserPrompt && (
+        <SelectPrompt
+          message={promptQueue[0].question}
+          options={promptQueue[0].options}
+          onSelect={(value) => {
+            const current = promptQueue[0];
+            setPromptQueue((prev) => prev.slice(1));
+            setMessages((prev) => [
+              ...prev,
+              { role: "routing", content: `→ ${value}` },
+            ]);
+            current.resolve(value);
+          }}
+          onCancel={() => {
+            const current = promptQueue[0];
+            setPromptQueue([]);
+            current.resolve(current.options[0]?.value ?? "");
           }}
         />
       )}


### PR DESCRIPTION
## Summary

Universal inline prompt system for all commands:

- **prompt()** callback in SlashContext — any command can show a SelectPrompt
- **/build** now uses inline selection: defaults/customize/cancel → per-step model pick
- **Role commands** use inline model selection when no number arg given
- **Prompt queue** — multiple sequential prompts stack naturally
- Falls back to text menus when prompt() unavailable (simple mode)

The user experience matches Claude Code: question appears inline with selectable options, arrow keys to navigate, Enter to pick.

## Test plan
- [x] Build clean (17/17)
- [ ] /build shows inline defaults/customize/cancel prompt
- [ ] /architect shows inline model picker

🤖 Generated with [Claude Code](https://claude.ai/code)