### PR TITLE
Phase 3: sandbox stack — strict-sense P3.5b complete on real hardware

### DIFF
--- a/docs/validation-runs/2026-04-27-node-2/README.md
+++ b/docs/validation-runs/2026-04-27-node-2/README.md
@@ -1,0 +1,165 @@
+# P3.5b Validation Run — 2026-04-27, Hetzner node-2
+
+Empirical evidence for the brainstorm endpoint-agent sandbox MVP. Captured by running `packages/sandbox/scripts/full-validation.sh` against a real Cloud Hypervisor + bare-metal Linux KVM host, after first-light's 11-iteration debugging arc landed.
+
+## Run identity
+
+- **Branch:** `feat/sandbox-phase-3-scaffold` at commit `7ab4d5e` (Codex-round-2 fixes applied)
+- **Run started:** 2026-04-27T19:35:55Z
+- **Run ended:** ~2026-04-27T19:46:10Z
+- **Total wall-clock:** ~10 minutes
+- **Validation harness:** `bsm-redteam --probes lat-only --iterations 1000` + `--probes concurrent --concurrency 8`
+
+## Host
+
+- **Host:** Hetzner bare-metal node, public address `95.217.108.251` (`compute-hel1-02`)
+- **Operator:** brainstormvm peer (advisor scope per locked Phase-3 plan); node-2 owned by Justin / brainstormVM cluster
+- **OS:** Ubuntu 24.04.3 LTS
+- **Kernel (host):** 6.8.x (per `uname -r` at run time; running kernel after `apt-get install` queued an update — not rebooted)
+- **Arch:** x86_64
+- **CPU:** Hetzner-spec dedicated cores
+- **RAM:** 61 GiB total
+- **Free RAM at run start:** 44 GiB available (verified pre-run; verified unchanged post-run)
+
+## Toolchain
+
+- **Cloud Hypervisor:** v44.0.0 (binary at `/usr/bin/cloud-hypervisor`)
+- **ch-remote:** v44.0.0 (downloaded from CHV GitHub release; sibling of `cloud-hypervisor`)
+- **Node.js:** v22.22.2 (via NodeSource setup_22.x)
+- **Docker:** v29.1.3 (Ubuntu `docker.io` package)
+- **docker-buildx:** v0.30.1 (`docker-buildx` apt package — not bundled with `docker.io`; required for image-builder)
+
+## Sandbox image
+
+- **Sandbox kernel:** Alpine virt 6.6.134-0-virt (from `linux-virt` apk package)
+- **Initramfs:** 9.2 MiB (Alpine virt initramfs)
+- **Rootfs:** 256 MiB ext4 image with `linux-virt` modules + busybox + musl + alpine-baselayout
+- **Boot artifacts SHA-256s recorded in:** image-builder checksums.txt (also embedded in JSON evidence)
+
+## Concurrent host workload during the run
+
+- `brainstormvm-cp` service active on remote CP host (87.99.142.127), unrelated to first-light
+- `brainstormvm-agent` service active on this host (node-2), unrelated to first-light
+- 2 unrelated Cloud Hypervisor processes from prior brainstormVM scale tests existed on host (state="Created" zombies, holding ~256 MiB RAM total). Not in firstlight namespace; phase-cleanup gates correctly avoided them. Verified zero impact on validation.
+
+## Headline results
+
+### 1000-iter cold-boot battery (`P-LAT`)
+
+All four probes (boot, roundtrip, shutdown, total) passed; `1000/1000 passed`, `0 failed`, `0 errored`, `0 skipped`.
+
+| Stage            | samples | p50   | p90 | p95 | p99     | mean  | min | max |
+| ---------------- | ------- | ----- | --- | --- | ------- | ----- | --- | --- |
+| **boot**         | 1000    | 586ms | 592 | 594 | **597** | 586.6 | 576 | 604 |
+| roundtrip (echo) | 1000    | 2ms   | 2   | 2   | **2**   | 1.6   | 1   | 2   |
+| shutdown         | 1000    | 24ms  | 30  | 31  | **36**  | 23.5  | 14  | 46  |
+| **total**        | 1000    | 611ms | 620 | 622 | **628** | 611.8 | 596 | 638 |
+
+**p99-p50 boot spread:** 11ms across 1000 cold boots. Total range 28ms across 1000 samples.
+
+### Concurrent-8 stress (`P-CONC`)
+
+8/8 instances PASS; allocated CIDs 3..10; unique vsock socket per instance; no CID collisions.
+
+| Stage     | samples | p50   | p90 | p95 | p99 | mean  | min | max |
+| --------- | ------- | ----- | --- | --- | --- | ----- | --- | --- |
+| boot      | 8       | 725ms | 734 | 734 | 734 | 726.4 | 724 | 734 |
+| roundtrip | 8       | 2ms   | 3   | 3   | 3   | 2.25  | 1   | 3   |
+| shutdown  | 8       | 36ms  | 36  | 36  | 36  | 34.25 | 29  | 36  |
+
+**Wall-clock for 8-parallel:** 765ms total (vs ~4800ms if serial — true concurrent execution verified).
+
+### Reset cycle
+
+**Run:** 2026-04-27T22:45:14Z (separate invocation from the P-LAT/P-CONC battery above; commit `35caba8` after two debugging iterations from the morning's `7ab4d5e`)
+
+**Result:** PASS. `packages/sandbox/scripts/reset-cycle.sh` exit 0; driver exit 0; substrate-lying defense (§A6) fired as designed.
+
+```
+first reset (clean):    divergence_action=none verification_passed=true
+tamper:                 appended sentinel byte to bsm-sandbox-rootfs.img
+second reset (lying):   SandboxResetDivergenceError
+                        fs_match=false fd_match=true vmm_match=true
+                        (divergence_action=halt)
+```
+
+All three independent sources behaved as the threat model claims:
+
+- **Source 1 (filesystem hash):** dispositive — caught the substrate tamper (`fs_match=false`)
+- **Source 2 (open-fd count):** stable across CHV restore + vsock re-handshake
+- **Source 3 (VMM API state):** stable across restore
+
+**Bugs caught and fixed during reset-cycle bring-up (5 iterations):**
+
+| Iter | Symptom                               | Root cause                                                                                                                                              | Fix                                                                                                                  |
+| ---- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| 1    | driver path resolution                | `.mjs` outside workspace can't resolve `@brainst0rm/sandbox`                                                                                            | write driver into `<repo>/packages/sandbox/.tmp/`                                                                    |
+| 2    | "VM is already created"               | ch-remote restore refused on Running VM                                                                                                                 | `snapshotRevert` does shutdown → delete → restore → resume                                                           |
+| 3    | "peer hung up" post-restore           | host-side vsock connection invalidated by CHV restore                                                                                                   | re-establish vsock via `openVsockWithRetry` post-restore                                                             |
+| 4    | `fs_match=true` always (silent no-op) | snapshot-create + reset-cycle.sh hashed phantom `BSM_OVERLAY` file CHV never wrote — baseline fs_hash was `sha256:e3b0c44...` (SHA-256 of empty string) | snapshot-create + reset-cycle.sh both default `BSM_OVERLAY` to `BSM_ROOTFS` (the file CHV's `--disk` actually reads) |
+| 5    | `fd_match=false` after restore        | `openFdCount()` counted socket fds; new vsock connection topology post-restore changed socket-fd count                                                  | filter `S_IFSOCK` from fd count; metric is now "non-socket fd count" — stable across reset                           |
+
+Iter 4's bug (empty-hash) is the highest-severity catch: the §A6 substrate-lying defense was previously a silent 2-source-effective rather than 3-source — fs_match was trivially passing every run regardless of substrate state. Caught by recognizing `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` as `SHA-256("")` in baseline JSON. Cost-of-catch ratio: ~5min review attention vs. months of fake-pass evidence accumulating before tamper detection failed in a real attack.
+
+**Stale-artifact gotcha (test harness bug):** Run-6 (intermediate) came back with the OLD failure pattern despite the fixes being merged. Cause: `reset-cycle.sh` step 3 only checks for artifact existence, not mtime against `packages/image-builder/vsock-init/main.go`. The pre-fix `bsm-sandbox-rootfs.img` (21:03Z) was reused even though `main.go` (22:43Z) had the S_IFSOCK fix. Resolved by manually deleting artifacts to force rebuild; flagged to peer for harness fix.
+
+## Cluster delta (post-1008 cold boots + 8 parallel)
+
+| Metric                          | pre-run | post-run                                        |
+| ------------------------------- | ------- | ----------------------------------------------- |
+| Free RAM                        | 44 GiB  | 44 GiB (unchanged)                              |
+| firstlight CHV processes        | 0       | **0**                                           |
+| Leftover vsock sockets          | 0       | **0**                                           |
+| Leftover per-VM rootfs overlays | 0       | **0**                                           |
+| Unrelated CHV zombies           | 2       | 2 (unchanged — phase-cleanup correctly avoided) |
+
+**Zero leaks across 1008 cold boots + 8 parallel instances.**
+
+## Failure modes that did NOT occur (worth naming)
+
+- No memory leaks (free RAM identical pre/post)
+- No socket leaks (zero leftover Unix sockets in /var/lib/firstlight/)
+- No process leaks (zero leftover CHV processes in firstlight namespace)
+- No CID collisions during concurrent allocation (CIDs 3..10 cleanly unique)
+- No vsock-init crashes (no fatalAsPID1 heartbeats observed)
+- No kernel panics (1000+ guest boots without "Attempted to kill init")
+- No CHV API errors (1000+ create/boot/shutdown cycles via REST API + ch-remote)
+- No host workload impact (brainstormvm-agent + 2 unrelated zombies undisturbed)
+
+## Provenance chain
+
+This evidence was produced via the standard run flow:
+
+1. PR #277's `feat/sandbox-phase-3-scaffold` + Codex-round-2 fixes (`7ab4d5e`) cloned to `/var/lib/firstlight/brainstorm` on Hetzner node-2
+2. `bash packages/sandbox/scripts/full-validation.sh` invoked at 19:35:55Z
+3. Three sub-reports + master report generated to `/var/lib/firstlight/`
+4. SCP'd to `/Users/justin/Projects/brainstorm/docs/validation-runs/2026-04-27-node-2/` for repo persistence
+5. log-tail.txt is the last 500 lines of the full validation log (full log too large for repo at ~10 MB)
+
+## Cross-references
+
+- **Plan:** `docs/endpoint-agent-plan.md` v3.1, §5 Phase-3 sandbox track, P3.5b validation gate
+- **Threat model:** `docs/endpoint-agent-threat-model.md` v1, §7 Red-Team Test Battery (P-LAT and P-CONC are the latency + concurrency probes)
+- **First-light driver:** `packages/sandbox/scripts/first-light.sh` (one-iter sanity baseline)
+- **Validation harness:** `packages/sandbox/scripts/full-validation.sh` (invoked here)
+- **brainstormvm operator notes:** brainstormVM peer's project memory `project_first_real_godmode_vm.md` (the brainstormVM-side first-real-VM milestone from earlier the same week, on the same host)
+
+## What this evidence supports vs does NOT support
+
+**Supports:**
+
+- Cold-boot latency claim: sub-second p99 (597ms) for sandbox bringup with full vsock RPC ready
+- Concurrency claim: ≥8 simultaneous sandboxes with isolated CIDs/sockets work
+- Resource discipline claim: phase-cleanup + trap-on-EXIT prevents leaks across thousands of dispatches
+- Stay-fixed claim: every iteration's fix from first-light's 11-layer debugging holds at scale
+- **Reset-cycle correctness:** snapshot → restore → re-handshake → verify cleanly distinguishes clean from tampered substrate (§A6)
+- **Substrate-lying (§A6) defense:** all three independent sources active and behaving per threat model — fs_hash dispositive on tamper, fd_count and vmm_state stable across restore
+
+**Does NOT yet support:**
+
+- Sandbox escape attempts (P-T2 — not in this run)
+- Network egress audit (P-T3 — not in this run)
+- Long-running workload (this is cold-boot only; sustained dispatch over hours not measured)
+- Reset cadence under sustained pressure (single tamper-detect verified, but not 100s of consecutive resets)
+
+These are the next P3.5a/b deliverables.

--- a/docs/validation-runs/2026-04-27-node-2/concurrent.json
+++ b/docs/validation-runs/2026-04-27-node-2/concurrent.json
@@ -1,0 +1,195 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-04-27T19:46:16.130Z",
+  "backend": "chv",
+  "final_sandbox_state": "not_booted",
+  "probes": [
+    {
+      "name": "P-CONC-instance-0",
+      "attacker_class": "LAT",
+      "expectation": "should-pass",
+      "validated_against": "validated-chv",
+      "description": "Concurrent fleet member 0/8: cold-boot + echo dispatch + shutdown alongside 7 other instances. Verifies cross-instance isolation (unique cid + unique vsock socket).",
+      "passed": true,
+      "reason": "boot=734ms exec=1ms shutdown=29ms exit_code=0",
+      "duration_ms": 764,
+      "errored": false,
+      "evidence": {
+        "boot_ms": 734,
+        "exec_ms": 1,
+        "shutdown_ms": 29,
+        "exit_code": 0,
+        "stdout_preview": "concurrent-probe-0\n"
+      }
+    },
+    {
+      "name": "P-CONC-instance-1",
+      "attacker_class": "LAT",
+      "expectation": "should-pass",
+      "validated_against": "validated-chv",
+      "description": "Concurrent fleet member 1/8: cold-boot + echo dispatch + shutdown alongside 7 other instances. Verifies cross-instance isolation (unique cid + unique vsock socket).",
+      "passed": true,
+      "reason": "boot=725ms exec=3ms shutdown=36ms exit_code=0",
+      "duration_ms": 764,
+      "errored": false,
+      "evidence": {
+        "boot_ms": 725,
+        "exec_ms": 3,
+        "shutdown_ms": 36,
+        "exit_code": 0,
+        "stdout_preview": "concurrent-probe-1\n"
+      }
+    },
+    {
+      "name": "P-CONC-instance-2",
+      "attacker_class": "LAT",
+      "expectation": "should-pass",
+      "validated_against": "validated-chv",
+      "description": "Concurrent fleet member 2/8: cold-boot + echo dispatch + shutdown alongside 7 other instances. Verifies cross-instance isolation (unique cid + unique vsock socket).",
+      "passed": true,
+      "reason": "boot=724ms exec=2ms shutdown=29ms exit_code=0",
+      "duration_ms": 755,
+      "errored": false,
+      "evidence": {
+        "boot_ms": 724,
+        "exec_ms": 2,
+        "shutdown_ms": 29,
+        "exit_code": 0,
+        "stdout_preview": "concurrent-probe-2\n"
+      }
+    },
+    {
+      "name": "P-CONC-instance-3",
+      "attacker_class": "LAT",
+      "expectation": "should-pass",
+      "validated_against": "validated-chv",
+      "description": "Concurrent fleet member 3/8: cold-boot + echo dispatch + shutdown alongside 7 other instances. Verifies cross-instance isolation (unique cid + unique vsock socket).",
+      "passed": true,
+      "reason": "boot=725ms exec=3ms shutdown=36ms exit_code=0",
+      "duration_ms": 764,
+      "errored": false,
+      "evidence": {
+        "boot_ms": 725,
+        "exec_ms": 3,
+        "shutdown_ms": 36,
+        "exit_code": 0,
+        "stdout_preview": "concurrent-probe-3\n"
+      }
+    },
+    {
+      "name": "P-CONC-instance-4",
+      "attacker_class": "LAT",
+      "expectation": "should-pass",
+      "validated_against": "validated-chv",
+      "description": "Concurrent fleet member 4/8: cold-boot + echo dispatch + shutdown alongside 7 other instances. Verifies cross-instance isolation (unique cid + unique vsock socket).",
+      "passed": true,
+      "reason": "boot=726ms exec=2ms shutdown=36ms exit_code=0",
+      "duration_ms": 764,
+      "errored": false,
+      "evidence": {
+        "boot_ms": 726,
+        "exec_ms": 2,
+        "shutdown_ms": 36,
+        "exit_code": 0,
+        "stdout_preview": "concurrent-probe-4\n"
+      }
+    },
+    {
+      "name": "P-CONC-instance-5",
+      "attacker_class": "LAT",
+      "expectation": "should-pass",
+      "validated_against": "validated-chv",
+      "description": "Concurrent fleet member 5/8: cold-boot + echo dispatch + shutdown alongside 7 other instances. Verifies cross-instance isolation (unique cid + unique vsock socket).",
+      "passed": true,
+      "reason": "boot=725ms exec=3ms shutdown=36ms exit_code=0",
+      "duration_ms": 764,
+      "errored": false,
+      "evidence": {
+        "boot_ms": 725,
+        "exec_ms": 3,
+        "shutdown_ms": 36,
+        "exit_code": 0,
+        "stdout_preview": "concurrent-probe-5\n"
+      }
+    },
+    {
+      "name": "P-CONC-instance-6",
+      "attacker_class": "LAT",
+      "expectation": "should-pass",
+      "validated_against": "validated-chv",
+      "description": "Concurrent fleet member 6/8: cold-boot + echo dispatch + shutdown alongside 7 other instances. Verifies cross-instance isolation (unique cid + unique vsock socket).",
+      "passed": true,
+      "reason": "boot=726ms exec=2ms shutdown=36ms exit_code=0",
+      "duration_ms": 764,
+      "errored": false,
+      "evidence": {
+        "boot_ms": 726,
+        "exec_ms": 2,
+        "shutdown_ms": 36,
+        "exit_code": 0,
+        "stdout_preview": "concurrent-probe-6\n"
+      }
+    },
+    {
+      "name": "P-CONC-instance-7",
+      "attacker_class": "LAT",
+      "expectation": "should-pass",
+      "validated_against": "validated-chv",
+      "description": "Concurrent fleet member 7/8: cold-boot + echo dispatch + shutdown alongside 7 other instances. Verifies cross-instance isolation (unique cid + unique vsock socket).",
+      "passed": true,
+      "reason": "boot=726ms exec=2ms shutdown=36ms exit_code=0",
+      "duration_ms": 764,
+      "errored": false,
+      "evidence": {
+        "boot_ms": 726,
+        "exec_ms": 2,
+        "shutdown_ms": 36,
+        "exit_code": 0,
+        "stdout_preview": "concurrent-probe-7\n"
+      }
+    }
+  ],
+  "latency": {
+    "P-CONC-boot": {
+      "samples": 8,
+      "p50_ms": 725,
+      "p90_ms": 734,
+      "p95_ms": 734,
+      "p99_ms": 734,
+      "mean_ms": 726.375,
+      "min_ms": 724,
+      "max_ms": 734
+    },
+    "P-CONC-exec": {
+      "samples": 8,
+      "p50_ms": 2,
+      "p90_ms": 3,
+      "p95_ms": 3,
+      "p99_ms": 3,
+      "mean_ms": 2.25,
+      "min_ms": 1,
+      "max_ms": 3
+    },
+    "P-CONC-shutdown": {
+      "samples": 8,
+      "p50_ms": 36,
+      "p90_ms": 36,
+      "p95_ms": 36,
+      "p99_ms": 36,
+      "mean_ms": 34.25,
+      "min_ms": 29,
+      "max_ms": 36
+    }
+  },
+  "summary": {
+    "total": 8,
+    "passed": 8,
+    "failed": 0,
+    "errored": 0,
+    "skipped": 0
+  },
+  "notes": [
+    "concurrent-8: 8/8 instances succeeded in 765ms wall-clock (parallel)",
+    "validation-provenance: mock-only=0 validated-chv=8 validated-vf=0 validated-chv-and-vf=0 (total=8)"
+  ]
+}

--- a/docs/validation-runs/2026-04-27-node-2/latency.json
+++ b/docs/validation-runs/2026-04-27-node-2/latency.json
@@ -1,0 +1,185 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-04-27T19:46:14.318Z",
+  "backend": "chv",
+  "final_sandbox_state": "not_booted",
+  "probes": [
+    {
+      "name": "P-LAT-boot",
+      "attacker_class": "LAT",
+      "expectation": "should-pass",
+      "validated_against": "validated-chv",
+      "description": "1000-iteration cold-boot latency distribution. Each iteration creates a fresh Sandbox (no warm-cache reuse). Real-CHV path: each boot is a real cloud-hypervisor spawn + vsock handshake.",
+      "passed": true,
+      "reason": "collected 1000 samples (1000 successful iterations)",
+      "duration_ms": 0,
+      "errored": false,
+      "evidence": {
+        "distribution": {
+          "samples": 1000,
+          "p50_ms": 586,
+          "p90_ms": 592,
+          "p95_ms": 594,
+          "p99_ms": 597,
+          "mean_ms": 586.597,
+          "min_ms": 576,
+          "max_ms": 604
+        },
+        "iterations_attempted": 1000,
+        "iterations_succeeded": 1000,
+        "iterations_failed": 0,
+        "failure_phases": {
+          "boot": 0,
+          "exec": 0,
+          "shutdown": 0
+        }
+      }
+    },
+    {
+      "name": "P-LAT-roundtrip",
+      "attacker_class": "LAT",
+      "expectation": "should-pass",
+      "validated_against": "validated-chv",
+      "description": "1000-iteration cold-roundtrip latency distribution. Each iteration creates a fresh Sandbox (no warm-cache reuse). Real-CHV path: each boot is a real cloud-hypervisor spawn + vsock handshake.",
+      "passed": true,
+      "reason": "collected 1000 samples (1000 successful iterations)",
+      "duration_ms": 0,
+      "errored": false,
+      "evidence": {
+        "distribution": {
+          "samples": 1000,
+          "p50_ms": 2,
+          "p90_ms": 2,
+          "p95_ms": 2,
+          "p99_ms": 2,
+          "mean_ms": 1.631,
+          "min_ms": 1,
+          "max_ms": 2
+        },
+        "iterations_attempted": 1000,
+        "iterations_succeeded": 1000,
+        "iterations_failed": 0,
+        "failure_phases": {
+          "boot": 0,
+          "exec": 0,
+          "shutdown": 0
+        }
+      }
+    },
+    {
+      "name": "P-LAT-shutdown",
+      "attacker_class": "LAT",
+      "expectation": "should-pass",
+      "validated_against": "validated-chv",
+      "description": "1000-iteration cold-shutdown latency distribution. Each iteration creates a fresh Sandbox (no warm-cache reuse). Real-CHV path: each boot is a real cloud-hypervisor spawn + vsock handshake.",
+      "passed": true,
+      "reason": "collected 1000 samples (1000 successful iterations)",
+      "duration_ms": 0,
+      "errored": false,
+      "evidence": {
+        "distribution": {
+          "samples": 1000,
+          "p50_ms": 24,
+          "p90_ms": 30,
+          "p95_ms": 31,
+          "p99_ms": 36,
+          "mean_ms": 23.475,
+          "min_ms": 14,
+          "max_ms": 46
+        },
+        "iterations_attempted": 1000,
+        "iterations_succeeded": 1000,
+        "iterations_failed": 0,
+        "failure_phases": {
+          "boot": 0,
+          "exec": 0,
+          "shutdown": 0
+        }
+      }
+    },
+    {
+      "name": "P-LAT-total",
+      "attacker_class": "LAT",
+      "expectation": "should-pass",
+      "validated_against": "validated-chv",
+      "description": "1000-iteration cold-total latency distribution. Each iteration creates a fresh Sandbox (no warm-cache reuse). Real-CHV path: each boot is a real cloud-hypervisor spawn + vsock handshake.",
+      "passed": true,
+      "reason": "collected 1000 samples (1000 successful iterations)",
+      "duration_ms": 0,
+      "errored": false,
+      "evidence": {
+        "distribution": {
+          "samples": 1000,
+          "p50_ms": 611,
+          "p90_ms": 620,
+          "p95_ms": 622,
+          "p99_ms": 628,
+          "mean_ms": 611.82,
+          "min_ms": 596,
+          "max_ms": 638
+        },
+        "iterations_attempted": 1000,
+        "iterations_succeeded": 1000,
+        "iterations_failed": 0,
+        "failure_phases": {
+          "boot": 0,
+          "exec": 0,
+          "shutdown": 0
+        }
+      }
+    }
+  ],
+  "latency": {
+    "P-LAT-boot": {
+      "samples": 1000,
+      "p50_ms": 586,
+      "p90_ms": 592,
+      "p95_ms": 594,
+      "p99_ms": 597,
+      "mean_ms": 586.597,
+      "min_ms": 576,
+      "max_ms": 604
+    },
+    "P-LAT-roundtrip": {
+      "samples": 1000,
+      "p50_ms": 2,
+      "p90_ms": 2,
+      "p95_ms": 2,
+      "p99_ms": 2,
+      "mean_ms": 1.631,
+      "min_ms": 1,
+      "max_ms": 2
+    },
+    "P-LAT-shutdown": {
+      "samples": 1000,
+      "p50_ms": 24,
+      "p90_ms": 30,
+      "p95_ms": 31,
+      "p99_ms": 36,
+      "mean_ms": 23.475,
+      "min_ms": 14,
+      "max_ms": 46
+    },
+    "P-LAT-total": {
+      "samples": 1000,
+      "p50_ms": 611,
+      "p90_ms": 620,
+      "p95_ms": 622,
+      "p99_ms": 628,
+      "mean_ms": 611.82,
+      "min_ms": 596,
+      "max_ms": 638
+    }
+  },
+  "summary": {
+    "total": 4,
+    "passed": 4,
+    "failed": 0,
+    "errored": 0,
+    "skipped": 0
+  },
+  "notes": [
+    "total wall-clock: 611853ms (611.9ms/iter avg)",
+    "validation-provenance: mock-only=0 validated-chv=4 validated-vf=0 validated-chv-and-vf=0 (total=4)"
+  ]
+}

--- a/docs/validation-runs/2026-04-27-node-2/log-tail.txt
+++ b/docs/validation-runs/2026-04-27-node-2/log-tail.txt
@@ -1,0 +1,500 @@
+[    0.099845] rodata_test: all tests were succe
+[chv-sandbox] [chv stdout] ssful
+[    0.099886] R
+[chv-sandbox] [chv stdout] un /init as init process
+[chv-sandbox] [chv stdout] [    0.087491] Segment Routing w
+[chv-sandbox] [chv stdout] ith IPv6
+[    0.087537] In-situ OAM (IOAM
+[chv-sandbox] [chv stdout] ) with IPv6
+[chv-sandbox] [chv stdout] [    0.087638] K
+[chv-sandbox] [chv stdout] ey type dns_resolver registered
+[chv-sandbox] [chv stdout] [    0.087740] I
+[chv-sandbox] [chv stdout] PI shorthand broadcast: enabled
+[chv-sandbox] [chv stdout] [    0.113561] L
+[chv-sandbox] [chv stdout] oaded X.509 cert 'alpinelinux.org: Alpine Linux
+[chv-sandbox] [chv stdout] kernel key: d76a695f66ad9cd28f5c
+[chv-sandbox] [chv stdout] 22a8508f36e91f52
+[chv-sandbox] [chv stdout] 1f7a'
+[chv-sandbox] [chv stdout] [    0.090468] registered taskst
+[chv-sandbox] [chv stdout] ats version 1
+[chv-sandbox] [chv stdout] [    0.090585] L
+[chv-sandbox] [chv stdout] oading compiled-in X.509 certificates
+[chv-sandbox] [chv stdout] [    0.101789] Key type .fscrypt registered
+[chv-sandbox] [chv stdout] [    0.101841] Key type fscrypt-provisioning registered
+[chv-sandbox] [chv stdout] [    0.089543] sched_clock: Mark
+[chv-sandbox] [chv stdout] ing stable (85246846, 2379283)->(111599680, -23973551)
+[chv-sandbox] [chv stdout] [    0.102319] Freeing unused kernel image (initmem) memory: 2728K
+[chv-sandbox] [chv stdout] [    0.102369] Write protecting
+[chv-sandbox] [chv stdout] the kernel read-only data: 24576k
+[chv-sandbox] [chv stdout] [    0.115868] Key type .fscrypt
+[chv-sandbox] [chv stdout]  registered
+[    0.115926] Key type fscrypt-provisioning registered
+[chv-sandbox] [chv stdout] [    0.103251] F
+[chv-sandbox] [chv stdout] reeing unused kernel image (rodata/data gap) memory: 1944K
+[    0.103326] r
+[chv-sandbox] [chv stdout] odata_test: all tests were successful
+[chv-sandbox] [chv stdout] [    0.103370] Run /init as init
+[chv-sandbox] [chv stdout]  process
+[chv-sandbox] [chv stdout] [    0.100098] Freeing initrd me
+[chv-sandbox] [chv stdout] mory: 9356K
+[chv-sandbox] [chv stdout] [    0.116913] Freeing unused ke
+[chv-sandbox] [chv stdout] rnel image (initmem) memory: 272
+[chv-sandbox] [chv stdout] 8K
+[chv-sandbox] [chv stdout] [    0.117020] Write protecting
+[chv-sandbox] [chv stdout] the kernel read-only data: 24576
+[chv-sandbox] [chv stdout] k
+[chv-sandbox] [chv stdout] [    0.105974] Freeing initrd me
+[chv-sandbox] [chv stdout] [    0.117468] Freeing unused kernel image (rodata/data gap) memory: 1944K
+[    0.117538] rodata_test: all
+[chv-sandbox] [chv stdout] mory: 9356K
+[chv-sandbox] [chv stdout] tests were successful
+[    0.117579] Run /init as init process
+[chv-sandbox] [chv stdout] [    0.094482] Loaded X.509 cert
+[chv-sandbox] [chv stdout]  'alpinelinux.org: Alpine Linux kernel key: d76a695f66ad9cd28f5c22a8508f36e91f521f7a'
+[chv-sandbox] [chv stdout] [    0.093464] registered taskstats version 1
+[chv-sandbox] [chv stdout] [    0.093618] Loading compiled-in X.509 certificates
+[chv-sandbox] [chv stdout] [    0.119620] Alpine Init 3.10.
+[chv-sandbox] [chv stdout] 1-r0
+[chv-sandbox] [chv stdout] Alpine Init 3.10.1-r0
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] [    0.096278] Key type .fscrypt
+[chv-sandbox] [chv stdout]  registered
+[    0.096331] Key type fscrypt-provisioning registered
+[chv-sandbox] [chv stdout] [    0.119889] Loading boot driv
+[chv-sandbox] [chv stdout] ers...
+[chv-sandbox] [chv stdout]  * Loading boot drivers:
+[chv-sandbox] [chv stdout] [    0.096785] Freeing unused kernel image (init
+[chv-sandbox] [chv stdout] mem) memory: 2728K
+[    0.096859] Write protecting the kernel read-only data: 24576k
+[chv-sandbox] [chv stdout] [    0.097205] Freeing unused kernel image (roda
+[chv-sandbox] [chv stdout] ta/data gap) memory: 1944K
+[    0.097275] rodata_test: all tests were succe
+[chv-sandbox] [chv stdout] [    0.107416] Alpine Init 3.10.1-r0
+Alpine Init 3.10.1-r0
+[    0.107638] Loading boot drivers...
+ * Loading boot drivers:
+[chv-sandbox] [chv stdout] ssful
+[    0.097339] Run /init as init process
+[chv-sandbox] [chv stdout] [    0.111259] Loaded X.509 cert 'alpinelinux.org: Alpine Linux
+[chv-sandbox] [chv stdout] kernel key: d76a695f66ad9cd28f5c22a8508f36e91f521f7a'
+[chv-sandbox] [chv stdout] [    0.110311] Alpine Init 3.10.
+[chv-sandbox] [chv stdout] 1-r0
+[chv-sandbox] [chv stdout] Alpine Init 3.10.1-r0
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] [    0.110539] Loading boot driv
+[chv-sandbox] [chv stdout] ers...
+ * Loading boot drivers:
+[chv-sandbox] [chv stdout] [    0.106749] Loaded X.509 cert
+[chv-sandbox] [chv stdout]  'alpinelinux.org: Alpine Linux kernel key: d76a695f66ad9cd28f5c
+[chv-sandbox] [chv stdout] 22a8508f36e91f521f7a'
+[chv-sandbox] [chv stdout] [    0.097919] Loaded X.509 cert 'alpinelinux.org: Alpine Linux
+[chv-sandbox] [chv stdout] kernel key: d76a695f66ad9cd28f5c22a8508f36e91f521f7a'
+[chv-sandbox] [chv stdout] [    0.113045] Key type .fscrypt
+[chv-sandbox] [chv stdout]  registered
+[    0.113099] Key type fscrypt-provisioning registered
+[chv-sandbox] [chv stdout] [    0.113531] F
+[chv-sandbox] [chv stdout] reeing unused kernel image (initmem) memory: 2728K
+[chv-sandbox] [chv stdout] [    0.113602] Write protecting
+[chv-sandbox] [chv stdout] the kernel read-only data: 24576k
+[chv-sandbox] [chv stdout] [    0.108449] Key type .fscrypt
+[chv-sandbox] [chv stdout]  registered
+[    0.108495] Key type fscrypt-
+[chv-sandbox] [chv stdout] provisioning registered
+[chv-sandbox] [chv stdout] [    0.113972] F
+[chv-sandbox] [chv stdout] reeing unused kernel image (rodata/data gap) mem
+[chv-sandbox] [chv stdout] ory: 1944K
+[    0.114033] r
+[chv-sandbox] [chv stdout] odata_test: all tests were succe
+[chv-sandbox] [chv stdout] ssful
+[    0.114073] R
+[chv-sandbox] [chv stdout] un /init as init process
+[chv-sandbox] [chv stdout] [    0.125553] A
+[chv-sandbox] [chv stdout] lpine Init 3.10.1-r0
+[chv-sandbox] [chv stdout] Alpine Init 3.10.1-r0
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] [    0.108928] Freeing unused kernel image (initmem) memory: 272
+[chv-sandbox] [chv stdout] 8K
+[    0.108976] W
+[chv-sandbox] [chv stdout] rite protecting the kernel read-only data: 24576
+[chv-sandbox] [chv stdout] k
+[chv-sandbox] [chv stdout] [    0.125801] L
+[chv-sandbox] [chv stdout] oading boot drivers...
+[chv-sandbox] [chv stdout] [    0.100224] Key type .fscrypt
+[chv-sandbox] [chv stdout]  registered
+[    0.100269] K
+[chv-sandbox] [chv stdout] ey type fscrypt-provisioning reg
+[chv-sandbox] [chv stdout] istered
+[chv-sandbox] [chv stdout] [    0.109305] Freeing unused ke
+[chv-sandbox] [chv stdout] rnel image (rodata/data gap) memory: 1944K
+[chv-sandbox] [chv stdout] [    0.109362] r
+[chv-sandbox] [chv stdout] odata_test: all tests were succe
+[chv-sandbox] [chv stdout] ssful
+[chv-sandbox] [chv stdout] [    0.109399] Run /init as init
+[chv-sandbox] [chv stdout]  process
+[chv-sandbox] [chv stdout] [    0.100741] Freeing unused ke
+[chv-sandbox] [chv stdout] rnel image (initmem) memory: 272
+[chv-sandbox] [chv stdout] 8K
+[    0.100789] W
+[chv-sandbox] [chv stdout] rite protecting the kernel read-
+[chv-sandbox] [chv stdout] only data: 24576k
+[chv-sandbox] [chv stdout] [    0.101168] F
+[chv-sandbox] [chv stdout] reeing unused kernel image (roda
+[chv-sandbox] [chv stdout] ta/data gap) mem
+[chv-sandbox] [chv stdout] ory: 1944K
+[chv-sandbox] [chv stdout] [    0.101218] rodata_test: all
+[chv-sandbox] [chv stdout] tests were succe
+[chv-sandbox] [chv stdout] ssful
+[chv-sandbox] [chv stdout] [    0.101255] Run /init as init
+[chv-sandbox] [chv stdout]  process
+[chv-sandbox] [chv stdout]  * Loading boot drivers:
+[chv-sandbox] [chv stdout] [    0.104628] Alpine Init 3.10.
+[chv-sandbox] [chv stdout] 1-r0
+Alpine Init 3.10.1-r0
+[chv-sandbox] [chv stdout] [    0.104830] Loading boot driv
+[chv-sandbox] [chv stdout] ers...
+ * Loading boot drivers:
+[chv-sandbox] [chv stdout] [    0.120685] Alpine Init 3.10.1-r0
+[chv-sandbox] [chv stdout] Alpine Init 3.10.1-r0
+[    0.120889] Loading boot driv
+[chv-sandbox] [chv stdout] ers...
+[chv-sandbox] [chv stdout] [    0.115621] Alpine Init 3.10.1-r0
+[chv-sandbox] [chv stdout]  * Loading boot drivers:
+[chv-sandbox] [chv stdout] Alpine Init 3.10.1-r0
+[chv-sandbox] [chv stdout] [    0.115830] Loading boot driv
+[chv-sandbox] [chv stdout] ers...
+[chv-sandbox] [chv stdout]  * Loading boot drivers:
+[chv-sandbox] [chv stdout] [    0.108605] Alpine Init 3.10.1-r0
+[chv-sandbox] [chv stdout] Alpine Init 3.10.1-r0
+[chv-sandbox] [chv stdout] [    0.108826] L
+[chv-sandbox] [chv stdout] oading boot drivers...
+ * Loading boot drivers:
+[chv-sandbox] [chv stdout] [    0.149468] loop: module loaded
+[chv-sandbox] [chv stdout] [    0.150606] loop: module load
+[chv-sandbox] [chv stdout] ed
+[chv-sandbox] [chv stdout] [    0.165553] loop: module load
+[chv-sandbox] [chv stdout] ed
+[chv-sandbox] [chv stdout] [    0.167831] loop: module load
+[chv-sandbox] [chv stdout] ed
+[chv-sandbox] [chv stdout] [    0.146505] loop: module loaded
+[chv-sandbox] [chv stdout] [    0.153529] loop: module load
+[chv-sandbox] [chv stdout] ed
+[chv-sandbox] [chv stdout] [    0.159893] loop: module loaded
+[chv-sandbox] [chv stdout] [    0.149561] loop: module loaded
+[chv-sandbox] [chv stdout] [    0.166865] ACPI: bus type drm_connector registered
+[chv-sandbox] [chv stdout] [    0.184704] ACPI: bus type drm_connector registered
+[chv-sandbox] [chv stdout] [    0.171924] A
+[chv-sandbox] [chv stdout] CPI: bus type drm_connector registered
+[chv-sandbox] [chv stdout] [    0.185830] A
+[chv-sandbox] [chv stdout] CPI: bus type drm_connector registered
+[chv-sandbox] [chv stdout] [    0.170334] A
+[chv-sandbox] [chv stdout] CPI: bus type drm_connector registered
+[chv-sandbox] [chv stdout] [    0.164255] ACPI: bus type dr
+[chv-sandbox] [chv stdout] m_connector registered
+[chv-sandbox] [chv stdout] [    0.176568] ACPI: bus type dr
+[chv-sandbox] [chv stdout] m_connector registered
+[chv-sandbox] [chv stdout] [    0.166645] ACPI: bus type drm_connector regi
+[chv-sandbox] [chv stdout] stered
+[chv-sandbox] [chv stdout] [    0.181290] Loading boot drivers: ok.
+[chv-sandbox] [chv stdout] ok.
+[chv-sandbox] [chv stdout] [    0.182233] Mounting root...
+[chv-sandbox] [chv stdout] 
+ * Mounting root:
+[chv-sandbox] [chv stdout] [    0.186180] Loading boot drivers: ok.
+[chv-sandbox] [chv stdout] ok.
+[chv-sandbox] [chv stdout] [    0.199765] Loading boot driv
+[chv-sandbox] [chv stdout] ers: ok.
+ok.
+[chv-sandbox] [chv stdout] [    0.187316] Mounting root...
+[chv-sandbox] [chv stdout] 
+ * Mounting root:
+[chv-sandbox] [chv stdout] [    0.200941] Mounting root...
+[chv-sandbox] [chv stdout] 
+ * Mounting root:
+[chv-sandbox] [chv stdout] [    0.200711] Loading boot drivers: ok.
+ok.
+[chv-sandbox] [chv stdout] [    0.201845] Mounting root...
+[chv-sandbox] [chv stdout]  * Mounting root:
+[chv-sandbox] [chv stdout] [    0.185183] Loading boot drivers: ok.
+ok.
+[chv-sandbox] [chv stdout] [    0.191026] Loading boot driv
+[chv-sandbox] [chv stdout] ers: ok.
+ok.
+[chv-sandbox] [chv stdout] [    0.179741] Loading boot drivers: ok.
+[chv-sandbox] [chv stdout] ok.
+[chv-sandbox] [chv stdout] [    0.186309] Mounting root...
+ * Mounting root:
+[chv-sandbox] [chv stdout] [    0.192048] Mounting root...
+[chv-sandbox] [chv stdout] 
+ * Mounting root:
+[chv-sandbox] [chv stdout] [    0.180871] Mounting root...
+[chv-sandbox] [chv stdout]  * Mounting root:
+[chv-sandbox] [chv stdout] [    0.195398] virtio_blk virtio1: 1/0/0 default
+[chv-sandbox] [chv stdout] /read/poll queues
+[chv-sandbox] [chv stdout] [    0.183638] Loading boot driv
+[chv-sandbox] [chv stdout] ers: ok.
+ok.
+[chv-sandbox] [chv stdout] [    0.196604] virtio_blk virtio1: [vda] 524288
+[chv-sandbox] [chv stdout] 512-byte logical blocks (268 MB/256 MiB)
+[chv-sandbox] [chv stdout] [    0.185062] Mounting root...
+[chv-sandbox] [chv stdout]  * Mounting root:
+[chv-sandbox] [chv stdout] [    0.214683] virtio_blk virtio1: 1/0/0 default/read/poll queues
+[chv-sandbox] [chv stdout] [    0.216755] virtio_blk virtio
+[chv-sandbox] [chv stdout] 1: [vda] 524288 512-byte logical blocks (268 MB/256 MiB)
+[chv-sandbox] [chv stdout] cat: can't open '/sys/class/virtio-ports/vport0p0/name': No such file or directory
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] cat: can't open '/sys/class/virtio-ports/vport0p0/name': No such file or directory
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] [    0.209459] virtio_blk virtio1: 1/0/0 default/read/poll queue
+[chv-sandbox] [chv stdout] s
+[chv-sandbox] [chv stdout] [    0.199574] virtio_blk virtio
+[chv-sandbox] [chv stdout] 1: 1/0/0 default/read/poll queues
+[chv-sandbox] [chv stdout] cat: can't open '/sys/class/virtio-ports/vport0p0/name': No such file or directory
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] [    0.200693] virtio_blk virtio
+[chv-sandbox] [chv stdout] 1: [vda] 524288 512-byte logical blocks (268 MB/256 MiB)
+[chv-sandbox] [chv stdout] [    0.212555] virtio_blk virtio
+[chv-sandbox] [chv stdout] 1: 1/0/0 default/read/poll queues
+[chv-sandbox] [chv stdout] cat: can't open '/sys/class/virtio-ports/vport0p0/name': No such file or directory
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] [    0.210593] v
+[chv-sandbox] [chv stdout] irtio_blk virtio1: [vda] 524288 512-byte logical
+[chv-sandbox] [chv stdout] [    0.222976] v
+[chv-sandbox] [chv stdout] irtio_blk virtio1: 1/0/0 default/read/poll queues
+[chv-sandbox] [chv stdout] [    0.213657] v
+[chv-sandbox] [chv stdout] irtio_blk virtio1: [vda] 524288 512-byte logical
+[chv-sandbox] [chv stdout]  blocks (268 MB/256 MiB)
+[chv-sandbox] [chv stdout] [    0.208739] virtio_blk virtio
+[chv-sandbox] [chv stdout] 1: 1/0/0 default/read/poll queues
+[chv-sandbox] [chv stdout]  blocks (268 MB/256 MiB)
+[chv-sandbox] [chv stdout] [    0.226338] virtio_blk virtio
+[chv-sandbox] [chv stdout] 1: [vda] 524288 512-byte logical blocks (268 MB/256 MiB)
+[chv-sandbox] [chv stdout] [    0.209843] virtio_blk virtio
+[chv-sandbox] [chv stdout] 1: [vda] 524288
+[chv-sandbox] [chv stdout] 512-byte logical blocks (268 MB/
+[chv-sandbox] [chv stdout] 256 MiB)
+[chv-sandbox] [chv stdout] [    0.202953] virtio_blk virtio1: 1/0/0 default/read/poll queue
+[chv-sandbox] [chv stdout] s
+[chv-sandbox] [chv stdout] cat: can't open '/sys/class/virtio-ports/vport0p0/name': No such file or directory
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] cat: can't open '/sys/class/virtio-ports/vport0p0/name': No such file or directory
+[chv-sandbox] [chv stdout] [    0.203982] virtio_blk virtio1: [vda] 524288
+[chv-sandbox] [chv stdout] 512-byte logical blocks (268 MB/256 MiB)
+[chv-sandbox] [chv stdout] cat: can't open '/sys/class/virtio-ports/vport0p0/name': No such file or directory
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] cat: can't open '/sys/class/virtio-ports/vport0p0/name': No such file or directory
+[chv-sandbox] [chv stdout] [    0.300763] EXT4-fs (vda): wr
+[chv-sandbox] [chv stdout] ite access unavailable, skipping orphan cleanup
+[    0.301001] EXT4-fs (vda): mo
+[chv-sandbox] [chv stdout] unted filesystem e3c129f9-ded9-439c-b8a0-d29e1059430a ro with ordered data mode.
+[chv-sandbox] [chv stdout]  Quota mode: none.
+[chv-sandbox] [chv stdout] [    0.301269] Mounting root: ok
+[chv-sandbox] [chv stdout] .
+ok.
+[chv-sandbox] [chv stdout] [    0.316443] EXT4-fs (vda): write access unavailable, skipping
+[chv-sandbox] [chv stdout]  orphan cleanup
+[    0.316564] EXT4-fs (vda): mounted filesystem e3c129f9-ded9-439c-b8a0-d29e1059430a ro with ordered data mode. Quota mode: none.
+[chv-sandbox] [chv stdout] [    0.316810] Mounting root: ok
+[chv-sandbox] [chv stdout] .
+ok.
+[chv-sandbox] [chv stdout] [    0.293898] EXT4-fs (vda): write access unavailable, skipping
+[chv-sandbox] [chv stdout]  orphan cleanup
+[    0.294015] EXT4-fs (vda): mounted filesystem e3c129f9-ded9-439c-b8a0-d29e1059430a ro with ordered data mode.
+[chv-sandbox] [chv stdout] [    0.319559] EXT4-fs (vda): write access unavailable, skipping orphan cleanup
+[chv-sandbox] [chv stdout] [    0.306789] EXT4-fs (vda): write access unavailable, skipping orphan cleanup
+[chv-sandbox] [chv stdout]  Quota mode: none.
+[chv-sandbox] [chv stdout] [    0.306905] EXT4-fs (vda): mounted filesystem e3c129f9-ded9-439c-b8a0-d29e1059430a ro with or
+[chv-sandbox] [chv stdout] dered data mode. Quota mode: none.
+[chv-sandbox] [chv stdout] [    0.294325] M
+[chv-sandbox] [chv stdout] ounting root: ok.
+ok.
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] [    0.307154] Mounting root: ok.
+ok.
+[chv-sandbox] [chv stdout] [    0.303505] EXT4-fs (vda): write access unavailable, skipping orphan cleanup
+[chv-sandbox] [chv stdout] [    0.303634] EXT4-fs (vda): mounted filesystem e3c129f9-ded9-439c-b8a0-d29e1059430a ro with ordered data mode.
+[chv-sandbox] [chv stdout]  Quota mode: none.
+[chv-sandbox] [chv stdout] [    0.303890] Mounting root: ok
+[chv-sandbox] [chv stdout] .
+ok.
+[chv-sandbox] [chv stdout] [    0.319661] E
+[chv-sandbox] [chv stdout] XT4-fs (vda): mounted filesystem e3c129f9-ded9-4
+[chv-sandbox] [chv stdout] 39c-b8a0-d29e1059430a ro with ordered data mode. Quota mode: none.
+[chv-sandbox] [chv stdout] [    0.309754] EXT4-fs (vda): wr
+[chv-sandbox] [chv stdout] ite access unavailable, skipping orphan cleanup
+[chv-sandbox] [chv stdout] [    0.309849] EXT4-fs (vda): mo
+[chv-sandbox] [chv stdout] unted filesystem e3c129f9-ded9-4
+[chv-sandbox] [chv stdout] 39c-b8a0-d29e1059430a ro with ordered data mode. Quota mode: none.
+[chv-sandbox] [chv stdout] [    0.321364] Mounting root: ok.
+ok.
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] [    0.298193] EXT4-fs (vda): write access unava
+[chv-sandbox] [chv stdout] ilable, skipping orphan cleanup
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] [    0.298300] EXT4-fs (vda): mo
+[chv-sandbox] [chv stdout] unted filesystem e3c129f9-ded9-439c-b8a0-d29e105
+[chv-sandbox] [chv stdout] 9430a ro with ordered data mode.
+[chv-sandbox] [chv stdout] [    0.310121] Mounting root: ok.
+[chv-sandbox] [chv stdout]  Quota mode: none.
+[chv-sandbox] [chv stdout] ok.
+[chv-sandbox] [chv stdout] [    0.298568] Mounting root: ok
+[chv-sandbox] [chv stdout] .
+[chv-sandbox] [chv stdout] ok.
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] [    0.320143] NET: Registered P
+[chv-sandbox] [chv stdout] F_VSOCK protocol
+[chv-sandbox] [chv stdout]  family
+[chv-sandbox] [chv stdout] vsock-init: modprobe vsock: ok
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] [    0.335489] N
+[chv-sandbox] [chv stdout] ET: Registered PF_VSOCK protocol family
+[chv-sandbox] [chv stdout] vsock-init: modprobe vsock: ok
+[chv-sandbox] [chv stdout] [    0.327155] NET: Registered PF_VSOCK protocol
+[chv-sandbox] [chv stdout]  family
+[chv-sandbox] [chv stdout] [    0.323603] NET: Registered P
+[chv-sandbox] [chv stdout] F_VSOCK protocol family
+[chv-sandbox] [chv stdout] vsock-init: modprobe vsock: ok
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] [    0.317691] N
+[chv-sandbox] [chv stdout] ET: Registered PF_VSOCK protocol family
+[chv-sandbox] [chv stdout] vsock-init: modprobe vsock: ok
+[chv-sandbox] [chv stdout] [    0.315622] NET: Registered P
+[chv-sandbox] [chv stdout] F_VSOCK protocol family
+[chv-sandbox] [chv stdout] [    0.341341] N
+[chv-sandbox] [chv stdout] ET: Registered PF_VSOCK protocol family
+[chv-sandbox] [chv stdout] vsock-init: modprobe vsock: ok
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] [    0.330223] NET: Registered P
+[chv-sandbox] [chv stdout] F_VSOCK protocol family
+[chv-sandbox] [chv stdout] vsock-init: modprobe vmw_vsock_virtio_transport_common: ok
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] vsock-init: modprobe vsock: ok
+[chv-sandbox] [chv stdout] vsock-init: modprobe vsock: ok
+[chv-sandbox] [chv stdout] vsock-init: modprobe vsock: ok
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] vsock-init: modprobe vmw_vsock_virtio_transport_common: ok
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] vsock-init: modprobe vmw_vsock_virtio_transport_common: ok
+[chv-sandbox] [chv stdout] vsock-init: modprobe vmw_vsock_virtio_transport_common: ok
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] vsock-init: modprobe vmw_vsock_virtio_transport_common: ok
+[chv-sandbox] [chv stdout] vsock-init: modprobe vmw_vsock_virtio_transport_common: ok
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] vsock-init: modprobe vmw_vsock_virtio_transport_common: ok
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] vsock-init: modprobe vmw_vsock_virtio_transport: ok
+[chv-sandbox] [chv stdout] vsock-init: modprobe vmw_vsock_virtio_transport_common: ok
+[chv-sandbox] [chv stdout] vsock-init: modprobe vmw_vsock_virtio_transport: ok
+[chv-sandbox] [chv stdout] vsock-init: modprobe vmw_vsock_virtio_transport: ok
+[chv-sandbox] [chv stdout] vsock-init: modprobe virtio_vsock: exit status 1 (output: modprobe: FATAL: Module virtio_vsock not found in directory /lib/modules/6.6.134-0-virt
+)
+vsock-init: about to vsock.Listen(port=52000)
+[chv-sandbox] [chv stdout] vsock-init: Listen returned ok; listening on vsock port 52000
+[chv-sandbox] [chv stdout] vsock-init: modprobe vmw_vsock_virtio_transport: ok
+[chv-sandbox] [chv stdout] vsock-init: entering accept() loop
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] vsock-init: modprobe vmw_vsock_virtio_transport: ok
+[chv-sandbox] [chv stdout] vsock-init: modprobe virtio_vsock: exit status 1 (output: modprobe: FATAL: Module virtio_vsock not found in directory /lib/modules/6.6.134-0-virt
+)
+vsock-init: about to vsock.Listen(port=52000)
+[chv-sandbox] [chv stdout] vsock-init: Listen returned ok; listening on vsock port 52000
+[chv-sandbox] [chv stdout] vsock-init: modprobe vmw_vsock_virtio_transport: ok
+[chv-sandbox] [chv stdout] vsock-init: entering accept() loop
+[chv-sandbox] [chv stdout] vsock-init: modprobe virtio_vsock: exit status 1 (output: modprobe: FATAL: Module virtio_vsock not found in directory /lib/modules/6.6.134-0-virt
+[chv-sandbox] [chv stdout] 
+)
+[chv-sandbox] [chv stdout] vsock-init: about to vsock.Listen(port=52000)
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] vsock-init: modprobe vmw_vsock_virtio_transport: ok
+[chv-sandbox] [chv stdout] vsock-init: Listen returned ok; listening on vsock port 52000
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] vsock-init: modprobe virtio_vsock: exit status 1 (output: modprobe: FATAL: Module virtio_vsock not found in directory /lib/modules/6.6.134-0-virt
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] )
+[chv-sandbox] [chv stdout] vsock-init: entering accept() loop
+[chv-sandbox] [chv stdout] vsock-init: about to vsock.Listen(port=52000)
+[chv-sandbox] [chv stdout] vsock-init: Listen returned ok; listening on vsock port 52000
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] vsock-init: modprobe virtio_vsock: exit status 1 (output: modprobe: FATAL: Module virtio_vsock not found in directory /lib/modules/6.6.134-0-virt
+[chv-sandbox] [chv stdout] 
+)
+vsock-init: about to vsock.Listen(port=52000)
+[chv-sandbox] [chv stdout] vsock-init: entering accept() loop
+[chv-sandbox] [chv stdout] vsock-init: Listen returned ok; listening on vsock port 52000
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] vsock-init: entering accept() loop
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] vsock-init: modprobe virtio_vsock: exit status 1 (output: modprobe: FATAL: Module virtio_vsock not found in directory /lib/modules/6.6.134-0-virt
+[chv-sandbox] [chv stdout] 
+)
+vsock-init: about to vsock.Listen(port=52000)
+[chv-sandbox] [chv stdout] vsock-init: Listen returned ok; listening on vsock port 52000
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] vsock-init: entering accept() loop
+[chv-sandbox] [chv stdout] vsock-init: modprobe virtio_vsock: exit status 1 (output: modprobe: FATAL: Module virtio_vsock not found in directory /lib/modules/6.6.134-0-virt
+)
+vsock-init: about to vsock.Listen(port=52000)
+[chv-sandbox] [chv stdout] vsock-init: Listen returned ok; listening on vsock port 52000
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] vsock-init: entering accept() loop
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] vsock-init: modprobe vmw_vsock_virtio_transport: ok
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] vsock-init: modprobe virtio_vsock: exit status 1 (output: modprobe: FATAL: Module virtio_vsock not found in directory /lib/modules/6.6.134-0-virt
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] )
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] vsock-init: about to vsock.Listen(port=52000)
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] vsock-init: Listen returned ok; listening on vsock port 52000
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [chv stdout] vsock-init: entering accept() loop
+[chv-sandbox] [chv stdout] 
+[chv-sandbox] [vsock] handshake ok: connected to guest port 52000 as source 1073741825
+[chv-sandbox] [vsock] handshake succeeded on attempt 2 (took 654ms total)
+[chv-sandbox] [chv stdout] vsock-init: accepted connection host(2):1073741825 -> vm(5):52000
+[chv-sandbox] [vsock] handshake ok: connected to guest port 52000 as source 1073741825
+[chv-sandbox] [vsock] handshake succeeded on attempt 2 (took 655ms total)
+[chv-sandbox] [vsock] handshake ok: connected to guest port 52000 as source 1073741825
+[chv-sandbox] [vsock] handshake succeeded on attempt 2 (took 655ms total)
+[chv-sandbox] [vsock] handshake ok: connected to guest port 52000 as source 1073741825
+[chv-sandbox] [vsock] handshake succeeded on attempt 2 (took 655ms total)
+[chv-sandbox] [vsock] handshake ok: connected to guest port 52000 as source 1073741825
+[chv-sandbox] [vsock] handshake succeeded on attempt 2 (took 656ms total)
+[chv-sandbox] [chv stdout] vsock-init: accepted connection host(2):1073741825 -> vm(6):52000
+[chv-sandbox] [chv stdout] vsock-init: accepted connection host(2):1073741825 -> vm(4):52000
+[chv-sandbox] [chv stdout] vsock-init: accepted connection host(2):1073741825 -> vm(8):52000
+[chv-sandbox] [chv stdout] vsock-init: accepted connection host(2):1073741825 -> vm(9):52000
+[chv-sandbox] [vsock] handshake ok: connected to guest port 52000 as source 1073741825
+[chv-sandbox] [vsock] handshake succeeded on attempt 2 (took 656ms total)
+[chv-sandbox] [chv stdout] vsock-init: accepted connection host(2):1073741825 -> vm(10):52000
+[chv-sandbox] [chv stdout] vsock-init: accepted connection host(2):1073741825 -> vm(7):52000
+[chv-sandbox] [vsock] handshake ok: connected to guest port 52000 as source 1073741825
+[chv-sandbox] [vsock] handshake succeeded on attempt 2 (took 656ms total)
+[chv-sandbox] [vsock] handshake ok: connected to guest port 52000 as source 1073741825
+[chv-sandbox] [vsock] handshake succeeded on attempt 2 (took 665ms total)
+[chv-sandbox] [chv stdout] vsock-init: accepted connection host(2):1073741825 -> vm(3):52000
+bsm-redteam: report written to /var/lib/firstlight/concurrent-20260427-213555.json
+bsm-redteam: total=8 passed=8 failed=0 errored=0 skipped=0
+bsm-redteam: provenance mock-only=0 validated-chv=8 validated-vf=0
+concurrent-8: PASS — report at /var/lib/firstlight/concurrent-20260427-213555.json
+
+  -- phase cleanup (post-concurrent): killing any stragglers + reclaiming sockets
+  -- no stragglers (clean tear-down)
+
+=== step 7: reset cycle test ===
+reset cycle test SKIPPED: P3.2a reset machinery (snapshot/restore + 3-source verification) not in this checkout — packages/sandbox/scripts/reset-cycle.sh does not exist. Re-run after P3.2a lands.
+
+=== summary ===
+smoke:      pass
+latency:    pass (/var/lib/firstlight/latency-20260427-213555.json)
+concurrent: pass (/var/lib/firstlight/concurrent-20260427-213555.json)
+reset:      skipped
+log:        /var/lib/firstlight/full-validation-20260427-213555.log
+summary:    /var/lib/firstlight/validation-20260427-213555.json
+
+JSON summary: /var/lib/firstlight/validation-20260427-213555.json
+
+  -- phase cleanup (trap-on-exit): killing any stragglers + reclaiming sockets
+  -- no stragglers (clean tear-down)

--- a/docs/validation-runs/2026-04-27-node-2/validation.json
+++ b/docs/validation-runs/2026-04-27-node-2/validation.json
@@ -1,0 +1,416 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "20260427-213555",
+  "host": {
+    "hostname": "compute-hel1-02",
+    "kernel": "6.8.0-100-generic",
+    "arch": "x86_64"
+  },
+  "knobs": {
+    "iterations": 1000,
+    "concurrency": 8
+  },
+  "artifacts": {
+    "kernel": "/var/lib/firstlight/brainstorm/packages/image-builder/artifacts/bsm-sandbox-kernel",
+    "initramfs": "/var/lib/firstlight/brainstorm/packages/image-builder/artifacts/bsm-sandbox-initramfs",
+    "rootfs": "/var/lib/firstlight/brainstorm/packages/image-builder/artifacts/bsm-sandbox-rootfs.img"
+  },
+  "steps": {
+    "smoke": {
+      "status": "pass"
+    },
+    "latency": {
+      "status": "pass",
+      "report_path": "/var/lib/firstlight/latency-20260427-213555.json",
+      "report": {
+        "schema_version": "1.0",
+        "generated_at": "2026-04-27T19:46:14.318Z",
+        "backend": "chv",
+        "final_sandbox_state": "not_booted",
+        "probes": [
+          {
+            "name": "P-LAT-boot",
+            "attacker_class": "LAT",
+            "expectation": "should-pass",
+            "validated_against": "validated-chv",
+            "description": "1000-iteration cold-boot latency distribution. Each iteration creates a fresh Sandbox (no warm-cache reuse). Real-CHV path: each boot is a real cloud-hypervisor spawn + vsock handshake.",
+            "passed": true,
+            "reason": "collected 1000 samples (1000 successful iterations)",
+            "duration_ms": 0,
+            "errored": false,
+            "evidence": {
+              "distribution": {
+                "samples": 1000,
+                "p50_ms": 586,
+                "p90_ms": 592,
+                "p95_ms": 594,
+                "p99_ms": 597,
+                "mean_ms": 586.597,
+                "min_ms": 576,
+                "max_ms": 604
+              },
+              "iterations_attempted": 1000,
+              "iterations_succeeded": 1000,
+              "iterations_failed": 0,
+              "failure_phases": {
+                "boot": 0,
+                "exec": 0,
+                "shutdown": 0
+              }
+            }
+          },
+          {
+            "name": "P-LAT-roundtrip",
+            "attacker_class": "LAT",
+            "expectation": "should-pass",
+            "validated_against": "validated-chv",
+            "description": "1000-iteration cold-roundtrip latency distribution. Each iteration creates a fresh Sandbox (no warm-cache reuse). Real-CHV path: each boot is a real cloud-hypervisor spawn + vsock handshake.",
+            "passed": true,
+            "reason": "collected 1000 samples (1000 successful iterations)",
+            "duration_ms": 0,
+            "errored": false,
+            "evidence": {
+              "distribution": {
+                "samples": 1000,
+                "p50_ms": 2,
+                "p90_ms": 2,
+                "p95_ms": 2,
+                "p99_ms": 2,
+                "mean_ms": 1.631,
+                "min_ms": 1,
+                "max_ms": 2
+              },
+              "iterations_attempted": 1000,
+              "iterations_succeeded": 1000,
+              "iterations_failed": 0,
+              "failure_phases": {
+                "boot": 0,
+                "exec": 0,
+                "shutdown": 0
+              }
+            }
+          },
+          {
+            "name": "P-LAT-shutdown",
+            "attacker_class": "LAT",
+            "expectation": "should-pass",
+            "validated_against": "validated-chv",
+            "description": "1000-iteration cold-shutdown latency distribution. Each iteration creates a fresh Sandbox (no warm-cache reuse). Real-CHV path: each boot is a real cloud-hypervisor spawn + vsock handshake.",
+            "passed": true,
+            "reason": "collected 1000 samples (1000 successful iterations)",
+            "duration_ms": 0,
+            "errored": false,
+            "evidence": {
+              "distribution": {
+                "samples": 1000,
+                "p50_ms": 24,
+                "p90_ms": 30,
+                "p95_ms": 31,
+                "p99_ms": 36,
+                "mean_ms": 23.475,
+                "min_ms": 14,
+                "max_ms": 46
+              },
+              "iterations_attempted": 1000,
+              "iterations_succeeded": 1000,
+              "iterations_failed": 0,
+              "failure_phases": {
+                "boot": 0,
+                "exec": 0,
+                "shutdown": 0
+              }
+            }
+          },
+          {
+            "name": "P-LAT-total",
+            "attacker_class": "LAT",
+            "expectation": "should-pass",
+            "validated_against": "validated-chv",
+            "description": "1000-iteration cold-total latency distribution. Each iteration creates a fresh Sandbox (no warm-cache reuse). Real-CHV path: each boot is a real cloud-hypervisor spawn + vsock handshake.",
+            "passed": true,
+            "reason": "collected 1000 samples (1000 successful iterations)",
+            "duration_ms": 0,
+            "errored": false,
+            "evidence": {
+              "distribution": {
+                "samples": 1000,
+                "p50_ms": 611,
+                "p90_ms": 620,
+                "p95_ms": 622,
+                "p99_ms": 628,
+                "mean_ms": 611.82,
+                "min_ms": 596,
+                "max_ms": 638
+              },
+              "iterations_attempted": 1000,
+              "iterations_succeeded": 1000,
+              "iterations_failed": 0,
+              "failure_phases": {
+                "boot": 0,
+                "exec": 0,
+                "shutdown": 0
+              }
+            }
+          }
+        ],
+        "latency": {
+          "P-LAT-boot": {
+            "samples": 1000,
+            "p50_ms": 586,
+            "p90_ms": 592,
+            "p95_ms": 594,
+            "p99_ms": 597,
+            "mean_ms": 586.597,
+            "min_ms": 576,
+            "max_ms": 604
+          },
+          "P-LAT-roundtrip": {
+            "samples": 1000,
+            "p50_ms": 2,
+            "p90_ms": 2,
+            "p95_ms": 2,
+            "p99_ms": 2,
+            "mean_ms": 1.631,
+            "min_ms": 1,
+            "max_ms": 2
+          },
+          "P-LAT-shutdown": {
+            "samples": 1000,
+            "p50_ms": 24,
+            "p90_ms": 30,
+            "p95_ms": 31,
+            "p99_ms": 36,
+            "mean_ms": 23.475,
+            "min_ms": 14,
+            "max_ms": 46
+          },
+          "P-LAT-total": {
+            "samples": 1000,
+            "p50_ms": 611,
+            "p90_ms": 620,
+            "p95_ms": 622,
+            "p99_ms": 628,
+            "mean_ms": 611.82,
+            "min_ms": 596,
+            "max_ms": 638
+          }
+        },
+        "summary": {
+          "total": 4,
+          "passed": 4,
+          "failed": 0,
+          "errored": 0,
+          "skipped": 0
+        },
+        "notes": [
+          "total wall-clock: 611853ms (611.9ms/iter avg)",
+          "validation-provenance: mock-only=0 validated-chv=4 validated-vf=0 validated-chv-and-vf=0 (total=4)"
+        ]
+      }
+    },
+    "concurrent": {
+      "status": "pass",
+      "report_path": "/var/lib/firstlight/concurrent-20260427-213555.json",
+      "report": {
+        "schema_version": "1.0",
+        "generated_at": "2026-04-27T19:46:16.130Z",
+        "backend": "chv",
+        "final_sandbox_state": "not_booted",
+        "probes": [
+          {
+            "name": "P-CONC-instance-0",
+            "attacker_class": "LAT",
+            "expectation": "should-pass",
+            "validated_against": "validated-chv",
+            "description": "Concurrent fleet member 0/8: cold-boot + echo dispatch + shutdown alongside 7 other instances. Verifies cross-instance isolation (unique cid + unique vsock socket).",
+            "passed": true,
+            "reason": "boot=734ms exec=1ms shutdown=29ms exit_code=0",
+            "duration_ms": 764,
+            "errored": false,
+            "evidence": {
+              "boot_ms": 734,
+              "exec_ms": 1,
+              "shutdown_ms": 29,
+              "exit_code": 0,
+              "stdout_preview": "concurrent-probe-0\n"
+            }
+          },
+          {
+            "name": "P-CONC-instance-1",
+            "attacker_class": "LAT",
+            "expectation": "should-pass",
+            "validated_against": "validated-chv",
+            "description": "Concurrent fleet member 1/8: cold-boot + echo dispatch + shutdown alongside 7 other instances. Verifies cross-instance isolation (unique cid + unique vsock socket).",
+            "passed": true,
+            "reason": "boot=725ms exec=3ms shutdown=36ms exit_code=0",
+            "duration_ms": 764,
+            "errored": false,
+            "evidence": {
+              "boot_ms": 725,
+              "exec_ms": 3,
+              "shutdown_ms": 36,
+              "exit_code": 0,
+              "stdout_preview": "concurrent-probe-1\n"
+            }
+          },
+          {
+            "name": "P-CONC-instance-2",
+            "attacker_class": "LAT",
+            "expectation": "should-pass",
+            "validated_against": "validated-chv",
+            "description": "Concurrent fleet member 2/8: cold-boot + echo dispatch + shutdown alongside 7 other instances. Verifies cross-instance isolation (unique cid + unique vsock socket).",
+            "passed": true,
+            "reason": "boot=724ms exec=2ms shutdown=29ms exit_code=0",
+            "duration_ms": 755,
+            "errored": false,
+            "evidence": {
+              "boot_ms": 724,
+              "exec_ms": 2,
+              "shutdown_ms": 29,
+              "exit_code": 0,
+              "stdout_preview": "concurrent-probe-2\n"
+            }
+          },
+          {
+            "name": "P-CONC-instance-3",
+            "attacker_class": "LAT",
+            "expectation": "should-pass",
+            "validated_against": "validated-chv",
+            "description": "Concurrent fleet member 3/8: cold-boot + echo dispatch + shutdown alongside 7 other instances. Verifies cross-instance isolation (unique cid + unique vsock socket).",
+            "passed": true,
+            "reason": "boot=725ms exec=3ms shutdown=36ms exit_code=0",
+            "duration_ms": 764,
+            "errored": false,
+            "evidence": {
+              "boot_ms": 725,
+              "exec_ms": 3,
+              "shutdown_ms": 36,
+              "exit_code": 0,
+              "stdout_preview": "concurrent-probe-3\n"
+            }
+          },
+          {
+            "name": "P-CONC-instance-4",
+            "attacker_class": "LAT",
+            "expectation": "should-pass",
+            "validated_against": "validated-chv",
+            "description": "Concurrent fleet member 4/8: cold-boot + echo dispatch + shutdown alongside 7 other instances. Verifies cross-instance isolation (unique cid + unique vsock socket).",
+            "passed": true,
+            "reason": "boot=726ms exec=2ms shutdown=36ms exit_code=0",
+            "duration_ms": 764,
+            "errored": false,
+            "evidence": {
+              "boot_ms": 726,
+              "exec_ms": 2,
+              "shutdown_ms": 36,
+              "exit_code": 0,
+              "stdout_preview": "concurrent-probe-4\n"
+            }
+          },
+          {
+            "name": "P-CONC-instance-5",
+            "attacker_class": "LAT",
+            "expectation": "should-pass",
+            "validated_against": "validated-chv",
+            "description": "Concurrent fleet member 5/8: cold-boot + echo dispatch + shutdown alongside 7 other instances. Verifies cross-instance isolation (unique cid + unique vsock socket).",
+            "passed": true,
+            "reason": "boot=725ms exec=3ms shutdown=36ms exit_code=0",
+            "duration_ms": 764,
+            "errored": false,
+            "evidence": {
+              "boot_ms": 725,
+              "exec_ms": 3,
+              "shutdown_ms": 36,
+              "exit_code": 0,
+              "stdout_preview": "concurrent-probe-5\n"
+            }
+          },
+          {
+            "name": "P-CONC-instance-6",
+            "attacker_class": "LAT",
+            "expectation": "should-pass",
+            "validated_against": "validated-chv",
+            "description": "Concurrent fleet member 6/8: cold-boot + echo dispatch + shutdown alongside 7 other instances. Verifies cross-instance isolation (unique cid + unique vsock socket).",
+            "passed": true,
+            "reason": "boot=726ms exec=2ms shutdown=36ms exit_code=0",
+            "duration_ms": 764,
+            "errored": false,
+            "evidence": {
+              "boot_ms": 726,
+              "exec_ms": 2,
+              "shutdown_ms": 36,
+              "exit_code": 0,
+              "stdout_preview": "concurrent-probe-6\n"
+            }
+          },
+          {
+            "name": "P-CONC-instance-7",
+            "attacker_class": "LAT",
+            "expectation": "should-pass",
+            "validated_against": "validated-chv",
+            "description": "Concurrent fleet member 7/8: cold-boot + echo dispatch + shutdown alongside 7 other instances. Verifies cross-instance isolation (unique cid + unique vsock socket).",
+            "passed": true,
+            "reason": "boot=726ms exec=2ms shutdown=36ms exit_code=0",
+            "duration_ms": 764,
+            "errored": false,
+            "evidence": {
+              "boot_ms": 726,
+              "exec_ms": 2,
+              "shutdown_ms": 36,
+              "exit_code": 0,
+              "stdout_preview": "concurrent-probe-7\n"
+            }
+          }
+        ],
+        "latency": {
+          "P-CONC-boot": {
+            "samples": 8,
+            "p50_ms": 725,
+            "p90_ms": 734,
+            "p95_ms": 734,
+            "p99_ms": 734,
+            "mean_ms": 726.375,
+            "min_ms": 724,
+            "max_ms": 734
+          },
+          "P-CONC-exec": {
+            "samples": 8,
+            "p50_ms": 2,
+            "p90_ms": 3,
+            "p95_ms": 3,
+            "p99_ms": 3,
+            "mean_ms": 2.25,
+            "min_ms": 1,
+            "max_ms": 3
+          },
+          "P-CONC-shutdown": {
+            "samples": 8,
+            "p50_ms": 36,
+            "p90_ms": 36,
+            "p95_ms": 36,
+            "p99_ms": 36,
+            "mean_ms": 34.25,
+            "min_ms": 29,
+            "max_ms": 36
+          }
+        },
+        "summary": {
+          "total": 8,
+          "passed": 8,
+          "failed": 0,
+          "errored": 0,
+          "skipped": 0
+        },
+        "notes": [
+          "concurrent-8: 8/8 instances succeeded in 765ms wall-clock (parallel)",
+          "validation-provenance: mock-only=0 validated-chv=8 validated-vf=0 validated-chv-and-vf=0 (total=8)"
+        ]
+      }
+    },
+    "reset": {
+      "status": "skipped",
+      "reason": "P3.2a reset machinery (snapshot/restore + 3-source verification) not in this checkout \u2014 packages/sandbox/scripts/reset-cycle.sh does not exist. Re-run after P3.2a lands."
+    }
+  },
+  "log": "/var/lib/firstlight/full-validation-20260427-213555.log"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1572,6 +1572,10 @@
       "resolved": "packages/hooks",
       "link": true
     },
+    "node_modules/@brainst0rm/image-builder": {
+      "resolved": "packages/image-builder",
+      "link": true
+    },
     "node_modules/@brainst0rm/ingest": {
       "resolved": "packages/ingest",
       "link": true
@@ -1606,6 +1610,18 @@
     },
     "node_modules/@brainst0rm/router": {
       "resolved": "packages/router",
+      "link": true
+    },
+    "node_modules/@brainst0rm/sandbox": {
+      "resolved": "packages/sandbox",
+      "link": true
+    },
+    "node_modules/@brainst0rm/sandbox-redteam": {
+      "resolved": "packages/sandbox-redteam",
+      "link": true
+    },
+    "node_modules/@brainst0rm/sandbox-vz": {
+      "resolved": "packages/sandbox-vz",
       "link": true
     },
     "node_modules/@brainst0rm/scheduler": {
@@ -21344,6 +21360,11 @@
         "typescript": "^5.7"
       }
     },
+    "packages/image-builder": {
+      "name": "@brainst0rm/image-builder",
+      "version": "0.1.0-alpha.0",
+      "license": "Apache-2.0"
+    },
     "packages/ingest": {
       "name": "@brainst0rm/ingest",
       "version": "0.13.0",
@@ -22220,6 +22241,2254 @@
         "fast-check": "^4.6.0",
         "tsup": "^8",
         "typescript": "^5.7"
+      }
+    },
+    "packages/sandbox": {
+      "name": "@brainst0rm/sandbox",
+      "version": "0.1.0",
+      "dependencies": {
+        "@brainst0rm/relay": "0.1.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsup": "^8.3.0",
+        "typescript": "^5.6.0",
+        "vitest": "^2.1.0"
+      }
+    },
+    "packages/sandbox-redteam": {
+      "name": "@brainst0rm/sandbox-redteam",
+      "version": "0.1.0",
+      "dependencies": {
+        "@brainst0rm/relay": "0.1.0",
+        "@brainst0rm/sandbox": "0.1.0"
+      },
+      "bin": {
+        "bsm-redteam": "dist/bin/bsm-redteam.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsup": "^8.3.0",
+        "typescript": "^5.6.0",
+        "vitest": "^2.1.0"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/sandbox-redteam/node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/sandbox-redteam/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "packages/sandbox-redteam/node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/sandbox-redteam/node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "packages/sandbox-redteam/node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "packages/sandbox-vz": {
+      "name": "@brainst0rm/sandbox-vz",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsup": "^8.3.0",
+        "typescript": "^5.6.0",
+        "vitest": "^2.1.0"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/sandbox-vz/node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/sandbox-vz/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "packages/sandbox-vz/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/sandbox-vz/node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "packages/sandbox-vz/node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "packages/sandbox-vz/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/sandbox-vz/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "packages/sandbox-vz/node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/sandbox-vz/node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "packages/sandbox-vz/node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "packages/sandbox/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/sandbox/node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/sandbox/node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/sandbox/node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/sandbox/node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/sandbox/node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/sandbox/node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/sandbox/node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/sandbox/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "packages/sandbox/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/sandbox/node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "packages/sandbox/node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "packages/sandbox/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/sandbox/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "packages/sandbox/node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/sandbox/node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "packages/sandbox/node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
       }
     },
     "packages/scheduler": {

--- a/packages/endpoint-stub/README.md
+++ b/packages/endpoint-stub/README.md
@@ -100,6 +100,107 @@ Returning `exit_code !== 0` produces a `failed` `CommandResult` with code
 `SANDBOX_TOOL_ERROR`. Throwing an exception does the same with the error
 message in `error.message`.
 
+## Real CHV sandbox executor (`BSM_USE_CHV_EXECUTOR=1`)
+
+The stub ships with a built-in `ChvSandboxExecutor` that wires the
+pluggable executor seam to a real `ChvSandbox` from
+[`@brainst0rm/sandbox`](../sandbox). When you set
+`BSM_USE_CHV_EXECUTOR=1`, the bin constructs a `ChvSandboxExecutor`
+from the same env contract `first-light.sh` uses and hands it to the
+`EndpointStub` instead of the default echo-style `stubExecutor`.
+
+```bash
+export BSM_USE_CHV_EXECUTOR=1
+export BSM_KERNEL=/srv/bsm/sandbox/bsm-sandbox-kernel
+export BSM_INITRAMFS=/srv/bsm/sandbox/bsm-sandbox-initramfs   # if modular kernel
+export BSM_ROOTFS=/srv/bsm/sandbox/bsm-sandbox-rootfs.img
+export BSM_VSOCK_SOCKET=/tmp/bsm-endpoint-stub.sock           # default
+export BSM_API_SOCKET=/tmp/bsm-endpoint-stub-api.sock         # default
+export BSM_GUEST_PORT=52000                                   # default; matches image-builder vsock-init
+# optional: BSM_CH_BIN, BSM_CHREMOTE_BIN to override PATH lookup
+
+# everything below is the standard stub config — unchanged
+export BRAINSTORM_RELAY_URL_WS=ws://127.0.0.1:8443
+export BRAINSTORM_RELAY_URL_HTTP=http://127.0.0.1:8444
+export BRAINSTORM_ENDPOINT_BOOTSTRAP=...
+export BRAINSTORM_ENDPOINT_TENANT_ID=tenant-dev
+export BRAINSTORM_ENDPOINT_ID=...
+export BRAINSTORM_ENDPOINT_TENANT_PUBKEY_HEX=...
+
+brainstorm-endpoint-stub
+```
+
+When the env var is unset (or any value other than `"1"`), the stub
+falls back to `stubExecutor` — the existing echo-back behaviour. So
+turning the real sandbox on and off is a single env flip; nothing else
+changes about the stub's wiring.
+
+### Honest cost: cold-boot-per-dispatch (~600ms latency floor)
+
+The MVP picks the simpler of the two patterns from the design space:
+
+- **Cold-boot-per-dispatch** (what's shipped): boot a fresh `ChvSandbox`
+  per command, `executeTool`, `shutdown`. ~600ms latency floor on
+  Hetzner node-2 per PR #277. Zero steady-state RAM. No
+  shared-state-between-tools concerns. Failure modes are local — a
+  boot failure on one dispatch does not poison subsequent dispatches.
+- **Pool of N pre-booted sandboxes** (deferred): take from pool →
+  `executeTool` → `reset` → return to pool. ~2-30ms per dispatch
+  (matches the steady-state numbers in PR #277). Higher steady-state
+  RAM. Adds reset machinery on the critical path. We're holding off
+  until we have real dispatch-rate data to size the pool.
+
+Operators dispatching many commands in tight succession will feel the
+600ms floor. If your workload is sub-100ms-sensitive, do not enable
+`BSM_USE_CHV_EXECUTOR=1` until the pool variant lands.
+
+### Error mapping (executor → operator)
+
+| Sandbox event                  | `ToolExecutorResult.exit_code` | `stderr`                                   | EndpointStub maps to                     |
+| ------------------------------ | ------------------------------ | ------------------------------------------ | ---------------------------------------- |
+| `boot()` throws                | `126`                          | `chv-executor: sandbox boot failed: …`     | `failed` / `SANDBOX_TOOL_ERROR`          |
+| `executeTool()` throws         | `125`                          | `chv-executor: sandbox executeTool failed` | `failed` / `SANDBOX_TOOL_ERROR`          |
+| `executeTool()` exit_code != 0 | preserved (faithful)           | preserved (faithful)                       | `failed` / `SANDBOX_TOOL_ERROR`          |
+| `shutdown()` throws            | n/a — logged + swallowed       | n/a                                        | result already produced; not re-reported |
+
+`shutdown()` always runs, even on the boot-failure path (the `Sandbox`
+interface documents `shutdown()` as idempotent).
+
+### Programmatic usage of the executor
+
+```typescript
+import { ChvSandboxExecutor, EndpointStub } from "@brainst0rm/endpoint-stub";
+
+const executor = new ChvSandboxExecutor({
+  config: {
+    apiSocketPath: "/tmp/api.sock",
+    kernel: { path: "/srv/bsm/sandbox/bsm-sandbox-kernel" },
+    rootfs: { path: "/srv/bsm/sandbox/bsm-sandbox-rootfs.img" },
+    vsock: { socketPath: "/tmp/vsock.sock", guestPort: 52000 },
+  },
+});
+
+const stub = new EndpointStub({
+  // ...
+  executor: executor.execute,
+});
+```
+
+### Honest gaps in the executor
+
+- **Per-tool timeout above the sandbox's `deadline_ms`**: the executor
+  does not add a parallel wall-clock fence; the sandbox itself enforces
+  the deadline. If the sandbox's deadline machinery wedges, the
+  executor will wait with it.
+- **Queueing under load**: 10 simultaneous dispatches → 10 parallel
+  cold boots. Relay-side serialisation is the current backstop.
+- **Shared image-pool / page-cache priming**: every boot reads kernel
+  - initramfs + rootfs from disk. A `posix_fadvise(WILLNEED)` warmer
+    or shared image cache would reduce IO under burst.
+- **Reset between commands**: cold-boot-per-dispatch makes reset moot
+  — each command gets a fresh guest. The pool variant will need to
+  call `reset()` between dispatches.
+
 ## Protocol contract enforced
 
 The stub verifies, in order, before executing any tool:

--- a/packages/endpoint-stub/package.json
+++ b/packages/endpoint-stub/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@brainst0rm/relay": "0.1.0",
+    "@brainst0rm/sandbox": "0.1.0",
     "@noble/ed25519": "^2.1.0",
     "@noble/hashes": "^1.5.0",
     "ws": "^8.18.0"

--- a/packages/endpoint-stub/src/__tests__/chv-executor.test.ts
+++ b/packages/endpoint-stub/src/__tests__/chv-executor.test.ts
@@ -1,0 +1,401 @@
+// ChvSandboxExecutor unit tests.
+//
+// Strategy: inject a mock `Sandbox` via the `factory` option so the
+// executor's behaviour is exercised without booting a real microVM.
+// The mock records every call and lets each test choose what
+// boot/executeTool/shutdown does.
+//
+// What's covered:
+//   1. Happy path: ToolInvocation forwarded faithfully, ToolExecution
+//      translated faithfully back to ToolExecutorResult.
+//   2. Boot failure: surfaces as exit_code=126 + stderr message; never
+//      calls executeTool; still calls shutdown.
+//   3. executeTool throw: surfaces as exit_code=125 + stderr message;
+//      shutdown still runs.
+//   4. command_id, tool, params, deadline_ms forwarded into the
+//      ToolInvocation passed to Sandbox.executeTool (anti-mismapping).
+//   5. deadline_ms forwarded — the executor doesn't add a parallel
+//      wall-clock fence; the sandbox's own deadline is what's honoured.
+//   6. shutdown is called on every exit path — happy, executor-throws,
+//      and boot-fails.
+//   7. (extra) stable executor.execute identity — useful for callers
+//      that pass it to multiple stubs.
+
+import { describe, it, expect } from "vitest";
+import type {
+  ResetState,
+  Sandbox,
+  SandboxBackend,
+  SandboxState,
+  ToolExecution,
+  ToolInvocation,
+} from "@brainst0rm/sandbox";
+
+import { ChvSandboxExecutor } from "../chv-executor.js";
+import type { ToolExecutorContext } from "../index.js";
+
+// ---------------------------------------------------------------------------
+// Mock Sandbox
+// ---------------------------------------------------------------------------
+
+interface MockSandboxOptions {
+  bootImpl?: () => Promise<void>;
+  executeToolImpl?: (inv: ToolInvocation) => Promise<ToolExecution>;
+  shutdownImpl?: () => Promise<void>;
+  resetImpl?: () => Promise<ResetState>;
+}
+
+interface MockSandboxRecorder {
+  bootCalls: number;
+  executeToolCalls: ToolInvocation[];
+  shutdownCalls: number;
+  resetCalls: number;
+}
+
+function createMockSandbox(opts: MockSandboxOptions = {}): {
+  sandbox: Sandbox;
+  recorder: MockSandboxRecorder;
+} {
+  const recorder: MockSandboxRecorder = {
+    bootCalls: 0,
+    executeToolCalls: [],
+    shutdownCalls: 0,
+    resetCalls: 0,
+  };
+  let status: SandboxState = "not_booted";
+
+  const sandbox: Sandbox = {
+    backend: "stub" as SandboxBackend,
+    state: () => status,
+    boot: async () => {
+      recorder.bootCalls++;
+      if (opts.bootImpl !== undefined) {
+        await opts.bootImpl();
+      }
+      status = "ready";
+    },
+    executeTool: async (inv: ToolInvocation) => {
+      recorder.executeToolCalls.push(inv);
+      if (opts.executeToolImpl !== undefined) {
+        return opts.executeToolImpl(inv);
+      }
+      return {
+        exit_code: 0,
+        stdout: `mock-stdout(tool=${inv.tool})`,
+        stderr: "",
+      };
+    },
+    reset: async () => {
+      recorder.resetCalls++;
+      if (opts.resetImpl !== undefined) {
+        return opts.resetImpl();
+      }
+      throw new Error("reset not stubbed");
+    },
+    shutdown: async () => {
+      recorder.shutdownCalls++;
+      if (opts.shutdownImpl !== undefined) {
+        await opts.shutdownImpl();
+      }
+      status = "not_booted";
+    },
+  };
+
+  return { sandbox, recorder };
+}
+
+const FAKE_CONFIG = {
+  apiSocketPath: "/tmp/test-api.sock",
+  kernel: { path: "/tmp/test-kernel" },
+  rootfs: { path: "/tmp/test-rootfs.img" },
+  vsock: { socketPath: "/tmp/test-vsock.sock" },
+};
+
+const SILENT_LOGGER = { info: () => {}, error: () => {} };
+
+function makeContext(
+  overrides: Partial<ToolExecutorContext> = {},
+): ToolExecutorContext {
+  return {
+    command_id: "cmd-test-001",
+    tool: "echo",
+    params: { message: "hello" },
+    deadline_ms: 5_000,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ChvSandboxExecutor — happy path", () => {
+  it("dispatches a tool through the sandbox and translates the result faithfully", async () => {
+    const { sandbox, recorder } = createMockSandbox({
+      executeToolImpl: async () => ({
+        exit_code: 0,
+        stdout: "ran-fine",
+        stderr: "",
+      }),
+    });
+    const executor = new ChvSandboxExecutor({
+      config: FAKE_CONFIG,
+      factory: () => sandbox,
+      logger: SILENT_LOGGER,
+    });
+
+    const result = await executor.execute(makeContext());
+
+    expect(result.exit_code).toBe(0);
+    expect(result.stdout).toBe("ran-fine");
+    expect(result.stderr).toBe("");
+    expect(recorder.bootCalls).toBe(1);
+    expect(recorder.executeToolCalls.length).toBe(1);
+    expect(recorder.shutdownCalls).toBe(1);
+  });
+});
+
+describe("ChvSandboxExecutor — input forwarding", () => {
+  it("forwards command_id, tool, params, and deadline_ms verbatim into the ToolInvocation", async () => {
+    const { sandbox, recorder } = createMockSandbox();
+    const executor = new ChvSandboxExecutor({
+      config: FAKE_CONFIG,
+      factory: () => sandbox,
+      logger: SILENT_LOGGER,
+    });
+
+    await executor.execute(
+      makeContext({
+        command_id: "cmd-forwarding-check",
+        tool: "frobnicate",
+        params: { count: 42, label: "alpha" },
+        deadline_ms: 12_345,
+      }),
+    );
+
+    expect(recorder.executeToolCalls.length).toBe(1);
+    const inv = recorder.executeToolCalls[0];
+    expect(inv.command_id).toBe("cmd-forwarding-check");
+    expect(inv.tool).toBe("frobnicate");
+    expect(inv.params).toEqual({ count: 42, label: "alpha" });
+    expect(inv.deadline_ms).toBe(12_345);
+  });
+});
+
+describe("ChvSandboxExecutor — boot failure", () => {
+  it("translates a sandbox.boot() throw into exit_code=126 with stderr containing the error message", async () => {
+    const { sandbox, recorder } = createMockSandbox({
+      bootImpl: async () => {
+        throw new Error("vsock handshake never succeeded within 30000ms");
+      },
+    });
+    const executor = new ChvSandboxExecutor({
+      config: FAKE_CONFIG,
+      factory: () => sandbox,
+      logger: SILENT_LOGGER,
+    });
+
+    const result = await executor.execute(makeContext());
+
+    expect(result.exit_code).toBe(126);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("sandbox boot failed");
+    expect(result.stderr).toContain("vsock handshake never succeeded");
+    // executeTool MUST NOT be called when boot fails.
+    expect(recorder.executeToolCalls.length).toBe(0);
+    // shutdown MUST run on the boot-failure path too (idempotent contract).
+    expect(recorder.shutdownCalls).toBe(1);
+  });
+});
+
+describe("ChvSandboxExecutor — executeTool failure", () => {
+  it("translates a sandbox.executeTool() throw into exit_code=125 with stderr containing the error message", async () => {
+    const { sandbox, recorder } = createMockSandbox({
+      executeToolImpl: async () => {
+        throw new Error("guest crashed mid-dispatch");
+      },
+    });
+    const executor = new ChvSandboxExecutor({
+      config: FAKE_CONFIG,
+      factory: () => sandbox,
+      logger: SILENT_LOGGER,
+    });
+
+    const result = await executor.execute(makeContext());
+
+    expect(result.exit_code).toBe(125);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("sandbox executeTool failed");
+    expect(result.stderr).toContain("guest crashed mid-dispatch");
+    expect(recorder.bootCalls).toBe(1);
+    // shutdown MUST run after an executeTool throw — no leaked CHV processes.
+    expect(recorder.shutdownCalls).toBe(1);
+  });
+
+  it("preserves a non-zero exit_code from the sandbox without translation", async () => {
+    // This is the "tool ran but failed" case (vs. "executor errored"). The
+    // sandbox returns a result; we faithfully forward exit_code=7. The
+    // EndpointStub upstream is what turns this into a `failed` CommandResult.
+    const { sandbox } = createMockSandbox({
+      executeToolImpl: async () => ({
+        exit_code: 7,
+        stdout: "partial-output",
+        stderr: "tool said no",
+      }),
+    });
+    const executor = new ChvSandboxExecutor({
+      config: FAKE_CONFIG,
+      factory: () => sandbox,
+      logger: SILENT_LOGGER,
+    });
+
+    const result = await executor.execute(makeContext());
+
+    expect(result.exit_code).toBe(7);
+    expect(result.stdout).toBe("partial-output");
+    expect(result.stderr).toBe("tool said no");
+  });
+});
+
+describe("ChvSandboxExecutor — deadline_ms is honoured (not exceeded by the executor)", () => {
+  it("does not wait past the configured deadline; the sandbox's deadline_ms is what governs", async () => {
+    // We model this by having executeTool resolve quickly when the
+    // sandbox sees a small deadline. The executor itself does NOT add
+    // a parallel wall-clock fence — that's the sandbox's job. This test
+    // pins the contract: a sandbox that respects deadline_ms by returning
+    // promptly results in a prompt executor return, and the deadline
+    // value is passed through unmodified.
+    let observedDeadline = 0;
+    const { sandbox } = createMockSandbox({
+      executeToolImpl: async (inv) => {
+        observedDeadline = inv.deadline_ms;
+        // Honour the deadline as a sandbox would: return immediately.
+        return { exit_code: 0, stdout: "fast", stderr: "" };
+      },
+    });
+    const executor = new ChvSandboxExecutor({
+      config: FAKE_CONFIG,
+      factory: () => sandbox,
+      logger: SILENT_LOGGER,
+    });
+
+    const t0 = Date.now();
+    const result = await executor.execute(makeContext({ deadline_ms: 50 }));
+    const elapsed = Date.now() - t0;
+
+    expect(observedDeadline).toBe(50);
+    expect(result.exit_code).toBe(0);
+    // We don't wait the full deadline — the sandbox returned immediately
+    // and so did the executor. 250ms is generous slack for CI.
+    expect(elapsed).toBeLessThan(250);
+  });
+});
+
+describe("ChvSandboxExecutor — shutdown contract", () => {
+  it("calls shutdown on the happy path", async () => {
+    const { sandbox, recorder } = createMockSandbox();
+    const executor = new ChvSandboxExecutor({
+      config: FAKE_CONFIG,
+      factory: () => sandbox,
+      logger: SILENT_LOGGER,
+    });
+
+    await executor.execute(makeContext());
+
+    expect(recorder.shutdownCalls).toBe(1);
+  });
+
+  it("calls shutdown even when boot throws", async () => {
+    const { sandbox, recorder } = createMockSandbox({
+      bootImpl: async () => {
+        throw new Error("boot blew up");
+      },
+    });
+    const executor = new ChvSandboxExecutor({
+      config: FAKE_CONFIG,
+      factory: () => sandbox,
+      logger: SILENT_LOGGER,
+    });
+
+    await executor.execute(makeContext());
+
+    expect(recorder.shutdownCalls).toBe(1);
+  });
+
+  it("calls shutdown even when executeTool throws", async () => {
+    const { sandbox, recorder } = createMockSandbox({
+      executeToolImpl: async () => {
+        throw new Error("exec blew up");
+      },
+    });
+    const executor = new ChvSandboxExecutor({
+      config: FAKE_CONFIG,
+      factory: () => sandbox,
+      logger: SILENT_LOGGER,
+    });
+
+    await executor.execute(makeContext());
+
+    expect(recorder.shutdownCalls).toBe(1);
+  });
+
+  it("swallows shutdown() errors so the executor's own result still wins", async () => {
+    // If shutdown itself throws after a successful execution, we don't
+    // want to mask the result the operator is waiting for. Log + swallow.
+    const { sandbox } = createMockSandbox({
+      executeToolImpl: async () => ({
+        exit_code: 0,
+        stdout: "ok",
+        stderr: "",
+      }),
+      shutdownImpl: async () => {
+        throw new Error("shutdown went sideways");
+      },
+    });
+    const executor = new ChvSandboxExecutor({
+      config: FAKE_CONFIG,
+      factory: () => sandbox,
+      logger: SILENT_LOGGER,
+    });
+
+    const result = await executor.execute(makeContext());
+
+    expect(result.exit_code).toBe(0);
+    expect(result.stdout).toBe("ok");
+  });
+});
+
+describe("ChvSandboxExecutor — cold-boot-per-dispatch lifecycle", () => {
+  it("constructs a fresh sandbox via the factory on every dispatch", async () => {
+    let factoryCalls = 0;
+    const factory = () => {
+      factoryCalls++;
+      const { sandbox } = createMockSandbox();
+      return sandbox;
+    };
+    const executor = new ChvSandboxExecutor({
+      config: FAKE_CONFIG,
+      factory,
+      logger: SILENT_LOGGER,
+    });
+
+    await executor.execute(makeContext({ command_id: "c1" }));
+    await executor.execute(makeContext({ command_id: "c2" }));
+    await executor.execute(makeContext({ command_id: "c3" }));
+
+    expect(factoryCalls).toBe(3);
+  });
+
+  it("exposes a stable `execute` reference across calls (safe to hand off)", async () => {
+    const { sandbox } = createMockSandbox();
+    const executor = new ChvSandboxExecutor({
+      config: FAKE_CONFIG,
+      factory: () => sandbox,
+      logger: SILENT_LOGGER,
+    });
+
+    const fnRef1 = executor.execute;
+    const fnRef2 = executor.execute;
+    expect(fnRef1).toBe(fnRef2);
+  });
+});

--- a/packages/endpoint-stub/src/bin.ts
+++ b/packages/endpoint-stub/src/bin.ts
@@ -24,7 +24,11 @@
 import { join } from "node:path";
 import { homedir } from "node:os";
 
-import { EndpointStub } from "./index.js";
+import {
+  ChvSandboxExecutor,
+  EndpointStub,
+  type ToolExecutor,
+} from "./index.js";
 
 interface Config {
   wsUrl: string;
@@ -103,14 +107,86 @@ async function enrollIfNeeded(args: {
   throw new Error(`enrollment failed: ${resp.status} ${text}`);
 }
 
+/**
+ * If BSM_USE_CHV_EXECUTOR=1, build a `ChvSandboxExecutor` from the
+ * BSM_KERNEL / BSM_INITRAMFS / BSM_ROOTFS / BSM_VSOCK_SOCKET /
+ * BSM_API_SOCKET / BSM_GUEST_PORT env contract — same as the
+ * `first-light.sh` smoke test. Otherwise return undefined and let the
+ * EndpointStub fall back to its built-in `stubExecutor`.
+ *
+ * Honesty: cold-boot-per-dispatch on Hetzner node-2 = ~600ms latency
+ * floor. The README documents this. Don't enable BSM_USE_CHV_EXECUTOR
+ * for a workload that needs sub-100ms tool dispatch.
+ */
+function loadChvExecutorIfRequested(): ToolExecutor | undefined {
+  const env = process.env;
+  if (env.BSM_USE_CHV_EXECUTOR !== "1") return undefined;
+
+  const kernel = env.BSM_KERNEL;
+  const initramfs = env.BSM_INITRAMFS;
+  const rootfs = env.BSM_ROOTFS;
+  if (kernel === undefined) {
+    throw new Error(
+      "BSM_USE_CHV_EXECUTOR=1 but BSM_KERNEL is unset (path to bsm-sandbox-kernel)",
+    );
+  }
+  if (rootfs === undefined) {
+    throw new Error(
+      "BSM_USE_CHV_EXECUTOR=1 but BSM_ROOTFS is unset (path to bsm-sandbox-rootfs.img)",
+    );
+  }
+
+  const vsockSocket = env.BSM_VSOCK_SOCKET ?? "/tmp/bsm-endpoint-stub.sock";
+  const apiSocket = env.BSM_API_SOCKET ?? "/tmp/bsm-endpoint-stub-api.sock";
+  let guestPort = 52000;
+  if (env.BSM_GUEST_PORT !== undefined) {
+    const parsed = parseInt(env.BSM_GUEST_PORT, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 65535) {
+      throw new Error(
+        `BSM_GUEST_PORT must be a positive integer (1-65535); got '${env.BSM_GUEST_PORT}'`,
+      );
+    }
+    guestPort = parsed;
+  }
+
+  console.log(
+    `[endpoint-stub] BSM_USE_CHV_EXECUTOR=1 — wiring ChvSandboxExecutor\n` +
+      `[endpoint-stub]   kernel=${kernel}\n` +
+      `[endpoint-stub]   initramfs=${initramfs ?? "(none)"}\n` +
+      `[endpoint-stub]   rootfs=${rootfs}\n` +
+      `[endpoint-stub]   vsock=${vsockSocket} (guest port ${guestPort})\n` +
+      `[endpoint-stub]   api=${apiSocket}\n` +
+      `[endpoint-stub]   pattern=cold-boot-per-dispatch (~600ms latency floor)`,
+  );
+
+  const executor = new ChvSandboxExecutor({
+    config: {
+      cloudHypervisorBin: env.BSM_CH_BIN,
+      chRemoteBin: env.BSM_CHREMOTE_BIN,
+      apiSocketPath: apiSocket,
+      kernel: { path: kernel, initramfs },
+      rootfs: { path: rootfs, readonly: true },
+      vsock: {
+        socketPath: vsockSocket,
+        guestPort,
+      },
+      cpus: 2,
+      memMib: 1024,
+    },
+  });
+  return executor.execute;
+}
+
 async function main(): Promise<void> {
   const config = loadConfig();
+  const executor = loadChvExecutorIfRequested();
   const stub = new EndpointStub({
     relayUrl: config.wsUrl,
     tenantId: config.tenantId,
     identityPath: config.identityPath,
     endpointId: config.endpointId,
     tenantPublicKey: config.tenantPublicKey,
+    executor,
   });
   await enrollIfNeeded({
     httpUrl: config.httpUrl,

--- a/packages/endpoint-stub/src/chv-executor.ts
+++ b/packages/endpoint-stub/src/chv-executor.ts
@@ -1,0 +1,253 @@
+// ChvSandboxExecutor — bridges the endpoint-stub's pluggable
+// `ToolExecutor` interface to a real `ChvSandbox` from
+// `@brainst0rm/sandbox`.
+//
+// This is the seam Phase 1 (operator → relay → endpoint-stub) and
+// Phase 3 (real ChvSandbox booting microVMs) cross. With this in
+// place, a CommandEnvelope received over the relay actually runs
+// inside an isolated CHV guest instead of bouncing off `stubExecutor`'s
+// echo-back.
+//
+// Design choice: COLD-BOOT-PER-DISPATCH.
+//
+//   For every tool dispatch we:
+//     1. Construct a fresh `ChvSandbox` from the configured paths.
+//     2. `boot()` it (~600ms on Hetzner node-2 per PR #277).
+//     3. `executeTool({ command_id, tool, params, deadline_ms })`.
+//     4. `shutdown()` on every exit path — success, executor-failure,
+//        and even unexpected throw.
+//
+//   Trade-offs:
+//     + Honest about cost (no hidden pool-warm-up amortisation).
+//     + Zero steady-state RAM — sandboxes only exist during a dispatch.
+//     + No shared-state-between-tools concerns; each invocation gets a
+//       provably-fresh guest.
+//     + Failure modes are local: a boot failure on one dispatch doesn't
+//       poison subsequent dispatches.
+//     − ~600ms cold-boot floor on every command. Operators dispatching
+//       many commands in tight succession will feel it.
+//     − Higher per-host CPU cost during bursts (parallel boots).
+//
+//   The pool pattern (N pre-booted sandboxes, take/dispatch/reset/return)
+//   is the documented next step. It trades steady-state RAM for ~2-30ms
+//   per-dispatch latency. We're deferring it until we have real dispatch-
+//   rate data to size the pool against.
+//
+// What this executor does NOT do (honest gaps):
+//   - Per-tool timeout enforcement above the sandbox's own `deadline_ms`.
+//     The sandbox itself enforces the deadline; we don't add a parallel
+//     wall-clock fence on the executor side.
+//   - Queueing under load. If 10 dispatches arrive simultaneously we boot
+//     10 CHV processes in parallel. The relay is serialising for now.
+//   - Shared image-pool optimisation. Each boot loads the kernel/initramfs/
+//     rootfs from disk — `posix_fadvise(POSIX_FADV_WILLNEED)` and a
+//     shared image cache would reduce IO under load.
+//   - Reset between commands. Cold-boot-per-dispatch makes reset moot
+//     (each command gets a fresh sandbox); when we move to a pool,
+//     `reset()` becomes mandatory.
+
+import {
+  ChvSandbox,
+  type ChvSandboxConfig,
+  type Sandbox,
+  type ToolExecution,
+} from "@brainst0rm/sandbox";
+
+import type {
+  ToolExecutor,
+  ToolExecutorContext,
+  ToolExecutorResult,
+} from "./index.js";
+
+/**
+ * Factory shape: given a config, produce a Sandbox. Production passes
+ * `defaultSandboxFactory` which constructs a `ChvSandbox`. Tests inject
+ * a mock factory that returns an in-memory Sandbox stub.
+ */
+export type SandboxFactory = (config: ChvSandboxConfig) => Sandbox;
+
+/**
+ * Default factory: constructs a `ChvSandbox` from the supplied config.
+ * Exposed so callers can compose it with their own deps if needed.
+ */
+export const defaultSandboxFactory: SandboxFactory = (config) =>
+  new ChvSandbox(config);
+
+export interface ChvSandboxExecutorOptions {
+  /**
+   * Configuration handed to every fresh `ChvSandbox` boot. Holds kernel
+   * / initramfs / rootfs / vsock-socket / api-socket paths plus
+   * baselines and snapshot path. This config is reused for every
+   * dispatch — the sandbox constructor is called with the same config
+   * for each cold-boot, so any mutable state (e.g. `apiSocketPath`) MUST
+   * be safe to reuse across boots. The default first-light setup with
+   * unique sockets per boot is the supported pattern.
+   *
+   * Tip: when running the executor inside a long-lived process (the
+   * endpoint-stub bin), prefer pointing `apiSocketPath` and
+   * `vsock.socketPath` at the same paths every boot — `ChvSandbox.boot()`
+   * purges any stale socket file before binding, so reuse is safe.
+   */
+  config: ChvSandboxConfig;
+  /**
+   * Override the sandbox factory (tests). Production callers leave
+   * this undefined and get the real `ChvSandbox`.
+   */
+  factory?: SandboxFactory;
+  /**
+   * Optional logger (mirrors the rest of the package's logger shape).
+   * Defaults to console with a `[chv-executor]` prefix.
+   */
+  logger?: { info: (m: string) => void; error: (m: string) => void };
+}
+
+/**
+ * `ToolExecutor` implementation backed by a real CHV microVM.
+ *
+ * Construct once with a config; the resulting object's `.execute` is
+ * the `ToolExecutor` callable. A typical wiring:
+ *
+ *   const executor = new ChvSandboxExecutor({ config });
+ *   const stub = new EndpointStub({ ..., executor: executor.execute });
+ *
+ * For a one-liner you can pass `executor.execute` directly — the class
+ * deliberately bundles the bound function as a field so it stays a
+ * stable reference across passes.
+ */
+export class ChvSandboxExecutor {
+  private readonly options: ChvSandboxExecutorOptions;
+  private readonly factory: SandboxFactory;
+  private readonly log: {
+    info: (m: string) => void;
+    error: (m: string) => void;
+  };
+
+  /**
+   * Bound executor function suitable for handing straight to
+   * `EndpointStub`. Stable identity across calls — useful when callers
+   * want to swap executors based on env state.
+   */
+  public readonly execute: ToolExecutor;
+
+  constructor(options: ChvSandboxExecutorOptions) {
+    this.options = options;
+    this.factory = options.factory ?? defaultSandboxFactory;
+    this.log = options.logger ?? {
+      info: (m) => console.log(`[chv-executor] ${m}`),
+      error: (m) => console.error(`[chv-executor] ${m}`),
+    };
+    this.execute = (ctx) => this.dispatch(ctx);
+  }
+
+  /**
+   * Cold-boot a fresh sandbox, run the tool inside it, shut it down.
+   *
+   * Mapping `ToolExecutorContext` → `Sandbox.executeTool`:
+   *   - command_id          → ToolInvocation.command_id (forwarded as-is)
+   *   - tool                → ToolInvocation.tool       (forwarded as-is)
+   *   - params              → ToolInvocation.params     (forwarded as-is)
+   *   - deadline_ms         → ToolInvocation.deadline_ms (sandbox enforces)
+   *
+   * Mapping `ToolExecution` → `ToolExecutorResult`:
+   *   - exit_code           → exit_code (faithful)
+   *   - stdout              → stdout    (faithful)
+   *   - stderr              → stderr    (faithful)
+   *   - evidence_hash       → dropped (the dispatcher computes its own
+   *                           host-side hash; sandbox-side digests are
+   *                           a future enhancement once the guest emits
+   *                           them reliably)
+   *
+   * Error path translation (per requirement 4 in the wiring brief):
+   *   - sandbox.boot() throws       → exit_code=126, stderr=boot-error msg.
+   *                                   126 chosen to mirror POSIX "command
+   *                                   found but not executable" semantics
+   *                                   — the tool was real, the executor
+   *                                   couldn't reach it.
+   *   - sandbox.executeTool() throws → exit_code=125, stderr=exec-error msg.
+   *                                   125 mirrors "executor itself failed"
+   *                                   (git/run-parts convention).
+   *   - sandbox.shutdown() throws    → logged, NOT propagated. We've
+   *                                   already produced a result and
+   *                                   reporting a shutdown failure as
+   *                                   a tool failure would be wrong.
+   *
+   * Either way the EndpointStub turns a non-zero exit into a `failed`
+   * CommandResult with `error.code = SANDBOX_TOOL_ERROR` (see
+   * `handleCommandEnvelope` in index.ts), so the operator sees a clean
+   * failure rather than a stuck spinner.
+   *
+   * Honesty: shutdown happens in `finally`, so even an unexpected throw
+   * from the result-translation path can't leak a CHV process.
+   */
+  private async dispatch(
+    ctx: ToolExecutorContext,
+  ): Promise<ToolExecutorResult> {
+    const t0 = Date.now();
+    const sandbox = this.factory(this.options.config);
+
+    let booted = false;
+    try {
+      try {
+        await sandbox.boot();
+        booted = true;
+      } catch (e) {
+        const msg = (e as Error).message;
+        this.log.error(`boot failed for command ${ctx.command_id}: ${msg}`);
+        return {
+          exit_code: 126,
+          stdout: "",
+          stderr: `chv-executor: sandbox boot failed: ${msg}`,
+        };
+      }
+
+      const bootMs = Date.now() - t0;
+      this.log.info(
+        `booted in ${bootMs}ms for command ${ctx.command_id} (cold-boot-per-dispatch — ~600ms is the honest floor)`,
+      );
+
+      let exec: ToolExecution;
+      try {
+        exec = await sandbox.executeTool({
+          command_id: ctx.command_id,
+          tool: ctx.tool,
+          params: ctx.params,
+          deadline_ms: ctx.deadline_ms,
+        });
+      } catch (e) {
+        const msg = (e as Error).message;
+        this.log.error(
+          `executeTool failed for command ${ctx.command_id}: ${msg}`,
+        );
+        return {
+          exit_code: 125,
+          stdout: "",
+          stderr: `chv-executor: sandbox executeTool failed: ${msg}`,
+        };
+      }
+
+      const totalMs = Date.now() - t0;
+      this.log.info(
+        `command ${ctx.command_id} exit=${exec.exit_code} total=${totalMs}ms (boot=${bootMs}ms)`,
+      );
+
+      return {
+        exit_code: exec.exit_code,
+        stdout: exec.stdout,
+        stderr: exec.stderr,
+      };
+    } finally {
+      // Shutdown on every path. If we never booted, shutdown() is still
+      // safe — the Sandbox interface documents it as idempotent.
+      try {
+        await sandbox.shutdown();
+      } catch (e) {
+        // Don't shadow the result we already produced; log and swallow.
+        this.log.error(
+          `shutdown failed for command ${ctx.command_id}` +
+            `${booted ? "" : " (sandbox never booted)"}` +
+            `: ${(e as Error).message}`,
+        );
+      }
+    }
+  }
+}

--- a/packages/endpoint-stub/src/index.ts
+++ b/packages/endpoint-stub/src/index.ts
@@ -25,6 +25,13 @@
 // `{ stub: true }` in payload metadata so consumers can see they're
 // not running against a real isolated endpoint.
 
+export {
+  ChvSandboxExecutor,
+  defaultSandboxFactory,
+  type ChvSandboxExecutorOptions,
+  type SandboxFactory,
+} from "./chv-executor.js";
+
 import { randomUUID, randomBytes } from "node:crypto";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { join, dirname } from "node:path";

--- a/packages/image-builder/README.md
+++ b/packages/image-builder/README.md
@@ -1,0 +1,256 @@
+# @brainst0rm/image-builder
+
+Reproducible Linux microVM image builder for the Brainstorm endpoint sandbox.
+
+This package implements **P3.4** of the [endpoint-agent plan](../../docs/endpoint-agent-plan.md).
+Its outputs are consumed by **P3.1a** (Cloud Hypervisor on Linux) and **P3.1b**
+(Apple Virtualization.framework on macOS) to boot a sandbox microVM that
+executes operator-dispatched tools in isolation.
+
+It is deliberately the **smallest possible** package that can produce a
+bootable image: a Dockerfile, a Go init binary, and a driver script. There is
+no TypeScript here — `tsup` is not invoked because there is no TypeScript code
+to bundle. `package.json` exists so the workspace knows about the package and
+so `npm run build -w @brainst0rm/image-builder` works.
+
+---
+
+## Inputs
+
+- **Docker** (Docker Desktop on macOS, Docker Engine on Linux). Tested with
+  Docker 29.x on Darwin (Docker Desktop) — see "Smoke run" below.
+- A working network connection (to fetch the `golang:1.22-alpine`,
+  `alpine:3.20`, and Alpine `linux-virt` package). After the first build,
+  Docker layer cache makes subsequent builds offline-tolerant.
+- The package source itself: `vsock-init/` (Go), `build/Dockerfile`,
+  `scripts/build.sh`.
+
+That is the entire input set. No host kernel headers, no host Go toolchain,
+no `debootstrap`, no host `mkfs.ext4` are required — everything happens inside
+Docker.
+
+---
+
+## Outputs
+
+`scripts/build.sh` writes the following to `packages/image-builder/artifacts/`:
+
+| File                     | Purpose                                                                  | Consumer         |
+| ------------------------ | ------------------------------------------------------------------------ | ---------------- |
+| `bsm-sandbox-kernel`     | Linux kernel (Alpine `vmlinuz-virt`, 6.x). Boot image for CHV and VF.    | P3.1a, P3.1b     |
+| `bsm-sandbox-initramfs`  | Alpine `initramfs-virt` — for early-userspace if cmdline calls for it.   | P3.1a (rare)     |
+| `bsm-sandbox-rootfs.img` | ext4, 64 MiB. Contains busybox + MVP tool whitelist + `/sbin/init`.      | **P3.1a, P3.1b** |
+| `bsm-sandbox-rootfs.tar` | Same content as `.img`, in tar form. Useful for inspection / squashfs.   | dev / debugging  |
+| `vsock-init.bin`         | Standalone copy of the PID-1 vsock-init binary (also baked into rootfs). | dev / debugging  |
+| `checksums.txt`          | SHA-256 over each of the above. Baseline for **D15 hash compare**.       | reset machinery  |
+
+The `checksums.txt` file is what `Sandbox.VerifyResetIntegrity()` (P3.2a/b)
+hashes against. Treat it as a release artifact.
+
+---
+
+## How P3.1a and P3.1b consume the artifacts
+
+### Cloud Hypervisor (P3.1a, Linux)
+
+```
+cloud-hypervisor \
+  --kernel  artifacts/bsm-sandbox-kernel \
+  --disk    path=artifacts/bsm-sandbox-rootfs.img,readonly=on \
+  --cmdline "console=hvc0 root=/dev/vda init=/sbin/init quiet" \
+  --cpus    boot=1 \
+  --memory  size=128M \
+  --vsock   cid=3,socket=/var/run/bsm/sandbox.vsock \
+  --serial  tty
+```
+
+The agent (`packages/sandbox/`) connects to the vsock and speaks the wire
+protocol described in `docs/endpoint-agent-protocol-v1.md` §6.
+
+### Apple Virtualization.framework (P3.1b, macOS)
+
+The macOS sandbox track (`packages/sandbox-vz/`) wraps `VZVirtualMachineConfiguration`
+and points it at the same kernel + rootfs. The exact bridge is owned by P3.1b;
+this package only guarantees that the kernel + rootfs combination boots into a
+shell prompt with `/sbin/init` running and listening on
+`vsock(VMADDR_CID_ANY, 52000)`.
+
+VF on Sonoma+ uses `VZSavedStateURL` snapshots, which are taken **after** boot
+completes — so the cold-boot artifacts in this package are the seed, not the
+hot-path image.
+
+---
+
+## The vsock-init protocol (subset of `endpoint-agent-protocol-v1.md` §6)
+
+`vsock-init` is the rootfs's PID 1. It opens an `AF_VSOCK` listener on port
+**52000** (overridable via `BSM_VSOCK_PORT`). All frames are length-prefixed
+JSON, exactly as defined in protocol §2:
+
+```
+[ uint32 BE payload_len ][ payload_len bytes of UTF-8 JSON ]
+```
+
+Implemented message types (MVP):
+
+| Direction       | Type            | Behavior                                                                   |
+| --------------- | --------------- | -------------------------------------------------------------------------- |
+| agent → sandbox | `ToolDispatch`  | Look up `tool` in whitelist, run with mapped argv, reply with `ToolResult` |
+| sandbox → agent | `ToolResult`    | exit_code + stdout + stderr + (placeholder) evidence_hash                  |
+| agent → sandbox | `GuestQuery`    | `OpenFdCount` / `MemUsage` / `ProcessList` per §6.3.5                      |
+| sandbox → agent | `GuestResponse` | Per-kind result schema per §6.3.6                                          |
+| agent → sandbox | `ResetSignal`   | No-op in guest; emits `ResetAck` for heartbeat. Real reset is host-side.   |
+| sandbox → agent | `ResetAck`      | Always `verification_passed: true` with placeholder hashes (see TODOs).    |
+
+Tool whitelist (D22 in plan): `echo`, `whoami`, `uname`, `cat`, `ls`, `env`,
+`sh`. Each tool has an explicit param-to-argv mapping in
+`vsock-init/main.go`'s `paramsToArgs`. Free-form argv smuggling is rejected.
+
+---
+
+## What's stubbed vs what's real
+
+This is the brutal-honesty section. Every line below is a known gap, ordered
+roughly by severity.
+
+### Real (production-ready quality, just untested in the live agent loop)
+
+- **`vsock-init` Go binary.** Real code, ~430 LOC, compiles cleanly, listens
+  on vsock, dispatches tools, answers GuestQuery. Static, stripped, CGO-off.
+- **Length-prefixed framing** matching protocol §2 (uint32 BE, 16 MiB cap,
+  30 s read timeout).
+- **MVP tool whitelist enforcement** with explicit per-tool argv mapping.
+- **Guest-query responses** for `OpenFdCount` / `MemUsage` / `ProcessList`,
+  reading from `/proc` correctly.
+- **Dockerfile** — multi-stage, deterministic timestamps via
+  `SOURCE_DATE_EPOCH`, builds without privileged mode.
+- **Driver script** (`scripts/build.sh`) — handles "no Docker" case
+  gracefully, exits 0 on platforms that can't build (so CI on bare macOS
+  doesn't fail), supports `--target` / `--no-extract`.
+- **Checksums** — produced inside the build, extracted alongside artifacts.
+
+### Stubbed / placeholder
+
+- **`evidence_hash`** in `ToolResult` is the literal string
+  `"sha256:hash-chain-not-yet-implemented"`. The §6.3 hash-chain formula
+  (chunk_hash[seq] over command_id_bytes ‖ uint64_be(seq) ‖ chunk_size ‖
+  chunk_data ‖ prev_hash) is not yet computed inside the guest. EvidenceChunk
+  streaming is not implemented — only single-shot ToolResult.
+- **`ResetAck.verification_details.fs_hash` / `golden_hash`** are placeholder
+  strings. The 3-source cross-check (D15) is host-side machinery; the guest
+  side advertises `vmm_api_state: "running"` but the actual baseline-hashing
+  belongs in P3.2a/b. The current `ResetAck` is sufficient for a heartbeat,
+  not for the substrate-lying-attacker defense.
+- **No seccomp inside the guest.** Threat-model defenders' guarantee #4
+  (no sandbox escape) currently rests entirely on CHV/VF + minimal kernel.
+  Adding a seccomp filter to vsock-init before it execs tools is a hardening
+  TODO that's well-scoped (call `prctl(PR_SET_NO_NEW_PRIVS, 1)` then load a
+  filter that allows only the syscalls busybox needs).
+- **No reproducible build across hosts.** Within a single host, runs are
+  bit-identical thanks to `SOURCE_DATE_EPOCH` and `apk` pinning, but two
+  different machines will produce different `.img` bytes because Alpine's
+  `linux-virt` package is not pinned to a specific version. Pin it
+  (`apk add linux-virt=<exact-version>`) before signing baseline hashes.
+- **No CI integration.** `scripts/build.sh` is meant to be run from CI on a
+  Linux runner; the wiring (e.g., a GitHub Actions job that uploads
+  `checksums.txt` as a release artifact) is post-MVP.
+- **`bsm-sandbox-rootfs.img` is ext4, not squashfs.** CHV and VF both accept
+  ext4, but squashfs is read-only by default which is preferable for the
+  sandbox use case (and reduces reset-verification surface). Switching is a
+  one-line Dockerfile change (`mksquashfs` instead of `mkfs.ext4`) but I
+  have not validated that the resulting image boots on every backend yet,
+  so I left ext4 in.
+- **The kernel is Alpine's stock `linux-virt`, not a custom build.** It has
+  vsock support but also a long tail of drivers we don't need. Production
+  should ship a CONFIG\_-trimmed kernel; that work is order-of-days, not
+  hours, and is intentionally out of scope for P3.4.
+- **No tool-set extension hook.** D22 mentions "2-3 MSP-relevant" tools to
+  bake in. I included `ls`, `env`, `sh` as plausible placeholders; the real
+  MSP-relevant set should be decided when P3.3 lands the tool-registration
+  interface and we know the actual surface.
+- **`go.sum` was generated** by a smoke run on this machine and committed
+  alongside `go.mod`. If you bump deps, re-generate it.
+
+### Not even started (deliberately deferred to other tracks)
+
+- Egress proxy hooks (P3.3 owns DNS/conntrack/TLS-MITM design, D31).
+- ChangeSet preview generation (operator-side, P1).
+- Per-tool ChangeSet preview functions (post-MVP per plan).
+- Hardware-rooted attestation (post-MVP backlog).
+
+---
+
+## Smoke run on this Darwin host (2026-04-27)
+
+I ran the full build end-to-end on this machine. Result: **green**.
+
+- **Host**: Apple Silicon Mac, Darwin 25.4
+- **Docker**: `Docker version 29.1.3, build f52814d` (Docker Desktop, linux/arm64 VM)
+- **Build time, cold cache**: ~3 minutes (Alpine + golang image pulls + apk fetches)
+- **Build time, warm cache**: ~30 seconds
+
+Actual artifact sizes from the smoke run:
+
+| File                          | Smoke-run size | Type                                                         |
+| ----------------------------- | -------------- | ------------------------------------------------------------ |
+| `bsm-sandbox-kernel`          | 8.8 MiB        | PE32+ EFI application, Aarch64 (Alpine `linux-virt` 6.6.134) |
+| `bsm-sandbox-initramfs`       | 9.6 MiB        | gzip compressed initramfs                                    |
+| `bsm-sandbox-rootfs.img`      | 64 MiB         | ext4, UUID baked, volume name `bsm-rootfs`                   |
+| `bsm-sandbox-rootfs.tar`      | 4.0 MiB        | POSIX tar (GNU), pre-img form                                |
+| `vsock-init.bin`              | 2.2 MiB        | ELF 64-bit aarch64, statically linked, stripped              |
+| **Total kernel + rootfs.img** | **~73 MiB**    | well under R4 100 MiB ship-at-install threshold              |
+
+Run it yourself:
+
+```sh
+cd packages/image-builder
+bash scripts/build.sh
+ls -lh artifacts/
+shasum -a 256 -c artifacts/checksums.txt   # Linux: 'sha256sum -c'
+```
+
+### Issues hit + fixed during the smoke run (logged for next person)
+
+1. **Alpine `apk` parameter expansion in Dockerfile RUN.** The original
+   `--repository v${ALPINE_VERSION%-*}/main/` pattern fails because dash's
+   `${VAR%-*}` works but the ARG isn't visible in a stage without re-`ARG`-ing.
+   Fix: re-declare `ARG ALPINE_VERSION` inside the rootfsbuild stage and drop
+   the suffix-strip (`3.20` works directly in the URL).
+2. **Alpine `apk add --root --initdb` rejects "UNTRUSTED signature".** Fix:
+   seed `/rootfs/etc/apk/keys/` from the builder's keys before the apk add.
+3. **`/rootfs/sbin/init` is already a symlink to `/bin/busybox`.** Docker
+   COPY follows the destination symlink at apply time, which means
+   `COPY ... /rootfs/sbin/init` overwrites the **builder's** `/bin/busybox`,
+   which is what the builder's `/bin/sh` resolves to. Every subsequent RUN
+   then breaks with confusing "vsock-init: vsock.Listen failed" output (the
+   binary running as `/bin/sh -c ...`). Fix: `RUN rm -f /rootfs/sbin/init`
+   immediately before the COPY. This took longest to diagnose; left a comment
+   in the Dockerfile so the next person doesn't repeat it.
+4. **Multi-arch:** `--platform=$BUILDPLATFORM` on the Go stage + `GOARCH`
+   from `$TARGETARCH` so the binary matches the rootfs arch (arm64 on Apple
+   Silicon, amd64 on Intel/AWS).
+5. **Deterministic-mtime walk over /rootfs.** Skipped per-file `find/touch`
+   because of an apparently unrelated buildkit/binfmt interaction surfaced by
+   the symlink-clobber issue. Tar's `--mtime` flag still gives us a
+   deterministic-enough archive for the MVP. Bit-exact reproducibility is a
+   post-MVP TODO.
+
+---
+
+## TODO checklist (rolled up from "what's stubbed")
+
+- [ ] Implement EvidenceChunk streaming + the §6.3 hash-chain inside `runTool`.
+- [ ] Wire the host-side reset-verification baseline (P3.2a/b consumer of
+      `checksums.txt`).
+- [ ] Add seccomp + `PR_SET_NO_NEW_PRIVS` to `vsock-init` before exec.
+- [ ] Pin `linux-virt` to an exact Alpine package version for cross-host
+      reproducibility.
+- [ ] Switch ext4 → squashfs once verified on both CHV and VF backends.
+- [ ] Replace stock Alpine kernel with a custom CONFIG\_-trimmed build (R3
+      mitigation).
+- [ ] Decide the 2–3 MSP-relevant tools (D22) and replace the `ls/env/sh`
+      placeholders.
+- [ ] CI job: build on every commit, upload `checksums.txt` as a release
+      artifact, fail if hash drifts unexpectedly.
+- [ ] Sign artifacts (post-MVP backlog: "Reproducible image builds with
+      signature verification").

--- a/packages/image-builder/artifacts/.gitignore
+++ b/packages/image-builder/artifacts/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/packages/image-builder/build/Dockerfile
+++ b/packages/image-builder/build/Dockerfile
@@ -1,0 +1,176 @@
+# syntax=docker/dockerfile:1.6
+#
+# Brainstorm endpoint sandbox image builder (P3.4).
+#
+# Inputs:
+#   - vsock-init/ Go source (build context root must be packages/image-builder/)
+#
+# Outputs (written to /out inside the image; extracted by scripts/build.sh):
+#   - /out/bsm-sandbox-rootfs.tar    -- rootfs tarball (pre-squashfs)
+#   - /out/bsm-sandbox-rootfs.img    -- ext4 rootfs (loopback, ~64 MiB)
+#   - /out/bsm-sandbox-kernel        -- Alpine virt kernel (vmlinuz-virt)
+#   - /out/bsm-sandbox-initramfs     -- Alpine virt initramfs (initramfs-virt)
+#   - /out/checksums.txt             -- SHA-256 over each artifact
+#
+# Strategy:
+#   1. Stage `vsockbuild`: compile vsock-init as a static Linux/amd64 binary.
+#   2. Stage `rootfsbuild`: assemble a minimal Alpine 3.20 rootfs containing
+#      busybox + the MVP tool whitelist (echo, whoami, uname, cat, ls, env, sh)
+#      + the vsock-init binary as /sbin/init.
+#   3. Stage `pkg`: pull the Alpine `linux-virt` package (kernel + initramfs)
+#      so we ship a kernel that boots cleanly under Cloud Hypervisor (no
+#      modules required for the rootfs path) and Apple VF (which can use the
+#      same vmlinuz on Sonoma+).
+#   4. Stage `final`: collect everything into /out and produce checksums.
+#
+# What's stubbed (see README "what's stubbed vs what's real"):
+#   - The kernel is Alpine's stock virt build, NOT a custom-stripped kernel.
+#     Production should re-build with CONFIG_VSOCK=y / CONFIG_VIRTIO_VSOCK=y
+#     verified, modules trimmed, and a baseline-hashed reproducible build.
+#   - We produce ext4 (not squashfs); CHV/VF both accept both, but squashfs
+#     is preferable for read-only enforcement.
+#   - Reset machinery (P3.2a/b) is not exercised by this build.
+#
+# Reproducibility note:
+#   We pin Alpine 3.20 + Go 1.22-alpine. SOURCE_DATE_EPOCH is exported so the
+#   tar/ext4 timestamps are deterministic enough for hash comparison across
+#   builds on the same host. Bit-for-bit reproducibility across hosts is a
+#   post-MVP goal (R4 / post-MVP backlog: "Reproducible image builds with
+#   signature verification").
+
+ARG ALPINE_VERSION=3.20
+ARG GO_VERSION=1.22
+
+# ---------------------------------------------------------------------------
+# Stage 1: build the vsock-init binary
+# ---------------------------------------------------------------------------
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS vsockbuild
+ARG TARGETARCH
+ARG TARGETOS
+
+WORKDIR /src
+COPY vsock-init/go.mod vsock-init/go.sum* ./
+# go.sum may not exist on first run; tolerate that.
+RUN go mod download || true
+COPY vsock-init/ ./
+
+# Static, stripped, deterministic binary. CGO disabled so we don't drag glibc
+# into a musl-based rootfs. Arch matches the target stage so the binary works
+# under whichever VMM the consumer boots (CHV is x86_64-only today; VF on
+# Apple Silicon needs arm64).
+ENV CGO_ENABLED=0
+RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
+    go mod tidy && \
+    GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
+    go build -trimpath -ldflags="-s -w -buildid=" -o /out/vsock-init . && \
+    ls -la /out/vsock-init
+
+# ---------------------------------------------------------------------------
+# Stage 2: assemble the rootfs
+# ---------------------------------------------------------------------------
+FROM alpine:${ALPINE_VERSION} AS rootfsbuild
+
+# Tools we need on the *builder* (not the rootfs) to assemble the image.
+RUN apk add --no-cache \
+        e2fsprogs \
+        coreutils \
+        tar \
+        xz \
+        gzip
+
+# Build a fresh /rootfs by installing the minimal-Alpine package set into it
+# via apk's --root flag. This gives us busybox (echo/cat/ls/sh/env/uname/whoami)
+# without dragging in apk-tools, dev headers, etc.
+ARG ALPINE_VERSION
+RUN mkdir -p /rootfs/etc/apk/keys && \
+    cp /etc/apk/keys/*.rsa.pub /rootfs/etc/apk/keys/ && \
+    apk add --no-cache --root /rootfs --initdb \
+        --keys-dir /etc/apk/keys \
+        --repository "https://dl-cdn.alpinelinux.org/alpine/v${ALPINE_VERSION}/main/" \
+        alpine-baselayout \
+        busybox \
+        musl \
+        linux-virt
+# linux-virt installs the kernel modules (including vsock + virtio-vsock)
+# under /lib/modules/<kver>/. The in-guest vsock-init modprobes them at
+# startup so /dev/vsock exists before vsock.Listen runs. Without this,
+# busybox modprobe fails with "can't change directory to '/lib/modules'"
+# (caught on first-light run #6 by 0bz7aztr).
+
+# Minimal /etc/hostname, /etc/resolv.conf so processes that touch them don't
+# crash. Networking is host-mediated per plan §3 (D21: agent-proxied egress);
+# the guest itself does not resolve DNS.
+RUN echo bsm-sandbox > /rootfs/etc/hostname && \
+    echo "# brainstorm sandbox: no in-guest DNS by design" > /rootfs/etc/resolv.conf
+
+# Alpine's busybox package installs /rootfs/sbin/init as a symlink to
+# /bin/busybox. Docker COPY follows destination symlinks and would overwrite
+# the *builder's* /bin/busybox (which is what /bin/sh resolves to in the
+# alpine image), breaking every subsequent RUN with confusing exec errors.
+# Delete the symlink first, then COPY into a real path.
+RUN rm -f /rootfs/sbin/init
+COPY --from=vsockbuild --chmod=0755 /out/vsock-init /rootfs/sbin/init
+
+# Deterministic timestamps for tar (passed via --mtime below). We deliberately
+# do NOT walk /rootfs to touch every file: on Darwin/aarch64 Docker Desktop
+# 29.x, `find -exec touch` and even `xargs touch` reproducibly trigger an
+# unwanted exec of /rootfs/sbin/init by some interaction with binfmt or
+# busybox triggers — likely qemu-user-static probing the ELF. Per-file mtime
+# bit-reproducibility is a post-MVP concern (see README TODOs).
+ARG SOURCE_DATE_EPOCH=1714000000
+
+# Produce a tarball (easy to inspect / extract).
+RUN cd /rootfs && \
+    tar --sort=name \
+        --owner=0 --group=0 --numeric-owner \
+        --mtime="@${SOURCE_DATE_EPOCH}" \
+        -cf /tmp/bsm-sandbox-rootfs.tar .
+
+# Produce an ext4 image. 64 MiB is enough headroom for the MVP tool set.
+RUN dd if=/dev/zero of=/tmp/bsm-sandbox-rootfs.img bs=1M count=256 status=none && \
+    mkfs.ext4 -F -L bsm-rootfs -d /rootfs /tmp/bsm-sandbox-rootfs.img
+# Why 256 MiB: linux-virt brings ~55 MiB of installed packages, which after
+# inode + journal + directory overhead doesn't fit a 64 MiB ext4 image
+# (caught by 0bz7aztr on first-light run #7 with mke2fs "Could not allocate
+# block ... while writing file tcp_bbr.ko.gz"). 256 MiB is comfortable
+# headroom; a follow-up should strip /lib/modules down to just vsock +
+# virtio-blk + ext4 deps and shrink back to a tighter image — minimal
+# rootfs is a §G2/G4 attack-surface property of the threat model, not just
+# an ergonomic concern.
+
+# ---------------------------------------------------------------------------
+# Stage 3: pull a kernel + initramfs
+# ---------------------------------------------------------------------------
+FROM alpine:${ALPINE_VERSION} AS pkg
+
+RUN apk add --no-cache linux-virt
+# linux-virt installs to /boot. Names are versioned (e.g. vmlinuz-virt); we
+# normalize to stable names.
+RUN cp /boot/vmlinuz-virt /tmp/bsm-sandbox-kernel && \
+    cp /boot/initramfs-virt /tmp/bsm-sandbox-initramfs
+
+# ---------------------------------------------------------------------------
+# Stage 4: collect outputs + checksums
+# ---------------------------------------------------------------------------
+FROM alpine:${ALPINE_VERSION} AS final
+
+RUN apk add --no-cache coreutils
+WORKDIR /out
+
+COPY --from=rootfsbuild /tmp/bsm-sandbox-rootfs.tar     /out/bsm-sandbox-rootfs.tar
+COPY --from=rootfsbuild /tmp/bsm-sandbox-rootfs.img     /out/bsm-sandbox-rootfs.img
+COPY --from=pkg         /tmp/bsm-sandbox-kernel         /out/bsm-sandbox-kernel
+COPY --from=pkg         /tmp/bsm-sandbox-initramfs      /out/bsm-sandbox-initramfs
+COPY --from=vsockbuild  /out/vsock-init                 /out/vsock-init.bin
+
+RUN cd /out && \
+    sha256sum \
+        bsm-sandbox-rootfs.tar \
+        bsm-sandbox-rootfs.img \
+        bsm-sandbox-kernel \
+        bsm-sandbox-initramfs \
+        vsock-init.bin \
+    > checksums.txt && \
+    cat checksums.txt
+
+CMD ["sh", "-c", "echo 'Image build complete. Artifacts in /out:' && ls -la /out && echo && cat /out/checksums.txt"]

--- a/packages/image-builder/package.json
+++ b/packages/image-builder/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@brainst0rm/image-builder",
+  "version": "0.1.0-alpha.0",
+  "private": true,
+  "type": "module",
+  "description": "Reproducible Linux microVM image builder for the Brainstorm endpoint sandbox (P3.4). Produces a minimal kernel + rootfs that boots under Cloud Hypervisor (Linux/P3.1a) and Apple Virtualization.framework (macOS/P3.1b).",
+  "license": "Apache-2.0",
+  "scripts": {
+    "build": "bash scripts/build.sh",
+    "build:rootfs": "bash scripts/build.sh --target rootfs",
+    "build:kernel": "bash scripts/build.sh --target kernel",
+    "build:vsock-init": "bash scripts/build.sh --target vsock-init",
+    "checksums": "bash scripts/checksums.sh",
+    "clean": "rm -rf artifacts/*.img artifacts/*.tar.gz artifacts/*.bin artifacts/checksums.txt",
+    "test": "echo 'image-builder has no unit tests; the smoke test is scripts/build.sh on a Linux/Docker host'"
+  },
+  "files": [
+    "build/",
+    "scripts/",
+    "vsock-init/",
+    "README.md"
+  ]
+}

--- a/packages/image-builder/scripts/build.sh
+++ b/packages/image-builder/scripts/build.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Brainstorm endpoint sandbox image builder (P3.4) — driver script.
+#
+# Usage:
+#   scripts/build.sh                 # full build
+#   scripts/build.sh --target rootfs # rootfs only (still needs Docker)
+#   scripts/build.sh --target kernel # kernel + initramfs only
+#   scripts/build.sh --no-extract    # skip artifact extraction
+#
+# Behavior on Darwin:
+#   - If Docker (Desktop) is available, runs the build inside Docker.
+#   - If not, prints a clear "skipped" message and exits 0.
+#
+# Behavior on Linux:
+#   - Uses Docker if available, else prints a "needs Docker" message and exits 0.
+#
+# Exit codes:
+#   0  build OK, OR build skipped on a platform that can't run it
+#   2  build attempted but failed
+#   3  invalid arguments
+
+set -euo pipefail
+
+PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ARTIFACTS_DIR="${PKG_DIR}/artifacts"
+DOCKERFILE="${PKG_DIR}/build/Dockerfile"
+IMAGE_TAG="brainstorm/image-builder:dev"
+
+TARGET="all"
+EXTRACT=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target)
+      TARGET="$2"
+      shift 2
+      ;;
+    --no-extract)
+      EXTRACT=0
+      shift
+      ;;
+    -h|--help)
+      sed -n '2,18p' "${BASH_SOURCE[0]}"
+      exit 0
+      ;;
+    *)
+      echo "build.sh: unknown arg: $1" >&2
+      exit 3
+      ;;
+  esac
+done
+
+case "${TARGET}" in
+  all|rootfs|kernel|vsock-init) ;;
+  *)
+    echo "build.sh: --target must be one of: all rootfs kernel vsock-init" >&2
+    exit 3
+    ;;
+esac
+
+mkdir -p "${ARTIFACTS_DIR}"
+
+OS="$(uname -s)"
+echo "[bsm-image-builder] host OS: ${OS}"
+echo "[bsm-image-builder] target: ${TARGET}"
+echo "[bsm-image-builder] artifacts: ${ARTIFACTS_DIR}"
+
+# ---------------------------------------------------------------------------
+# Pre-flight: Docker
+# ---------------------------------------------------------------------------
+if ! command -v docker >/dev/null 2>&1; then
+  cat >&2 <<EOF
+[bsm-image-builder] Docker not found in PATH.
+
+This package builds a Linux kernel + rootfs and therefore requires either:
+  (a) a Linux host with the kernel headers + e2fsprogs, OR
+  (b) any host with Docker / Docker Desktop installed.
+
+On macOS: install Docker Desktop (https://docs.docker.com/desktop/install/mac/)
+or run this build on the Linux relay/CI host.
+
+Skipping build. Exit 0 so this is not a CI failure on platforms that can't run it.
+EOF
+  exit 0
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  cat >&2 <<EOF
+[bsm-image-builder] Docker is installed but the daemon is not reachable.
+  - On macOS: open Docker Desktop and wait for it to finish starting.
+  - On Linux: 'sudo systemctl start docker' or check group membership.
+
+Skipping build (exit 0).
+EOF
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Build
+# ---------------------------------------------------------------------------
+echo "[bsm-image-builder] building image: ${IMAGE_TAG}"
+DOCKER_BUILDKIT=1 docker build \
+  --progress=plain \
+  -f "${DOCKERFILE}" \
+  -t "${IMAGE_TAG}" \
+  "${PKG_DIR}" \
+  || {
+    echo "[bsm-image-builder] docker build FAILED" >&2
+    exit 2
+  }
+
+echo "[bsm-image-builder] image built OK"
+
+if [[ "${EXTRACT}" -eq 0 ]]; then
+  echo "[bsm-image-builder] --no-extract set; leaving artifacts in image"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Extract artifacts: spin up a throwaway container and `docker cp` /out.
+# ---------------------------------------------------------------------------
+CID="$(docker create "${IMAGE_TAG}")"
+trap 'docker rm -f "${CID}" >/dev/null 2>&1 || true' EXIT
+
+echo "[bsm-image-builder] extracting artifacts from container ${CID}"
+
+case "${TARGET}" in
+  all)
+    files=(bsm-sandbox-rootfs.tar bsm-sandbox-rootfs.img bsm-sandbox-kernel bsm-sandbox-initramfs vsock-init.bin checksums.txt)
+    ;;
+  rootfs)
+    files=(bsm-sandbox-rootfs.tar bsm-sandbox-rootfs.img checksums.txt)
+    ;;
+  kernel)
+    files=(bsm-sandbox-kernel bsm-sandbox-initramfs checksums.txt)
+    ;;
+  vsock-init)
+    files=(vsock-init.bin checksums.txt)
+    ;;
+esac
+
+for f in "${files[@]}"; do
+  docker cp "${CID}:/out/${f}" "${ARTIFACTS_DIR}/${f}"
+  echo "  -> ${ARTIFACTS_DIR}/${f}"
+done
+
+echo
+echo "[bsm-image-builder] DONE."
+echo "Artifacts:"
+ls -lh "${ARTIFACTS_DIR}"
+echo
+echo "Checksums:"
+cat "${ARTIFACTS_DIR}/checksums.txt" 2>/dev/null || true

--- a/packages/image-builder/scripts/checksums.sh
+++ b/packages/image-builder/scripts/checksums.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Verify (or print) checksums for already-built artifacts.
+set -euo pipefail
+PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${PKG_DIR}/artifacts"
+if [[ ! -f checksums.txt ]]; then
+  echo "no checksums.txt — run scripts/build.sh first" >&2
+  exit 1
+fi
+sha256sum -c checksums.txt

--- a/packages/image-builder/scripts/lib-stale-check.sh
+++ b/packages/image-builder/scripts/lib-stale-check.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# image_artifacts_stale REPO_ROOT
+#
+# Returns 0 (true) if the produced image-builder artifacts are STALE
+# relative to their inputs — any file under
+# `packages/image-builder/{vsock-init/, build/, scripts/build.sh,
+# scripts/checksums.sh}` is newer than the oldest produced artifact.
+# Returns 1 (false) if artifacts are either missing entirely (caller
+# should treat that as "needs build" too) or all newer than every
+# input.
+#
+# Why this exists: 0bz7aztr's run-6 caught a silent staleness gap in
+# our validation harness. The exists-check on the .img files was
+# letting OLD vsock-init binaries run against fresh source — which
+# masked both fixes-not-applying AND would mask regressions-not-caught.
+# Both directions are bad; the second is invisible, so we always check.
+#
+# Usage:
+#   . packages/image-builder/scripts/lib-stale-check.sh
+#   if image_artifacts_stale "$(pwd)" || [[ ! -f "$ROOTFS" ]]; then
+#       bash packages/image-builder/scripts/build.sh
+#   fi
+
+image_artifacts_stale() {
+    local repo_root="${1:-$(pwd)}"
+    local artifacts="$repo_root/packages/image-builder/artifacts"
+    local rootfs_img="$artifacts/bsm-sandbox-rootfs.img"
+
+    # Missing artifacts → caller should rebuild. Returning false here
+    # because "stale" is specifically about source-newer-than-artifact.
+    # Caller is expected to also test [[ -f $ROOTFS ]] separately.
+    [[ -f "$rootfs_img" ]] || return 1
+
+    local rootfs_mtime
+    rootfs_mtime=$(stat -c %Y "$rootfs_img" 2>/dev/null \
+                    || stat -f %m "$rootfs_img" 2>/dev/null \
+                    || echo 0)
+
+    # Walk every input directory + script, find max source mtime.
+    local newest_source_mtime=0
+    local input_paths=(
+        "$repo_root/packages/image-builder/vsock-init"
+        "$repo_root/packages/image-builder/build"
+        "$repo_root/packages/image-builder/scripts/build.sh"
+        "$repo_root/packages/image-builder/scripts/checksums.sh"
+    )
+    for p in "${input_paths[@]}"; do
+        [[ -e "$p" ]] || continue
+        local m
+        # On Linux: -printf '%T@\n' gives epoch seconds; on macOS: stat -f %m
+        m=$(find "$p" -type f -printf '%T@\n' 2>/dev/null \
+            | sort -nr | head -1 | cut -d. -f1) || true
+        if [[ -z "$m" ]]; then
+            # macOS fallback
+            m=$(find "$p" -type f -exec stat -f %m {} \; 2>/dev/null \
+                | sort -nr | head -1) || true
+        fi
+        m="${m:-0}"
+        if (( m > newest_source_mtime )); then
+            newest_source_mtime=$m
+        fi
+    done
+
+    if (( newest_source_mtime > rootfs_mtime )); then
+        return 0  # stale: source newer
+    fi
+    return 1  # fresh
+}

--- a/packages/image-builder/vsock-init/go.mod
+++ b/packages/image-builder/vsock-init/go.mod
@@ -1,0 +1,12 @@
+module github.com/brainstorm/image-builder/vsock-init
+
+go 1.22
+
+require github.com/mdlayher/vsock v1.2.1
+
+require (
+	github.com/mdlayher/socket v0.4.1 // indirect
+	golang.org/x/net v0.17.0 // indirect
+	golang.org/x/sync v0.4.0 // indirect
+	golang.org/x/sys v0.13.0 // indirect
+)

--- a/packages/image-builder/vsock-init/go.sum
+++ b/packages/image-builder/vsock-init/go.sum
@@ -1,0 +1,12 @@
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/mdlayher/socket v0.4.1 h1:eM9y2/jlbs1M615oshPQOHZzj6R6wMT7bX5NPiQvn2U=
+github.com/mdlayher/socket v0.4.1/go.mod h1:cAqeGjoufqdxWkD7DkpyS+wcefOtmu5OQ8KuoJGIReA=
+github.com/mdlayher/vsock v1.2.1 h1:pC1mTJTvjo1r9n9fbm7S1j04rCgCzhCOS5DY0zqHlnQ=
+github.com/mdlayher/vsock v1.2.1/go.mod h1:NRfCibel++DgeMD8z/hP+PPTjlNJsdPOmxcnENvE+SE=
+golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
+golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
+golang.org/x/sync v0.4.0 h1:zxkM55ReGkDlKSM+Fu41A+zmbZuaPVbGMzvvdUPznYQ=
+golang.org/x/sync v0.4.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/packages/image-builder/vsock-init/main.go
+++ b/packages/image-builder/vsock-init/main.go
@@ -1,0 +1,620 @@
+// vsock-init is the PID-1 init program inside the Brainstorm sandbox microVM.
+//
+// Lifecycle:
+//  1. Mount /proc, /sys, /dev/pts (best-effort; ignores errors so the binary still
+//     works in a non-init smoke-test context).
+//  2. Listen on vsock CID=VMADDR_CID_ANY, port BSM_VSOCK_PORT (default 52000).
+//  3. For each accepted connection: read length-prefixed JSON frames, dispatch
+//     the supported message types defined in
+//     `docs/endpoint-agent-protocol-v1.md` §6 (vsock layer), reply on the same
+//     socket, and close on EOF.
+//
+// Wire frame format (matches §2 of the protocol — length-prefixed binary):
+//
+//	[ uint32 big-endian payload_len ][ payload_len bytes of UTF-8 JSON ]
+//
+// Supported message types (MVP subset of §6):
+//   - ToolDispatch    -> ToolResult           (§6.1, §6.2)
+//   - GuestQuery      -> GuestResponse        (§6.3.5, §6.3.6)
+//   - ResetSignal     -> ResetAck             (§6.4, §6.5; in-guest is a no-op
+//     because real reset is host-side snapshot
+//     revert — see README "what's stubbed")
+//
+// NOT YET IMPLEMENTED (tracked as TODOs in package README):
+//   - EvidenceChunk streaming (§6.3) — only single-shot ToolResult for now
+//   - Hash-chain evidence_hash computation per §6.3 formula
+//   - command_id deduplication across reconnects
+//   - seccomp inside the guest (threat-model defenders' guarantee #4)
+//   - Tool whitelist (currently any binary on $PATH is dispatchable; this is
+//     intentional for MVP echo/whoami/uname/cat-file but is a hardening gap)
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"os/signal"
+	"runtime"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/mdlayher/vsock"
+)
+
+const (
+	defaultVsockPort uint32 = 52000
+	maxFrameBytes           = 16 * 1024 * 1024 // §2 protocol cap = 16 MiB
+	frameReadTimeout        = 30 * time.Second // §2 partial-frame timeout
+
+	// Sentinel exit codes used when the guest itself can't run the requested
+	// command. These are reported in ToolResult.exit_code and are documented
+	// in README.md so callers can distinguish "tool failed" from "guest
+	// failed".
+	exitToolNotFound = 127
+	exitToolKilled   = 137
+	exitGuestError   = 254
+)
+
+// MVP tool whitelist baked into the image (per plan §3.4 D22):
+// echo, whoami, uname, cat (renamed from cat-file for POSIX), plus 2-3
+// MSP-relevant placeholders (ls, env, sh -c). The whitelist is enforced in
+// runTool() so an attacker who lands a frame can't simply exec /bin/anything.
+var allowedTools = map[string]bool{
+	"echo":   true,
+	"whoami": true,
+	"uname":  true,
+	"cat":    true,
+	"ls":     true,
+	"env":    true,
+	"sh":     true, // intentionally allowed for MVP; threat-model gap, see TODO
+}
+
+// ---- wire types -----------------------------------------------------------
+
+type envelope struct {
+	Type string `json:"type"`
+}
+
+type toolDispatch struct {
+	Type       string                 `json:"type"`
+	CommandID  string                 `json:"command_id"`
+	Tool       string                 `json:"tool"`
+	Params     map[string]interface{} `json:"params"`
+	DeadlineMs int64                  `json:"deadline_ms"`
+}
+
+type toolResult struct {
+	Type         string `json:"type"`
+	CommandID    string `json:"command_id"`
+	ExitCode     int    `json:"exit_code"`
+	Stdout       string `json:"stdout"`
+	Stderr       string `json:"stderr"`
+	EvidenceHash string `json:"evidence_hash"`
+}
+
+type guestQuery struct {
+	Type      string `json:"type"`
+	QueryID   string `json:"query_id"`
+	QueryKind string `json:"query_kind"`
+	TS        string `json:"ts"`
+}
+
+type guestResponseMem struct {
+	BytesUsed  uint64 `json:"bytes_used"`
+	BytesTotal uint64 `json:"bytes_total"`
+}
+
+type guestResponse struct {
+	Type      string      `json:"type"`
+	QueryID   string      `json:"query_id"`
+	QueryKind string      `json:"query_kind"`
+	Result    interface{} `json:"result"`
+	TS        string      `json:"ts"`
+}
+
+type resetSignal struct {
+	Type    string `json:"type"`
+	ResetID string `json:"reset_id"`
+	Reason  string `json:"reason"`
+}
+
+type resetAck struct {
+	Type             string                 `json:"type"`
+	ResetID          string                 `json:"reset_id"`
+	ResetCompleteAt  string                 `json:"reset_complete_at"`
+	GoldenHash       string                 `json:"golden_hash"`
+	VerificationPass bool                   `json:"verification_passed"`
+	Details          map[string]interface{} `json:"verification_details"`
+}
+
+// ---- main -----------------------------------------------------------------
+
+func main() {
+	if runtime.GOOS != "linux" {
+		// vsock is Linux-only; refuse to start anywhere else so a developer
+		// running this binary on Darwin sees a clear message rather than a
+		// confusing socket error.
+		fmt.Fprintln(os.Stderr, "vsock-init: only runs on Linux (vsock requires AF_VSOCK)")
+		fatalAsPID1(fmt.Errorf("non-linux host"))
+	}
+
+	if err := runInit(); err != nil {
+		fatalAsPID1(err)
+	}
+}
+
+// runInit returns on listener-close (orderly shutdown) or returns an error
+// on any unrecoverable startup failure. The caller (main) treats both cases
+// — error and clean return — as "do not os.Exit if PID=1": a non-zero exit
+// from PID 1 triggers a kernel panic and burns the console diagnostics that
+// tell us what went wrong (see 0bz7aztr first-light run #5: vsock.Listen
+// failure → os.Exit → "Attempted to kill init!" → panic → no further
+// observability).
+func runInit() error {
+	mountPseudoFilesystems()
+	loadVsockModules()
+
+	port := defaultVsockPort
+	if envPort := os.Getenv("BSM_VSOCK_PORT"); envPort != "" {
+		if p, err := strconv.ParseUint(envPort, 10, 32); err == nil {
+			port = uint32(p)
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "vsock-init: about to vsock.Listen(port=%d)\n", port)
+	l, err := vsock.Listen(port, nil)
+	if err != nil {
+		return fmt.Errorf("vsock.Listen(%d): %w", port, err)
+	}
+	fmt.Fprintf(os.Stderr, "vsock-init: Listen returned ok; listening on vsock port %d\n", port)
+
+	ctx, cancel := signalContext()
+	defer cancel()
+
+	go func() {
+		<-ctx.Done()
+		l.Close()
+	}()
+
+	fmt.Fprintln(os.Stderr, "vsock-init: entering accept() loop")
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			fmt.Fprintf(os.Stderr, "vsock-init: accept error: %v\n", err)
+			continue
+		}
+		fmt.Fprintf(os.Stderr, "vsock-init: accepted connection %s -> %s\n",
+			conn.RemoteAddr(), conn.LocalAddr())
+		go handleConn(conn)
+	}
+}
+
+// fatalAsPID1 prints the error and halts forever rather than os.Exit'ing.
+// PID 1 cannot exit without crashing the kernel, so the only safe failure
+// mode is to log loudly and block, leaving the console scrollback intact
+// for whoever's reading the boot log.
+//
+// IMPORTANT: do NOT use `select {}` here. Go's runtime deadlock detector
+// classifies a single goroutine blocked on an empty select as deadlock,
+// prints a stack trace, and exits with code 2 — which then panics the
+// kernel with "Attempted to kill init! exitcode=0x00000200". (0bz7aztr
+// caught this on first-light run #6.) A heartbeat ticker keeps the
+// runtime busy AND surfaces every-minute "still halted" lines so the
+// operator can tell halt-state apart from full kernel hang.
+func fatalAsPID1(err error) {
+	fmt.Fprintf(os.Stderr, "vsock-init: FATAL (PID=%d): %v\n", os.Getpid(), err)
+	fmt.Fprintln(os.Stderr, "vsock-init: halting indefinitely so console output is preserved (would-be exit code 1)")
+	t := time.NewTicker(60 * time.Second)
+	defer t.Stop()
+	for range t.C {
+		fmt.Fprintf(os.Stderr, "vsock-init: still halted (PID=%d): %v\n", os.Getpid(), err)
+	}
+}
+
+// loadVsockModules best-effort-loads the kernel modules that expose
+// /dev/vsock under Cloud Hypervisor (or any virtio-vsock host). On Alpine
+// virt these ship as separate .ko's, so the in-guest dispatcher must
+// modprobe them before vsock.Listen — otherwise vsock.Listen returns
+// "open /dev/vsock: no such file or directory".
+//
+// We try each module name independently; failures are logged but ignored
+// because (a) some are pulled transitively as deps, (b) some kernels build
+// them in (no-op modprobe). Order matters: vsock first (provides the
+// /dev/vsock node), then transports.
+func loadVsockModules() {
+	modules := []string{
+		"vsock",
+		"vmw_vsock_virtio_transport_common",
+		"vmw_vsock_virtio_transport",
+		// virtio_vsock historically existed as a separate alias on
+		// pre-5.x kernels but was merged into vmw_vsock_virtio_transport.
+		// Linux 6.6.x (Alpine virt) does not have it; the modprobe noise
+		// confused first-light boot logs. If we ever ship to a kernel
+		// older than ~5.x, re-add it here.
+	}
+	for _, m := range modules {
+		cmd := exec.Command("/sbin/modprobe", m)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "vsock-init: modprobe %s: %v (output: %s)\n", m, err, string(out))
+			continue
+		}
+		fmt.Fprintf(os.Stderr, "vsock-init: modprobe %s: ok\n", m)
+	}
+}
+
+func signalContext() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-ch
+		cancel()
+	}()
+	return ctx, cancel
+}
+
+// mountPseudoFilesystems is a best-effort PID-1 setup. It deliberately ignores
+// errors so this binary can also be run as a smoke test inside a regular
+// container during CI (where /proc is already mounted).
+func mountPseudoFilesystems() {
+	type m struct{ src, dst, fs string }
+	for _, x := range []m{
+		{"proc", "/proc", "proc"},
+		{"sysfs", "/sys", "sysfs"},
+		{"devtmpfs", "/dev", "devtmpfs"},
+	} {
+		_ = syscall.Mount(x.src, x.dst, x.fs, 0, "")
+	}
+}
+
+// ---- per-connection loop --------------------------------------------------
+
+func handleConn(c net.Conn) {
+	defer c.Close()
+	for {
+		_ = c.SetReadDeadline(time.Now().Add(frameReadTimeout))
+		payload, err := readFrame(c)
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				fmt.Fprintf(os.Stderr, "vsock-init: readFrame: %v\n", err)
+			}
+			return
+		}
+
+		var env envelope
+		if err := json.Unmarshal(payload, &env); err != nil {
+			writeError(c, "FRAME_MALFORMED", err.Error())
+			return
+		}
+
+		switch env.Type {
+		case "ToolDispatch":
+			var td toolDispatch
+			if err := json.Unmarshal(payload, &td); err != nil {
+				writeError(c, "FRAME_MALFORMED", err.Error())
+				return
+			}
+			tr := runTool(td)
+			_ = writeJSON(c, tr)
+
+		case "GuestQuery":
+			var gq guestQuery
+			if err := json.Unmarshal(payload, &gq); err != nil {
+				writeError(c, "FRAME_MALFORMED", err.Error())
+				return
+			}
+			gr := answerQuery(gq)
+			_ = writeJSON(c, gr)
+
+		case "ResetSignal":
+			var rs resetSignal
+			if err := json.Unmarshal(payload, &rs); err != nil {
+				writeError(c, "FRAME_MALFORMED", err.Error())
+				return
+			}
+			// In-guest reset is a no-op for MVP — the real reset happens
+			// host-side via Cloud Hypervisor / VF snapshot revert. We still
+			// emit a ResetAck so the host loop has a heartbeat.
+			_ = writeJSON(c, resetAck{
+				Type:             "ResetAck",
+				ResetID:          rs.ResetID,
+				ResetCompleteAt:  time.Now().UTC().Format(time.RFC3339Nano),
+				GoldenHash:       "sha256:guest-side-reset-not-implemented",
+				VerificationPass: true,
+				Details: map[string]interface{}{
+					"fs_hash":                 "sha256:guest-side-reset-not-implemented",
+					"fs_hash_baseline":        "sha256:guest-side-reset-not-implemented",
+					"fs_hash_match":           true,
+					"open_fd_count":           openFdCount(),
+					"open_fd_count_baseline":  openFdCount(),
+					"vmm_api_state":           "running",
+					"expected_vmm_api_state":  "Running",
+					"divergence_action":       "none",
+				},
+			})
+
+		default:
+			writeError(c, "FRAME_MALFORMED", "unknown type: "+env.Type)
+			return
+		}
+	}
+}
+
+// ---- frame I/O ------------------------------------------------------------
+
+func readFrame(r io.Reader) ([]byte, error) {
+	var hdr [4]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, err
+	}
+	n := binary.BigEndian.Uint32(hdr[:])
+	if n == 0 {
+		return nil, errors.New("FRAME_MALFORMED: zero length")
+	}
+	if n > maxFrameBytes {
+		return nil, fmt.Errorf("FRAME_TOO_LARGE: %d > %d", n, maxFrameBytes)
+	}
+	buf := make([]byte, n)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+func writeFrame(w io.Writer, payload []byte) error {
+	if len(payload) > maxFrameBytes {
+		return fmt.Errorf("FRAME_TOO_LARGE: %d > %d", len(payload), maxFrameBytes)
+	}
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], uint32(len(payload)))
+	if _, err := w.Write(hdr[:]); err != nil {
+		return err
+	}
+	_, err := w.Write(payload)
+	return err
+}
+
+func writeJSON(w io.Writer, v interface{}) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	return writeFrame(w, b)
+}
+
+func writeError(w io.Writer, code, msg string) {
+	_ = writeJSON(w, map[string]string{
+		"type":    "ErrorEvent",
+		"code":    code,
+		"message": msg,
+	})
+}
+
+// ---- tool dispatch --------------------------------------------------------
+
+func runTool(td toolDispatch) toolResult {
+	tr := toolResult{
+		Type:      "ToolResult",
+		CommandID: td.CommandID,
+		// evidence_hash placeholder — real hash-chain is a TODO (see README).
+		EvidenceHash: "sha256:hash-chain-not-yet-implemented",
+	}
+
+	if !allowedTools[td.Tool] {
+		tr.ExitCode = exitToolNotFound
+		tr.Stderr = "tool not in MVP whitelist: " + td.Tool
+		return tr
+	}
+
+	args, err := paramsToArgs(td.Tool, td.Params)
+	if err != nil {
+		tr.ExitCode = exitGuestError
+		tr.Stderr = err.Error()
+		return tr
+	}
+
+	deadline := time.Duration(td.DeadlineMs) * time.Millisecond
+	if deadline <= 0 {
+		deadline = 30 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), deadline)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, td.Tool, args...)
+	out, err := cmd.Output()
+	tr.Stdout = string(out)
+
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			tr.ExitCode = ee.ExitCode()
+			tr.Stderr = string(ee.Stderr)
+		} else if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			tr.ExitCode = exitToolKilled
+			tr.Stderr = "deadline_exceeded"
+		} else {
+			tr.ExitCode = exitGuestError
+			tr.Stderr = err.Error()
+		}
+	}
+	return tr
+}
+
+// paramsToArgs converts the JSON params blob to argv. Each tool gets a tiny,
+// explicitly enumerated mapping so an attacker can't smuggle arbitrary argv
+// through a free-form params shape.
+func paramsToArgs(tool string, params map[string]interface{}) ([]string, error) {
+	switch tool {
+	case "echo":
+		if msg, ok := params["message"].(string); ok {
+			return []string{msg}, nil
+		}
+		return []string{""}, nil
+	case "whoami":
+		return nil, nil
+	case "uname":
+		flag, _ := params["flag"].(string)
+		if flag == "" {
+			flag = "-a"
+		}
+		return []string{flag}, nil
+	case "cat":
+		path, ok := params["path"].(string)
+		if !ok {
+			return nil, errors.New("cat requires params.path (string)")
+		}
+		return []string{path}, nil
+	case "ls":
+		path, _ := params["path"].(string)
+		if path == "" {
+			path = "/"
+		}
+		return []string{"-la", path}, nil
+	case "env":
+		return nil, nil
+	case "sh":
+		script, ok := params["script"].(string)
+		if !ok {
+			return nil, errors.New("sh requires params.script (string)")
+		}
+		return []string{"-c", script}, nil
+	}
+	return nil, errors.New("unmapped tool: " + tool)
+}
+
+// ---- guest queries (§6.3.5/§6.3.6) ----------------------------------------
+
+func answerQuery(gq guestQuery) guestResponse {
+	resp := guestResponse{
+		Type:      "GuestResponse",
+		QueryID:   gq.QueryID,
+		QueryKind: gq.QueryKind,
+		TS:        time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	switch gq.QueryKind {
+	case "OpenFdCount":
+		resp.Result = map[string]int{"open_fd_count": openFdCount()}
+	case "MemUsage":
+		used, total := memUsage()
+		resp.Result = guestResponseMem{BytesUsed: used, BytesTotal: total}
+	case "ProcessList":
+		resp.Result = map[string]interface{}{"processes": processList()}
+	default:
+		resp.Result = map[string]string{"error": "unknown query_kind"}
+	}
+	return resp
+}
+
+// openFdCount returns vsock-init's open NON-SOCKET fd count.
+//
+// Why exclude sockets: the integrity monitor's reset-cycle compares
+// pre-reset and post-reset fd counts. After CHV's restore + host's
+// re-handshake, the vsock listener and any accepted connections are
+// in different connection-topology than at baseline-capture time —
+// even though the metric's intent ("did anything in the guest leak fds
+// across reset") is invariant under host-connection topology. Filtering
+// sockets makes the metric stable: any change indicates a non-socket
+// resource leak (file handles, pipes, eventfds, etc.) which IS what we
+// want to detect. Caught by 0bz7aztr on run-5 — without this filter,
+// fd_match=false fired on every reset because of the natural
+// connection-topology asymmetry across CHV restore.
+func openFdCount() int {
+	entries, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		return -1
+	}
+	count := 0
+	for _, e := range entries {
+		// Stat each fd. Socket fds have type S_IFSOCK; we exclude those.
+		// Other fds (regular files, pipes, devices, eventfds) are counted
+		// because their growth indicates real resource leaks across reset.
+		path := "/proc/self/fd/" + e.Name()
+		info, err := os.Stat(path)
+		if err != nil {
+			// Fd may have been closed between ReadDir and Stat — race
+			// is rare but real on a busy guest. Skip; don't bias the
+			// count with a stale entry.
+			continue
+		}
+		if info.Mode()&os.ModeSocket != 0 {
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+func memUsage() (used, total uint64) {
+	// Best-effort — parses /proc/meminfo. Errors → zeros (silent per §6.3.6).
+	f, err := os.Open("/proc/meminfo")
+	if err != nil {
+		return 0, 0
+	}
+	defer f.Close()
+	var memTotalKB, memAvailableKB uint64
+	for {
+		var key string
+		var val uint64
+		var unit string
+		_, err := fmt.Fscanf(f, "%s %d %s\n", &key, &val, &unit)
+		if err != nil {
+			break
+		}
+		switch key {
+		case "MemTotal:":
+			memTotalKB = val
+		case "MemAvailable:":
+			memAvailableKB = val
+		}
+	}
+	total = memTotalKB * 1024
+	if memTotalKB >= memAvailableKB {
+		used = (memTotalKB - memAvailableKB) * 1024
+	}
+	return used, total
+}
+
+func processList() []map[string]interface{} {
+	out := []map[string]interface{}{}
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return out
+	}
+	const maxProcs = 100
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(e.Name())
+		if err != nil {
+			continue
+		}
+		name, _ := os.ReadFile("/proc/" + e.Name() + "/comm")
+		out = append(out, map[string]interface{}{
+			"pid":  pid,
+			"name": trimNewline(string(name)),
+		})
+		if len(out) >= maxProcs {
+			break
+		}
+	}
+	return out
+}
+
+func trimNewline(s string) string {
+	for len(s) > 0 && (s[len(s)-1] == '\n' || s[len(s)-1] == '\r') {
+		s = s[:len(s)-1]
+	}
+	return s
+}

--- a/packages/sandbox-redteam/README.md
+++ b/packages/sandbox-redteam/README.md
@@ -1,0 +1,165 @@
+# @brainst0rm/sandbox-redteam
+
+P3.5a red-team test framework for the Brainstorm endpoint-agent sandbox boundary.
+
+## Status
+
+This package is the **validation layer**. It runs a configurable battery of probes (mapped to the A1–A10 attacker classes from the threat model) against any concrete `Sandbox` implementation. Once CHV (`@brainst0rm/sandbox`) and VF (`@brainst0rm/sandbox-vz`) first-boot, this is what proves the boundary actually contains tool execution.
+
+Today, both real backends are **scaffold-only** (PR #277). All probes are validated against a `MockSandbox` that mirrors the `Sandbox` interface. The `validatedAgainst` field on each probe declares this honestly.
+
+## Architecture
+
+```
+RedTeamRunner
+    │
+    ├─ sandbox.boot()        (autoBoot, opt-out)
+    │
+    └─ for each Probe:
+         ├─ probe.setup(sandbox)
+         ├─ probe.run(sandbox) ─► ProbeOutcome { passed, reason, evidence }
+         ├─ probe.teardown(sandbox)
+         └─ sandbox.reset()      (D13 trigger; SandboxResetDivergenceError
+                                 from A6-class probes is expected)
+```
+
+A `Probe` is `{ name, attackerClass, description, validatedAgainst, expectation, run(sandbox) }`. The runner wraps each probe with timing + per-probe budget enforcement and produces a `RedTeamReport` (schema v1.0).
+
+## Probe matrix
+
+| Probe                     | Attacker class | Tests                                                                                                                                                                                                                                                                 | Validation |
+| ------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| **P-A1-net-egress**       | A1             | Tool opens arbitrary outbound TCP. MUST fail.                                                                                                                                                                                                                         | mock-only  |
+| **P-A2-fs-escape**        | A2             | Tool reads host `/etc/shadow`. MUST fail; marker MUST NOT leak.                                                                                                                                                                                                       | mock-only  |
+| **P-A3-process-escape**   | A3             | Tool sends SIGTERM to host PID 1. MUST fail.                                                                                                                                                                                                                          | mock-only  |
+| **P-A4-resource-exhaust** | A4             | Tool allocates 100 GiB / fork-bombs. MUST be killed.                                                                                                                                                                                                                  | mock-only  |
+| **P-A5-time-bomb**        | A5             | Tool sleeps past `deadline_ms`. MUST throw `SandboxToolTimeoutError`.                                                                                                                                                                                                 | mock-only  |
+| **P-A6-substrate-lie**    | A6             | Host mutates overlay between dispatches. Next `reset()` MUST detect divergence in 3-source verification (`divergence_action !== "none"`) AND throw `SandboxResetDivergenceError`. The headline integrity-check. Catches lying-VMM via independent host-side evidence. | mock-only  |
+| **P-A7-stdout-injection** | A7             | Tool emits forged `CommandResult` JSON to stdout. Boundary MUST NOT promote it to a protocol frame.                                                                                                                                                                   | mock-only  |
+| **P-A8-vsock-poison**     | A8             | Sandbox receives oversized / truncated / JSON-injection vsock frames. MUST reject without crashing; subsequent `executeTool` MUST succeed.                                                                                                                            | mock-only  |
+| **P-LAT-boot**            | LAT            | 1000-iteration boot/shutdown distribution. p50/p90/p95/p99.                                                                                                                                                                                                           | mock-only  |
+| **P-LAT-reset**           | LAT            | 1000-iteration reset distribution.                                                                                                                                                                                                                                    | mock-only  |
+| **P-LAT-roundtrip**       | LAT            | 1000-iteration `executeTool(noop)` distribution.                                                                                                                                                                                                                      | mock-only  |
+
+## Honest gap list
+
+What this framework does **not** cover:
+
+- **Crypto-side-channel** attacks (timing, cache, Spectre-class) — out of MVP.
+- **Kernel-CVE chains** — needs a curated CVE corpus and an in-guest exploit harness; the image-builder pipeline (P3.4) owns that.
+- **A4 build-time image compromise** — by definition baseline-compromised; integrity monitor cannot detect at runtime (threat-model §5.5).
+- **A5 compromised host agent** — the monitor IS the agent; no probe here can detect it.
+- **A9 cross-context replay** — covered by relay/operator-key tests, not the sandbox boundary.
+- **A10 replay after agent restart** — same; covered by `@brainst0rm/relay` nonce-store tests.
+- **Real CHV cow-overlay mutation** for P-A6 — needs the P3.4 image-builder overlay layout to be locked in. The probe currently returns "stubbed" when given a non-mock backend.
+- **Real vsock poison framing** — needs `vsock-client.ts` CONNECT handshake to land first.
+- **1000-iteration latency on real microVM** — mock numbers reflect Node event-loop overhead, not microVM reality.
+
+## CLI
+
+```bash
+# Default: mock backend, full battery, JSON to stdout
+npx bsm-redteam
+
+# Once CHV first-boots on a Linux host:
+bsm-redteam --sandbox chv --probes all --output /tmp/p35a-report.json
+
+# Once VF first-boots on macOS:
+bsm-redteam --sandbox vf --probes all --output /tmp/p35a-report.json
+
+# Just adversarial probes (no latency battery):
+bsm-redteam --sandbox mock --probes adversarial -o report.json
+
+# Latency battery only, with a smaller iteration count:
+bsm-redteam --sandbox mock --probes lat --iterations 100
+```
+
+Selecting `--sandbox chv|vf` on a host without that backend produces a clean skip report with a note in `report.notes` — exit code 0, but `summary.passed === 0`. CI consumers should assert on `summary.passed > 0` to catch silent skips.
+
+Exit codes:
+
+- `0` — clean report (no failures, no errors)
+- `1` — at least one probe failed or errored
+- `2` — CLI usage error
+
+## Report schema (v1.0)
+
+```jsonc
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-04-27T12:00:00.000Z",
+  "backend": "chv",
+  "final_sandbox_state": "ready",
+  "probes": [
+    {
+      "name": "P-A6-substrate-lie",
+      "attacker_class": "A6",
+      "expectation": "should-fail",
+      "validated_against": "mock-only",
+      "description": "...",
+      "passed": true,
+      "reason": "reset detected divergence: ...",
+      "duration_ms": 12,
+      "errored": false,
+      "evidence": { "error_code": "SANDBOX_RESET_DIVERGENCE" },
+    },
+    // ...
+  ],
+  "latency": {
+    "P-LAT-roundtrip": {
+      "samples": 1000,
+      "p50_ms": 0.05,
+      "p90_ms": 0.12,
+      "p95_ms": 0.18,
+      "p99_ms": 0.31,
+      "mean_ms": 0.07,
+      "min_ms": 0.02,
+      "max_ms": 1.4,
+    },
+  },
+  "summary": {
+    "total": 11,
+    "passed": 11,
+    "failed": 0,
+    "errored": 0,
+    "skipped": 0,
+  },
+  "notes": [],
+}
+```
+
+## Building probes
+
+Each probe is a plain object satisfying the `Probe` interface. The contract:
+
+```ts
+import type { Probe, ProbeOutcome } from "@brainst0rm/sandbox-redteam";
+import type { Sandbox } from "@brainst0rm/sandbox";
+
+export const myProbe: Probe = {
+  name: "P-A3-fork-bomb",
+  attackerClass: "A3",
+  expectation: "should-fail",
+  validatedAgainst: "mock-only", // bump to "validated-chv" once exercised
+  description: "Tool fork-bombs the guest. cgroup pids.max should kill it.",
+  async run(sandbox: Sandbox): Promise<ProbeOutcome> {
+    const exec = await sandbox.executeTool({
+      command_id: "fork-bomb",
+      tool: "shell.exec",
+      params: { cmd: ":(){ :|:& };:" },
+      deadline_ms: 5_000,
+    });
+    return {
+      passed: exec.exit_code !== 0,
+      reason: `exit=${exec.exit_code}`,
+      evidence: { exit_code: exec.exit_code },
+    };
+  },
+};
+```
+
+When you exercise a probe against a real CHV/VF host, bump `validatedAgainst` to `"validated-chv"`, `"validated-vf"`, or `"validated-chv-and-vf"`. CI should fail the day all probes still say `"mock-only"` after first-boot.
+
+## Why a separate package
+
+This lives outside `@brainst0rm/sandbox` so the sandbox interface is not co-versioned with the red-team probes. Probes evolve faster than the boundary; pinning them in their own `0.1.0` package lets us iterate without forcing sandbox consumers to bump.

--- a/packages/sandbox-redteam/package.json
+++ b/packages/sandbox-redteam/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@brainst0rm/sandbox-redteam",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "P3.5a red-team test framework for the Brainstorm endpoint-agent sandbox abstraction. Runs a configurable battery of probes (A1-A10 attacker classes) against any concrete Sandbox implementation (CHV, VF, mock) and emits a structured RedTeamReport. Validation layer that — once a real sandbox first-boots — proves it actually contains tool execution. Today probes are validated against a mock Sandbox; real CHV/VF runs are gated until first-boot.",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "bin": {
+    "bsm-redteam": "dist/bin/bsm-redteam.js"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@brainst0rm/relay": "0.1.0",
+    "@brainst0rm/sandbox": "0.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsup": "^8.3.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/sandbox-redteam/src/__tests__/real-chv-runner.test.ts
+++ b/packages/sandbox-redteam/src/__tests__/real-chv-runner.test.ts
@@ -1,0 +1,463 @@
+// Tests for the P3.5b real-CHV validation modes.
+//
+// These tests use a deterministic-timing fake `Sandbox` so we can assert
+// the aggregation math, the concurrent-launch behaviour, the failure-mode
+// reporting, and the JSON output schema without touching real CHV.
+//
+// The real-CHV path itself is exercised by
+// `packages/sandbox/scripts/full-validation.sh` on a Linux+KVM host —
+// these unit tests only prove the framework code does the right thing
+// once the real sandbox is wired in.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildChvConfig,
+  concurrentOverrides,
+  shardSocketPath,
+  runConcurrentBattery,
+  runLatencyBattery,
+  serializeReport,
+  summariseValidationProvenance,
+} from "../index.js";
+import type {
+  Sandbox,
+  SandboxBackend,
+  SandboxState,
+  ToolExecution,
+  ToolInvocation,
+} from "@brainst0rm/sandbox";
+
+// ---------- deterministic-timing fake Sandbox ----------------------------
+
+interface FakeSandboxOpts {
+  /** ms to spend in `boot()` (simulated via setTimeout). */
+  bootMs?: number;
+  /** ms to spend in `executeTool()`. */
+  execMs?: number;
+  /** ms to spend in `shutdown()`. */
+  shutdownMs?: number;
+  /** Force boot to throw with this message. */
+  failBoot?: string;
+  /** Force exec to throw with this message. */
+  failExec?: string;
+  /** Force exec to return a non-zero exit_code with this stderr. */
+  execNonZero?: { exit_code: number; stderr: string };
+  /** Force shutdown to throw with this message. */
+  failShutdown?: string;
+  /** Backend label to surface. */
+  backend?: SandboxBackend;
+}
+
+class FakeSandbox implements Sandbox {
+  public readonly backend: SandboxBackend;
+  private status: SandboxState = "not_booted";
+  private readonly opts: FakeSandboxOpts;
+  constructor(opts: FakeSandboxOpts = {}) {
+    this.opts = opts;
+    this.backend = opts.backend ?? "chv";
+  }
+  state(): SandboxState {
+    return this.status;
+  }
+  async boot(): Promise<void> {
+    this.status = "booting";
+    await sleep(this.opts.bootMs ?? 0);
+    if (this.opts.failBoot !== undefined) {
+      this.status = "failed";
+      throw new Error(this.opts.failBoot);
+    }
+    this.status = "ready";
+  }
+  async executeTool(_inv: ToolInvocation): Promise<ToolExecution> {
+    await sleep(this.opts.execMs ?? 0);
+    if (this.opts.failExec !== undefined) {
+      throw new Error(this.opts.failExec);
+    }
+    if (this.opts.execNonZero !== undefined) {
+      return {
+        exit_code: this.opts.execNonZero.exit_code,
+        stdout: "",
+        stderr: this.opts.execNonZero.stderr,
+      };
+    }
+    return { exit_code: 0, stdout: "echo ok", stderr: "" };
+  }
+  async reset(): Promise<never> {
+    throw new Error("reset not implemented in FakeSandbox");
+  }
+  async shutdown(): Promise<void> {
+    await sleep(this.opts.shutdownMs ?? 0);
+    if (this.opts.failShutdown !== undefined) {
+      throw new Error(this.opts.failShutdown);
+    }
+    this.status = "not_booted";
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// ---------- 1. lat-only mode aggregation math ----------------------------
+
+describe("runLatencyBattery — aggregation math", () => {
+  it("collects N samples, all-passing case produces clean report", async () => {
+    const N = 20;
+    const factory = (): Sandbox =>
+      new FakeSandbox({ bootMs: 1, execMs: 0, shutdownMs: 0 });
+    const report = await runLatencyBattery(factory, {
+      iterations: N,
+      backendLabel: "chv-test",
+    });
+
+    expect(report.summary.total).toBe(4); // boot/roundtrip/shutdown/total
+    expect(report.summary.passed).toBe(4);
+    expect(report.summary.failed).toBe(0);
+    expect(report.latency["P-LAT-boot"]?.samples).toBe(N);
+    expect(report.latency["P-LAT-roundtrip"]?.samples).toBe(N);
+    expect(report.latency["P-LAT-shutdown"]?.samples).toBe(N);
+    expect(report.latency["P-LAT-total"]?.samples).toBe(N);
+
+    // boot should dominate timing since execMs=0/shutdownMs=0 and bootMs=1.
+    // Since setTimeout granularity is rough, just assert the relationship.
+    const bootDist = report.latency["P-LAT-boot"]!;
+    expect(bootDist.min_ms).toBeGreaterThanOrEqual(0);
+    expect(bootDist.max_ms).toBeGreaterThanOrEqual(bootDist.min_ms);
+    expect(bootDist.p99_ms).toBeGreaterThanOrEqual(bootDist.p50_ms);
+
+    // Probe results carry the validation-provenance marker.
+    for (const probe of report.probes) {
+      expect(probe.validated_against).toBe("validated-chv");
+      expect(probe.attacker_class).toBe("LAT");
+      expect(probe.passed).toBe(true);
+    }
+  });
+
+  it("records per-iteration failures without aborting the battery", async () => {
+    const N = 10;
+    let i = -1;
+    const factory = (): Sandbox => {
+      i += 1;
+      // Fail boot on iter 3 + 7. All other iterations succeed.
+      if (i === 3 || i === 7) {
+        return new FakeSandbox({ failBoot: `forced-boot-failure-${i}` });
+      }
+      return new FakeSandbox({ bootMs: 1 });
+    };
+    const report = await runLatencyBattery(factory, {
+      iterations: N,
+      backendLabel: "chv-test",
+    });
+
+    // 4 LAT probes, all marked "failed" because not every iter succeeded.
+    expect(report.summary.failed).toBe(4);
+    expect(report.summary.passed).toBe(0);
+    const ev = report.probes[0]!.evidence as {
+      iterations_attempted: number;
+      iterations_succeeded: number;
+      iterations_failed: number;
+      failure_phases: Record<string, number>;
+    };
+    expect(ev.iterations_attempted).toBe(N);
+    expect(ev.iterations_succeeded).toBe(N - 2);
+    expect(ev.iterations_failed).toBe(2);
+    expect(ev.failure_phases.boot).toBe(2);
+  });
+
+  it("aggregates known timings deterministically", async () => {
+    // Force iter index into bootMs so we get a known distribution.
+    let i = -1;
+    const factory = (): Sandbox => {
+      i += 1;
+      // bootMs sweeps 1..10ms — the resulting distribution should have
+      // p50 ~ 5..6ms and p99 == max == 10ms (or close due to setTimeout
+      // jitter).
+      return new FakeSandbox({ bootMs: i + 1 });
+    };
+    const N = 10;
+    const report = await runLatencyBattery(factory, {
+      iterations: N,
+      backendLabel: "chv-test",
+    });
+    const bootDist = report.latency["P-LAT-boot"]!;
+    expect(bootDist.samples).toBe(N);
+    // p99 should be the largest sample (or within timer slack) — the
+    // 10th iteration sleeps the longest. We allow a 50ms slack to tolerate
+    // event-loop scheduling jitter on busy CI runners.
+    expect(bootDist.p99_ms).toBeGreaterThanOrEqual(bootDist.p50_ms);
+    expect(bootDist.max_ms).toBeGreaterThanOrEqual(bootDist.p99_ms);
+    expect(bootDist.min_ms).toBeLessThanOrEqual(bootDist.p50_ms);
+  });
+});
+
+// ---------- 2. concurrent mode launches N sandboxes ----------------------
+
+describe("runConcurrentBattery — N sandboxes in parallel", () => {
+  it("launches N sandboxes and reports per-instance results", async () => {
+    const N = 8;
+    const factory = (i: number): Sandbox => {
+      // Boot times stagger so we can observe parallelism (highest takes
+      // ~16ms; total wall-clock should be << N*16ms because they're
+      // concurrent).
+      return new FakeSandbox({ bootMs: 2 + (i % 4) * 2 });
+    };
+    const t0 = Date.now();
+    const report = await runConcurrentBattery(factory, {
+      concurrency: N,
+      backendLabel: "chv-test",
+    });
+    const elapsed = Date.now() - t0;
+
+    expect(report.summary.total).toBe(N);
+    expect(report.summary.passed).toBe(N);
+    expect(report.summary.failed).toBe(0);
+
+    // All probes named P-CONC-instance-0..N-1.
+    for (let i = 0; i < N; i += 1) {
+      const probe = report.probes.find(
+        (p) => p.name === `P-CONC-instance-${i}`,
+      );
+      expect(probe).toBeDefined();
+      expect(probe!.passed).toBe(true);
+      expect(probe!.validated_against).toBe("validated-chv");
+    }
+
+    // Parallelism check: total wall < ~N*16ms by a wide margin.
+    // Generous 200ms upper bound to tolerate noisy CI; sequential would
+    // be roughly sum(2,4,6,8,2,4,6,8) = 40ms with overhead. Concurrent
+    // should be ~8ms-ish.
+    expect(elapsed).toBeLessThan(200);
+
+    // Latency map populated.
+    expect(report.latency["P-CONC-boot"]?.samples).toBe(N);
+    expect(report.latency["P-CONC-exec"]?.samples).toBe(N);
+    expect(report.latency["P-CONC-shutdown"]?.samples).toBe(N);
+  });
+});
+
+// ---------- 3. concurrent mode fails cleanly when one of N fails ---------
+
+describe("runConcurrentBattery — failure isolation", () => {
+  it("records the failing instance, others still pass", async () => {
+    const N = 6;
+    const factory = (i: number): Sandbox => {
+      if (i === 3) {
+        return new FakeSandbox({ failBoot: "instance-3-cant-boot" });
+      }
+      return new FakeSandbox({ bootMs: 1 });
+    };
+    const report = await runConcurrentBattery(factory, {
+      concurrency: N,
+      backendLabel: "chv-test",
+    });
+
+    expect(report.summary.total).toBe(N);
+    expect(report.summary.passed).toBe(N - 1);
+    expect(report.summary.failed).toBe(1);
+
+    const failed = report.probes.find((p) => p.name === "P-CONC-instance-3")!;
+    expect(failed.passed).toBe(false);
+    expect(failed.reason).toMatch(/boot.*instance-3-cant-boot/);
+    const ev = failed.evidence as {
+      failure_phase?: string;
+      error?: string;
+    };
+    expect(ev.failure_phase).toBe("boot");
+
+    // Notes section enumerates each failure for operator visibility.
+    expect(report.notes.join(" ")).toMatch(/instance 3 failed/);
+  });
+
+  it("exec-phase failure on one instance reported distinctly", async () => {
+    const N = 4;
+    const factory = (i: number): Sandbox => {
+      if (i === 1) {
+        return new FakeSandbox({ failExec: "exec-blew-up" });
+      }
+      return new FakeSandbox();
+    };
+    const report = await runConcurrentBattery(factory, {
+      concurrency: N,
+      backendLabel: "chv-test",
+    });
+    expect(report.summary.failed).toBe(1);
+    const failed = report.probes.find((p) => p.name === "P-CONC-instance-1")!;
+    const ev = failed.evidence as { failure_phase?: string };
+    expect(ev.failure_phase).toBe("exec");
+  });
+});
+
+// ---------- 4. validation-provenance count distinct ----------------------
+
+describe("validation provenance counting", () => {
+  it("distinguishes mock-only vs validated-chv probes in the summary", async () => {
+    const N = 3;
+    const factory = (): Sandbox => new FakeSandbox();
+    // Run a real-CHV-marked latency battery → all 4 probes are
+    // validated-chv.
+    const real = await runLatencyBattery(factory, {
+      iterations: N,
+      validatedAgainst: "validated-chv",
+      backendLabel: "chv",
+    });
+    const realProv = summariseValidationProvenance(real);
+    expect(realProv.validatedChv).toBe(4);
+    expect(realProv.mockOnly).toBe(0);
+    expect(realProv.total).toBe(4);
+
+    // Manually craft a report with a mix to assert the counter handles
+    // multiple statuses without conflating them.
+    const mixed = {
+      ...real,
+      probes: [
+        ...real.probes,
+        {
+          ...real.probes[0]!,
+          name: "P-A6-mock",
+          validated_against: "mock-only" as const,
+        },
+        {
+          ...real.probes[0]!,
+          name: "P-A1-mock",
+          validated_against: "mock-only" as const,
+        },
+      ],
+    };
+    const mixedProv = summariseValidationProvenance(mixed);
+    expect(mixedProv.total).toBe(6);
+    expect(mixedProv.validatedChv).toBe(4);
+    expect(mixedProv.mockOnly).toBe(2);
+    expect(mixedProv.validatedVf).toBe(0);
+  });
+});
+
+// ---------- 5. JSON output schema is stable ------------------------------
+
+describe("JSON output schema", () => {
+  it("real-chv lat report round-trips with stable top-level keys", async () => {
+    const factory = (): Sandbox => new FakeSandbox();
+    const report = await runLatencyBattery(factory, {
+      iterations: 5,
+      backendLabel: "chv",
+    });
+    const json = serializeReport(report);
+    const parsed = JSON.parse(json) as typeof report;
+
+    // Schema-version is pinned.
+    expect(parsed.schema_version).toBe("1.0");
+
+    // Top-level keys match the documented set.
+    const keys = new Set(Object.keys(parsed));
+    expect(keys.has("schema_version")).toBe(true);
+    expect(keys.has("generated_at")).toBe(true);
+    expect(keys.has("backend")).toBe(true);
+    expect(keys.has("final_sandbox_state")).toBe(true);
+    expect(keys.has("probes")).toBe(true);
+    expect(keys.has("latency")).toBe(true);
+    expect(keys.has("summary")).toBe(true);
+    expect(keys.has("notes")).toBe(true);
+
+    // summary keys match.
+    const summaryKeys = new Set(Object.keys(parsed.summary));
+    expect(summaryKeys.has("total")).toBe(true);
+    expect(summaryKeys.has("passed")).toBe(true);
+    expect(summaryKeys.has("failed")).toBe(true);
+    expect(summaryKeys.has("errored")).toBe(true);
+    expect(summaryKeys.has("skipped")).toBe(true);
+
+    // Probe shape matches.
+    for (const probe of parsed.probes) {
+      expect(probe.name).toBeDefined();
+      expect(probe.attacker_class).toBeDefined();
+      expect(probe.expectation).toBeDefined();
+      expect(probe.validated_against).toBeDefined();
+      expect(typeof probe.passed).toBe("boolean");
+      expect(typeof probe.reason).toBe("string");
+      expect(typeof probe.duration_ms).toBe("number");
+      expect(typeof probe.errored).toBe("boolean");
+    }
+
+    // Each LatencyDistribution carries the documented stats.
+    for (const dist of Object.values(parsed.latency)) {
+      expect(typeof dist.samples).toBe("number");
+      expect(typeof dist.p50_ms).toBe("number");
+      expect(typeof dist.p90_ms).toBe("number");
+      expect(typeof dist.p95_ms).toBe("number");
+      expect(typeof dist.p99_ms).toBe("number");
+      expect(typeof dist.mean_ms).toBe("number");
+      expect(typeof dist.min_ms).toBe("number");
+      expect(typeof dist.max_ms).toBe("number");
+    }
+  });
+
+  it("concurrent report round-trips with stable schema", async () => {
+    const factory = (): Sandbox => new FakeSandbox();
+    const report = await runConcurrentBattery(factory, {
+      concurrency: 3,
+      backendLabel: "chv",
+    });
+    const json = serializeReport(report);
+    const parsed = JSON.parse(json) as typeof report;
+    expect(parsed.schema_version).toBe("1.0");
+    expect(parsed.probes.length).toBe(3);
+    expect(parsed.latency["P-CONC-boot"]).toBeDefined();
+  });
+});
+
+// ---------- 6. config builder + concurrent overrides ---------------------
+
+describe("buildChvConfig + concurrentOverrides", () => {
+  it("rejects missing required env vars with humane errors", () => {
+    const here = new URL(import.meta.url).pathname;
+    expect(() => buildChvConfig({})).toThrow(/BSM_KERNEL is required/);
+    expect(() => buildChvConfig({ BSM_KERNEL: here })).toThrow(
+      /BSM_ROOTFS is required/,
+    );
+  });
+
+  it("rejects nonexistent paths", () => {
+    const here = new URL(import.meta.url).pathname;
+    expect(() =>
+      buildChvConfig({
+        BSM_KERNEL: "/this/path/does/not/exist",
+        BSM_ROOTFS: here,
+      }),
+    ).toThrow(/BSM_KERNEL points to nonexistent path/);
+  });
+
+  it("shardSocketPath inserts -N before .sock", () => {
+    expect(shardSocketPath("/tmp/foo.sock", 0)).toBe("/tmp/foo-0.sock");
+    expect(shardSocketPath("/tmp/foo.sock", 7)).toBe("/tmp/foo-7.sock");
+    expect(shardSocketPath("/tmp/foo", 3)).toBe("/tmp/foo-3");
+  });
+
+  it("concurrentOverrides assigns unique cid 3+i and unique sockets", () => {
+    const o0 = concurrentOverrides(0, "/tmp/v.sock", "/tmp/a.sock");
+    const o1 = concurrentOverrides(1, "/tmp/v.sock", "/tmp/a.sock");
+    expect(o0.cid).toBe(3);
+    expect(o1.cid).toBe(4);
+    expect(o0.vsockSocketPath).toBe("/tmp/v-0.sock");
+    expect(o1.vsockSocketPath).toBe("/tmp/v-1.sock");
+    expect(o0.apiSocketPath).toBe("/tmp/a-0.sock");
+    expect(o1.apiSocketPath).toBe("/tmp/a-1.sock");
+  });
+
+  it("buildChvConfig accepts overrides and produces the right config", () => {
+    // Use a self-reference path that always exists across platforms
+    // (we're just testing the shape, not actually loading the kernel).
+    const here = new URL(import.meta.url).pathname;
+    const env = {
+      BSM_KERNEL: here,
+      BSM_ROOTFS: here,
+      BSM_VSOCK_SOCKET: "/tmp/v.sock",
+      BSM_API_SOCKET: "/tmp/a.sock",
+    };
+    const overrides = concurrentOverrides(2, "/tmp/v.sock", "/tmp/a.sock");
+    const built = buildChvConfig(env, overrides);
+    expect(built.config.vsock.cid).toBe(5);
+    expect(built.config.vsock.socketPath).toBe("/tmp/v-2.sock");
+    expect(built.config.apiSocketPath).toBe("/tmp/a-2.sock");
+    expect(built.effective.cid).toBe(5);
+  });
+});

--- a/packages/sandbox-redteam/src/__tests__/runner.test.ts
+++ b/packages/sandbox-redteam/src/__tests__/runner.test.ts
@@ -1,0 +1,244 @@
+// Tests for the P3.5a red-team framework against MockSandbox.
+//
+// These tests are the framework's only proof that probes mean what they
+// say. Once a real CHV/VF host is available, the same probes (with
+// additional `validatedAgainst` markers) become the production gate.
+//
+// Coverage target (per spec):
+//   1. probe success path
+//   2. probe failure path
+//   3. latency aggregation correctness
+//   4. P-A6 host-mutation detection (lying-VMM scenario)
+//   5. report serialization round-trip
+//   6. runner skip behaviour when sandbox is not available
+
+import { describe, it, expect } from "vitest";
+
+import {
+  MockSandbox,
+  RedTeamRunner,
+  defenderToolBattery,
+  attackerToolBattery,
+  serializeReport,
+  reportIsClean,
+  aggregateLatency,
+  percentile,
+  pA1NetEgress,
+  pA2FsEscape,
+  pA3ProcessEscape,
+  pA6SubstrateLie,
+  pA8VsockPoison,
+  ALL_ADVERSARIAL_PROBES,
+  makeLatencyProbe,
+} from "../index.js";
+import { SandboxNotAvailableError, type Sandbox } from "@brainst0rm/sandbox";
+
+// ---------- 1. probe success path ----------------------------------------
+
+describe("RedTeamRunner — probe success path", () => {
+  it("all 8 adversarial probes pass against a defender-posture mock", async () => {
+    // ALL_ADVERSARIAL_PROBES is pre-ordered with P-A6 last so the
+    // divergence-induced failed-state at the end doesn't skip earlier probes.
+    const sandbox = new MockSandbox({ tools: defenderToolBattery() });
+    const runner = new RedTeamRunner(sandbox, {
+      probes: ALL_ADVERSARIAL_PROBES,
+    });
+    const report = await runner.run();
+
+    expect(report.summary.total).toBe(8);
+    expect(report.summary.passed).toBe(8);
+    expect(report.summary.failed).toBe(0);
+    expect(report.summary.errored).toBe(0);
+
+    // P-A6 is the last entry by design.
+    expect(report.probes[report.probes.length - 1]!.name).toBe(
+      "P-A6-substrate-lie",
+    );
+    // All probes carry honest validation status (mock-only today).
+    for (const p of report.probes) {
+      expect(p.validated_against).toBe("mock-only");
+    }
+  });
+});
+
+// ---------- 2. probe failure path ----------------------------------------
+
+describe("RedTeamRunner — probe failure path", () => {
+  it("records failures when the attacker-posture battery is wired in", async () => {
+    const sandbox = new MockSandbox({ tools: attackerToolBattery() });
+    const runner = new RedTeamRunner(sandbox, {
+      probes: [
+        pA1NetEgress, // egress succeeds -> fail
+        pA2FsEscape, // host secret marker leaks -> fail
+        pA3ProcessEscape, // signal succeeds -> fail
+      ],
+    });
+    const report = await runner.run();
+    expect(report.summary.total).toBe(3);
+    expect(report.summary.failed).toBe(3);
+    expect(report.summary.passed).toBe(0);
+    for (const probe of report.probes) {
+      expect(probe.passed).toBe(false);
+      expect(probe.errored).toBe(false);
+    }
+    // P-A2 in particular should mention the host secret marker leak.
+    const a2 = report.probes.find((p) => p.name === "P-A2-fs-escape")!;
+    expect(a2.reason).toMatch(/host secret marker/i);
+  });
+});
+
+// ---------- 3. latency aggregation correctness ---------------------------
+
+describe("latency aggregation", () => {
+  it("percentile() uses nearest-rank on sorted input", () => {
+    const sorted = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    expect(percentile(sorted, 50)).toBe(5);
+    expect(percentile(sorted, 90)).toBe(9);
+    expect(percentile(sorted, 99)).toBe(10);
+    expect(percentile(sorted, 0)).toBe(1);
+    expect(percentile([], 50)).toBe(0);
+  });
+
+  it("aggregate() produces p50/p90/p95/p99 + mean/min/max", () => {
+    const samples = Array.from({ length: 100 }, (_, i) => i + 1); // 1..100
+    const dist = aggregateLatency(samples);
+    expect(dist.samples).toBe(100);
+    expect(dist.p50_ms).toBe(50);
+    expect(dist.p90_ms).toBe(90);
+    expect(dist.p95_ms).toBe(95);
+    expect(dist.p99_ms).toBe(99);
+    expect(dist.min_ms).toBe(1);
+    expect(dist.max_ms).toBe(100);
+    expect(dist.mean_ms).toBeCloseTo(50.5, 5);
+  });
+
+  it("LAT-roundtrip probe collects N samples and produces a distribution", async () => {
+    const sandbox = new MockSandbox({ tools: defenderToolBattery() });
+    const probe = makeLatencyProbe("roundtrip", { iterations: 50 });
+    const runner = new RedTeamRunner(sandbox, { probes: [probe] });
+    const report = await runner.run();
+    expect(report.summary.passed).toBe(1);
+    const evidence = report.probes[0]!.evidence as
+      | { distribution?: { samples: number } }
+      | undefined;
+    expect(evidence?.distribution?.samples).toBe(50);
+    // The runner should hoist the distribution into the top-level
+    // `latency` map keyed by probe name.
+    expect(report.latency["P-LAT-roundtrip"]?.samples).toBe(50);
+  });
+});
+
+// ---------- 4. P-A6 host-mutation detection ------------------------------
+
+describe("P-A6 substrate-lie detection", () => {
+  it("honest VMM: detects host mutation and throws divergence on next reset", async () => {
+    const sandbox = new MockSandbox({ tools: defenderToolBattery() });
+    const runner = new RedTeamRunner(sandbox, { probes: [pA6SubstrateLie] });
+    const report = await runner.run();
+    expect(report.summary.passed).toBe(1);
+    expect(report.probes[0]!.evidence).toMatchObject({
+      error_code: "SANDBOX_RESET_DIVERGENCE",
+    });
+  });
+
+  it("lying VMM: probe still catches via independent host evidence", async () => {
+    // We use a fake reset implementation that "lies" — after the host
+    // mutation, the mock's next reset is configured to claim baseline
+    // state. The probe must still flag failure because overlay is
+    // observably dirty post-reset (the independent host-side evidence
+    // path).
+    const sandbox = new MockSandbox({ tools: defenderToolBattery() });
+    // Wrap reset() to swallow divergence and return a clean ResetState
+    // — the canonical "lying VMM" failure mode.
+    const realReset = sandbox.reset.bind(sandbox);
+    sandbox.reset = async () => {
+      try {
+        return await realReset();
+      } catch (_e) {
+        // Lie: overlay still dirty, but report success.
+        return {
+          reset_at: new Date().toISOString(),
+          golden_hash: "mock-fs-hash:0:00000000",
+          verification_passed: true,
+          verification_details: {
+            fs_hash: "mock-fs-hash:0:00000000",
+            fs_hash_baseline: "mock-fs-hash:0:00000000",
+            fs_hash_match: true,
+            open_fd_count: 0,
+            open_fd_count_baseline: 0,
+            vmm_api_state: "running",
+            expected_vmm_api_state: "running",
+            divergence_action: "none",
+          },
+        };
+      }
+    };
+    const runner = new RedTeamRunner(sandbox, { probes: [pA6SubstrateLie] });
+    const report = await runner.run();
+    expect(report.summary.failed).toBe(1);
+    expect(report.probes[0]!.passed).toBe(false);
+    expect(report.probes[0]!.reason).toMatch(/overlay still contains/i);
+  });
+});
+
+// ---------- 5. report serialization --------------------------------------
+
+describe("RedTeamReport serialization", () => {
+  it("round-trips via JSON and preserves schema_version + probe shape", async () => {
+    const sandbox = new MockSandbox({ tools: defenderToolBattery() });
+    const runner = new RedTeamRunner(sandbox, {
+      probes: [pA1NetEgress, pA8VsockPoison],
+    });
+    const report = await runner.run();
+    const json = serializeReport(report);
+    const parsed = JSON.parse(json) as typeof report;
+    expect(parsed.schema_version).toBe("1.0");
+    expect(parsed.probes).toHaveLength(2);
+    expect(parsed.probes[0]!.name).toBe("P-A1-net-egress");
+    expect(parsed.summary.total).toBe(2);
+    expect(typeof parsed.generated_at).toBe("string");
+    expect(reportIsClean(report)).toBe(true);
+  });
+
+  it("reportIsClean returns false on any failure", async () => {
+    const sandbox = new MockSandbox({ tools: attackerToolBattery() });
+    const runner = new RedTeamRunner(sandbox, { probes: [pA1NetEgress] });
+    const report = await runner.run();
+    expect(reportIsClean(report)).toBe(false);
+  });
+});
+
+// ---------- 6. runner skip behaviour -------------------------------------
+
+describe("RedTeamRunner — sandbox-not-available skip", () => {
+  it("emits a skip note when boot() throws SandboxNotAvailableError", async () => {
+    // Construct a Sandbox stand-in whose boot() fails the canonical way.
+    const fakeSandbox: Sandbox = {
+      backend: "chv",
+      state: () => "not_booted",
+      boot: async () => {
+        throw new SandboxNotAvailableError(
+          "cloud-hypervisor binary not found on this host (Darwin)",
+        );
+      },
+      executeTool: async () => {
+        throw new Error("should not be reached");
+      },
+      reset: async () => {
+        throw new Error("should not be reached");
+      },
+      shutdown: async () => {},
+    };
+    const runner = new RedTeamRunner(fakeSandbox, {
+      probes: ALL_ADVERSARIAL_PROBES,
+    });
+    const report = await runner.run();
+    expect(report.summary.total).toBe(ALL_ADVERSARIAL_PROBES.length);
+    expect(report.probes).toHaveLength(0);
+    expect(report.notes.join(" ")).toMatch(/sandbox not available/i);
+    // The CLI exit-code path: not clean (because nothing ran).
+    expect(reportIsClean(report)).toBe(true); // no failures, no errors
+    // But also no passes.
+    expect(report.summary.passed).toBe(0);
+  });
+});

--- a/packages/sandbox-redteam/src/bin/bsm-redteam.ts
+++ b/packages/sandbox-redteam/src/bin/bsm-redteam.ts
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+// bsm-redteam — CLI for the P3.5a/P3.5b red-team battery.
+//
+// Modes:
+//   1. Probe battery (legacy P3.5a, mock-only):
+//        bsm-redteam --sandbox <chv|vf|mock> --probes <all|adversarial|lat>
+//                    [--output report.json] [--iterations N]
+//
+//   2. Real-CHV latency battery (P3.5b):
+//        bsm-redteam --probes lat-only --iterations N --output report.json
+//      Uses the same env-var contract as packages/sandbox/scripts/first-light.sh
+//      (BSM_KERNEL, BSM_INITRAMFS, BSM_ROOTFS, BSM_VSOCK_SOCKET,
+//       BSM_API_SOCKET, BSM_GUEST_PORT, BSM_CH_BIN, BSM_CHREMOTE_BIN).
+//      Each iteration is a fresh ChvSandbox: cold-boot + dispatch + shutdown.
+//      Default N=1000.
+//
+//   3. Real-CHV concurrent stress (P3.5b):
+//        bsm-redteam --probes concurrent --concurrency N --output report.json
+//      Stands up N ChvSandbox instances in parallel (unique cid 3..3+N-1,
+//      unique vsock + api sockets), boots them all, dispatches one echo
+//      through each, shuts them all down. Default N=8.
+//
+// Exit codes:
+//   0 — clean report (all probes passed, no errors, no failures)
+//   1 — at least one probe failed or errored
+//   2 — CLI usage error / sandbox could not be constructed / config missing
+//
+// Honesty: probes that genuinely run against a real CHV report
+// `validated_against: "validated-chv"`. Probes still on mock substrate
+// keep `validated_against: "mock-only"`. The report's notes section
+// surfaces the count distinction.
+
+import { writeFileSync } from "node:fs";
+
+import { ChvSandbox } from "@brainst0rm/sandbox";
+
+import {
+  buildChvConfig,
+  concurrentOverrides,
+  DEFAULT_API_SOCKET,
+  DEFAULT_VSOCK_SOCKET,
+} from "../chv-config-builder.js";
+import { MockSandbox } from "../mock-sandbox.js";
+import { defenderToolBattery } from "../mock-tools.js";
+import {
+  ALL_ADVERSARIAL_PROBES,
+  allProbes,
+  makeLatencyBattery,
+} from "../probes/index.js";
+import {
+  reportIsClean,
+  serializeReport,
+  summariseValidationProvenance,
+} from "../reporter.js";
+import { runConcurrentBattery, runLatencyBattery } from "../real-chv-runner.js";
+import { RedTeamRunner } from "../runner.js";
+import type { Probe, RedTeamReport } from "../types.js";
+
+type SandboxBackend = "chv" | "vf" | "mock";
+type ProbeMode = "all" | "adversarial" | "lat" | "lat-only" | "concurrent";
+
+interface Args {
+  sandbox: SandboxBackend;
+  probes: ProbeMode;
+  output?: string;
+  iterations: number;
+  concurrency: number;
+}
+
+function parseArgs(argv: string[]): Args {
+  const a: Args = {
+    sandbox: "mock",
+    probes: "all",
+    iterations: 1000,
+    concurrency: 8,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const tok = argv[i]!;
+    const next = (): string => {
+      const v = argv[++i];
+      if (v === undefined) {
+        throw new Error(`flag ${tok} requires a value`);
+      }
+      return v;
+    };
+    if (tok === "--sandbox") {
+      const v = next();
+      if (v !== "chv" && v !== "vf" && v !== "mock") {
+        throw new Error(`--sandbox must be chv|vf|mock, got ${v}`);
+      }
+      a.sandbox = v;
+    } else if (tok === "--probes") {
+      const v = next();
+      if (
+        v !== "all" &&
+        v !== "adversarial" &&
+        v !== "lat" &&
+        v !== "lat-only" &&
+        v !== "concurrent"
+      ) {
+        throw new Error(
+          `--probes must be all|adversarial|lat|lat-only|concurrent, got ${v}`,
+        );
+      }
+      a.probes = v;
+    } else if (tok === "--output" || tok === "-o") {
+      a.output = next();
+    } else if (tok === "--iterations") {
+      a.iterations = Number(next());
+      if (!Number.isFinite(a.iterations) || a.iterations <= 0) {
+        throw new Error(`--iterations must be a positive integer`);
+      }
+    } else if (tok === "--concurrency") {
+      a.concurrency = Number(next());
+      if (!Number.isFinite(a.concurrency) || a.concurrency <= 0) {
+        throw new Error(`--concurrency must be a positive integer`);
+      }
+    } else if (tok === "--help" || tok === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`unknown flag: ${tok}`);
+    }
+  }
+  return a;
+}
+
+function printHelp(): void {
+  process.stdout.write(
+    "bsm-redteam — Brainstorm sandbox red-team battery\n\n" +
+      "Modes:\n" +
+      "  --probes all|adversarial|lat        legacy P3.5a probe battery (--sandbox chv|vf|mock)\n" +
+      "  --probes lat-only --iterations N    P3.5b cold-boot+exec+shutdown latency battery (real CHV)\n" +
+      "  --probes concurrent --concurrency N P3.5b N-instance parallel stress (real CHV)\n\n" +
+      "Required env (lat-only and concurrent modes — same as first-light.sh):\n" +
+      "  BSM_KERNEL, BSM_ROOTFS, BSM_INITRAMFS (modular kernels), and\n" +
+      "  optionally BSM_VSOCK_SOCKET, BSM_API_SOCKET, BSM_GUEST_PORT,\n" +
+      "  BSM_CH_BIN, BSM_CHREMOTE_BIN.\n\n" +
+      "Defaults: --sandbox mock --probes all --iterations 1000 --concurrency 8\n\n" +
+      "Output:\n" +
+      "  --output PATH    write JSON report to PATH (else stdout)\n",
+  );
+}
+
+async function main(): Promise<void> {
+  let args: Args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (e) {
+    process.stderr.write(`bsm-redteam: ${(e as Error).message}\n`);
+    printHelp();
+    process.exit(2);
+  }
+
+  // ---- P3.5b real-CHV modes ---------------------------------------------
+  if (args.probes === "lat-only") {
+    await runLatOnlyMode(args);
+    return;
+  }
+  if (args.probes === "concurrent") {
+    await runConcurrentMode(args);
+    return;
+  }
+
+  // ---- P3.5a probe-battery modes (mock + skip-on-real) ------------------
+  let probeSet: Probe[];
+  if (args.probes === "all") {
+    probeSet = allProbes({ iterations: args.iterations });
+  } else if (args.probes === "adversarial") {
+    probeSet = ALL_ADVERSARIAL_PROBES;
+  } else {
+    probeSet = makeLatencyBattery({ iterations: args.iterations });
+  }
+
+  if (args.sandbox === "chv" || args.sandbox === "vf") {
+    process.stderr.write(
+      `bsm-redteam: --sandbox ${args.sandbox} for adversarial probe batteries\n` +
+        `(mock-substrate probes A1..A8) is intentionally surfacing as a\n` +
+        `documented skip — these probes are still mock-only and should be\n` +
+        `re-run only after their substrate is hardened (P3.2a for A6, etc.).\n` +
+        `For real-CHV validation, use --probes lat-only or --probes concurrent.\n`,
+    );
+    const skipMock = new MockSandbox({
+      backendLabel: args.sandbox,
+      tools: defenderToolBattery(),
+    });
+    const origBoot = skipMock.boot.bind(skipMock);
+    skipMock.boot = async (): Promise<void> => {
+      const { SandboxNotAvailableError } = await import("@brainst0rm/sandbox");
+      throw new SandboxNotAvailableError(
+        `${args.sandbox} probe-battery not yet wired to real backend ` +
+          `(P3.5b lat-only/concurrent modes ARE wired — use those)`,
+      );
+    };
+    void origBoot;
+    const runner = new RedTeamRunner(skipMock, { probes: probeSet });
+    const report = await runner.run();
+    finalize(report, args);
+    return;
+  }
+
+  // mock
+  const mock = new MockSandbox({
+    backendLabel: "stub",
+    tools: defenderToolBattery(),
+  });
+  const runner = new RedTeamRunner(mock, { probes: probeSet });
+  const report = await runner.run();
+  finalize(report, args);
+}
+
+async function runLatOnlyMode(args: Args): Promise<void> {
+  let built: ReturnType<typeof buildChvConfig>;
+  try {
+    built = buildChvConfig();
+  } catch (e) {
+    process.stderr.write(`bsm-redteam: ${(e as Error).message}\n`);
+    process.exit(2);
+  }
+  const eff = built.effective;
+  process.stderr.write(
+    `bsm-redteam[lat-only]: kernel=${eff.kernel}\n` +
+      `bsm-redteam[lat-only]: initramfs=${eff.initramfs ?? "(none)"}\n` +
+      `bsm-redteam[lat-only]: rootfs=${eff.rootfs}\n` +
+      `bsm-redteam[lat-only]: vsock=${eff.vsockSocket} api=${eff.apiSocket} cid=${eff.cid}\n` +
+      `bsm-redteam[lat-only]: iterations=${args.iterations}\n`,
+  );
+
+  // The factory creates a fresh ChvSandbox per iteration. Each iteration
+  // also gets its own per-iter socket paths so a botched shutdown can't
+  // leave a stale socket file that blocks the next iter's CHV bind.
+  const factory = (i: number): ChvSandbox => {
+    const overrides = {
+      // Always use a fresh socket suffix so a partial shutdown can't bork
+      // the next iter. CID stays at the default (single-instance path).
+      vsockSocketPath: `${eff.vsockSocket}.iter${i}`,
+      apiSocketPath: `${eff.apiSocket}.iter${i}`,
+    };
+    const { config } = buildChvConfig(undefined, overrides);
+    return new ChvSandbox(config);
+  };
+
+  const report = await runLatencyBattery(factory, {
+    iterations: args.iterations,
+    backendLabel: "chv",
+    validatedAgainst: "validated-chv",
+    onProgress: (done, total): void => {
+      process.stderr.write(`bsm-redteam[lat-only]: iter ${done}/${total}\n`);
+    },
+  });
+  finalize(report, args);
+}
+
+async function runConcurrentMode(args: Args): Promise<void> {
+  let built: ReturnType<typeof buildChvConfig>;
+  try {
+    built = buildChvConfig();
+  } catch (e) {
+    process.stderr.write(`bsm-redteam: ${(e as Error).message}\n`);
+    process.exit(2);
+  }
+  const eff = built.effective;
+  process.stderr.write(
+    `bsm-redteam[concurrent]: kernel=${eff.kernel}\n` +
+      `bsm-redteam[concurrent]: rootfs=${eff.rootfs}\n` +
+      `bsm-redteam[concurrent]: concurrency=${args.concurrency} ` +
+      `(cids ${3}..${3 + args.concurrency - 1})\n`,
+  );
+
+  // Per-instance factory: shard sockets and CIDs so the N sandboxes
+  // genuinely don't collide.
+  const baseVsock = eff.vsockSocket || DEFAULT_VSOCK_SOCKET;
+  const baseApi = eff.apiSocket || DEFAULT_API_SOCKET;
+  const factory = (i: number): ChvSandbox => {
+    const overrides = concurrentOverrides(i, baseVsock, baseApi);
+    const { config } = buildChvConfig(undefined, overrides);
+    return new ChvSandbox(config);
+  };
+
+  const report = await runConcurrentBattery(factory, {
+    concurrency: args.concurrency,
+    backendLabel: "chv",
+    validatedAgainst: "validated-chv",
+  });
+  finalize(report, args);
+}
+
+function finalize(report: RedTeamReport, args: Args): void {
+  // Append a provenance summary to the report's notes so the report itself
+  // carries the honesty marker (independent of stderr).
+  const provenance = summariseValidationProvenance(report);
+  report.notes.push(
+    `validation-provenance: ` +
+      `mock-only=${provenance.mockOnly} ` +
+      `validated-chv=${provenance.validatedChv} ` +
+      `validated-vf=${provenance.validatedVf} ` +
+      `validated-chv-and-vf=${provenance.validatedChvAndVf} ` +
+      `(total=${provenance.total})`,
+  );
+
+  const json = serializeReport(report);
+  if (args.output !== undefined) {
+    writeFileSync(args.output, json);
+    process.stderr.write(`bsm-redteam: report written to ${args.output}\n`);
+  } else {
+    process.stdout.write(json + "\n");
+  }
+  process.stderr.write(
+    `bsm-redteam: total=${report.summary.total} ` +
+      `passed=${report.summary.passed} ` +
+      `failed=${report.summary.failed} ` +
+      `errored=${report.summary.errored} ` +
+      `skipped=${report.summary.skipped}\n`,
+  );
+  process.stderr.write(
+    `bsm-redteam: provenance mock-only=${provenance.mockOnly} ` +
+      `validated-chv=${provenance.validatedChv} ` +
+      `validated-vf=${provenance.validatedVf}\n`,
+  );
+  process.exit(reportIsClean(report) ? 0 : 1);
+}
+
+main().catch((e: unknown) => {
+  process.stderr.write(`bsm-redteam: ${(e as Error).message}\n`);
+  process.exit(2);
+});

--- a/packages/sandbox-redteam/src/chv-config-builder.ts
+++ b/packages/sandbox-redteam/src/chv-config-builder.ts
@@ -1,0 +1,203 @@
+// Build a `ChvSandboxConfig` from the same env-var contract that
+// `packages/sandbox/scripts/first-light.sh` uses. Keeping this in lock-step
+// with first-light means 0bz7aztr's bring-up muscle memory carries over
+// directly: any host that already passed first-light can run the red-team
+// battery with the same exported env.
+//
+// Inputs (matches first-light.ts loadConfig()):
+//   BSM_KERNEL          — absolute path to bsm-sandbox-kernel       (required)
+//   BSM_INITRAMFS       — absolute path to bsm-sandbox-initramfs    (optional but
+//                         required for modular kernels like Alpine virt)
+//   BSM_ROOTFS          — absolute path to bsm-sandbox-rootfs.img   (required)
+//   BSM_VSOCK_SOCKET    — host-side AF_UNIX path for CHV vsock      (default
+//                         /tmp/bsm-redteam.sock — distinct from first-light's
+//                         to avoid stomping concurrent runs)
+//   BSM_API_SOCKET      — Cloud Hypervisor REST API socket          (default
+//                         /tmp/bsm-redteam-api.sock)
+//   BSM_GUEST_PORT      — guest-side vsock port for vsock-init      (default 52000,
+//                         image-builder default)
+//   BSM_CH_BIN          — cloud-hypervisor binary                   (default: lookup
+//                         on PATH at boot)
+//   BSM_CHREMOTE_BIN    — ch-remote binary                          (default: lookup
+//                         on PATH at boot)
+//
+// `buildChvConfig()` is intentionally pure (returns a config object) — it does
+// not check filesystem existence; that's the caller's job. The lat-only and
+// concurrent runners do the filesystem check once up-front so a single bad
+// path produces a single clear error rather than 1000 boot failures.
+
+import { existsSync } from "node:fs";
+
+import type { ChvSandboxConfig } from "@brainst0rm/sandbox";
+
+export interface ChvBuilderEnv {
+  BSM_KERNEL?: string;
+  BSM_INITRAMFS?: string;
+  BSM_ROOTFS?: string;
+  BSM_VSOCK_SOCKET?: string;
+  BSM_API_SOCKET?: string;
+  BSM_GUEST_PORT?: string;
+  BSM_CH_BIN?: string;
+  BSM_CHREMOTE_BIN?: string;
+  // For concurrent mode, callers pass the per-instance socket paths and CID
+  // explicitly via overrides — this keeps the env var contract identical to
+  // first-light while letting the runner shard.
+}
+
+export interface ChvBuilderOverrides {
+  /** Override the host-side vsock socket path. */
+  vsockSocketPath?: string;
+  /** Override the CHV REST API socket path. */
+  apiSocketPath?: string;
+  /** Override the guest-side vsock CID. CHV requires CID >= 3. */
+  cid?: number;
+  /** Override the guest-side vsock port. */
+  guestPort?: number;
+}
+
+export interface BuiltChvConfig {
+  /** The `ChvSandboxConfig` ready to hand to `new ChvSandbox(config)`. */
+  config: ChvSandboxConfig;
+  /** Effective paths surfaced for logging/diagnostics. */
+  effective: {
+    kernel: string;
+    initramfs?: string;
+    rootfs: string;
+    vsockSocket: string;
+    apiSocket: string;
+    guestPort: number;
+    cid: number;
+    cloudHypervisorBin?: string;
+    chRemoteBin?: string;
+  };
+}
+
+export const DEFAULT_VSOCK_SOCKET = "/tmp/bsm-redteam.sock";
+export const DEFAULT_API_SOCKET = "/tmp/bsm-redteam-api.sock";
+export const DEFAULT_GUEST_PORT = 52000;
+export const DEFAULT_CID = 3;
+
+/**
+ * Build a `ChvSandboxConfig` from env (matches first-light.sh contract).
+ * Throws a plain Error with a humane message if a required env var is
+ * missing or points at a nonexistent path. Caller is expected to print
+ * the message and exit 3 (matching first-light's "usage / config error"
+ * exit code).
+ */
+export function buildChvConfig(
+  env: ChvBuilderEnv = process.env as ChvBuilderEnv,
+  overrides: ChvBuilderOverrides = {},
+): BuiltChvConfig {
+  const kernel = env.BSM_KERNEL;
+  const initramfs = env.BSM_INITRAMFS;
+  const rootfs = env.BSM_ROOTFS;
+  if (kernel === undefined || kernel === "") {
+    throw new Error(
+      "BSM_KERNEL is required (path to bsm-sandbox-kernel produced by image-builder). " +
+        "Run packages/image-builder/scripts/build.sh first.",
+    );
+  }
+  if (rootfs === undefined || rootfs === "") {
+    throw new Error(
+      "BSM_ROOTFS is required (path to bsm-sandbox-rootfs.img produced by image-builder). " +
+        "Run packages/image-builder/scripts/build.sh first.",
+    );
+  }
+  if (!existsSync(kernel)) {
+    throw new Error(`BSM_KERNEL points to nonexistent path: ${kernel}`);
+  }
+  if (!existsSync(rootfs)) {
+    throw new Error(`BSM_ROOTFS points to nonexistent path: ${rootfs}`);
+  }
+  if (initramfs !== undefined && initramfs !== "" && !existsSync(initramfs)) {
+    throw new Error(`BSM_INITRAMFS points to nonexistent path: ${initramfs}`);
+  }
+
+  const vsockSocket =
+    overrides.vsockSocketPath ?? env.BSM_VSOCK_SOCKET ?? DEFAULT_VSOCK_SOCKET;
+  const apiSocket =
+    overrides.apiSocketPath ?? env.BSM_API_SOCKET ?? DEFAULT_API_SOCKET;
+  const guestPort =
+    overrides.guestPort ??
+    (env.BSM_GUEST_PORT !== undefined && env.BSM_GUEST_PORT !== ""
+      ? parseInt(env.BSM_GUEST_PORT, 10)
+      : DEFAULT_GUEST_PORT);
+  if (!Number.isFinite(guestPort) || guestPort <= 0 || guestPort > 65535) {
+    throw new Error(
+      `BSM_GUEST_PORT invalid: ${env.BSM_GUEST_PORT} (must be 1..65535)`,
+    );
+  }
+  const cid = overrides.cid ?? DEFAULT_CID;
+  if (!Number.isInteger(cid) || cid < 3) {
+    throw new Error(
+      `vsock CID must be an integer >= 3 (CIDs 0/1/2 are reserved); got ${cid}`,
+    );
+  }
+
+  const config: ChvSandboxConfig = {
+    cloudHypervisorBin: env.BSM_CH_BIN,
+    chRemoteBin: env.BSM_CHREMOTE_BIN,
+    apiSocketPath: apiSocket,
+    kernel: {
+      path: kernel,
+      ...(initramfs !== undefined && initramfs !== "" ? { initramfs } : {}),
+    },
+    rootfs: { path: rootfs, readonly: true },
+    vsock: {
+      cid,
+      socketPath: vsockSocket,
+      guestPort,
+    },
+    cpus: 2,
+    memMib: 1024,
+  };
+
+  return {
+    config,
+    effective: {
+      kernel,
+      ...(initramfs !== undefined && initramfs !== "" ? { initramfs } : {}),
+      rootfs,
+      vsockSocket,
+      apiSocket,
+      guestPort,
+      cid,
+      cloudHypervisorBin: env.BSM_CH_BIN,
+      chRemoteBin: env.BSM_CHREMOTE_BIN,
+    },
+  };
+}
+
+/**
+ * Per-instance overrides for concurrent mode. Given an instance index
+ * (0-based) and the base socket paths, produces non-colliding paths and a
+ * unique CID. CIDs are allocated as 3, 4, 5, ... by index — CHV reserves
+ * 0/1/2.
+ */
+export function concurrentOverrides(
+  index: number,
+  baseVsock: string = DEFAULT_VSOCK_SOCKET,
+  baseApi: string = DEFAULT_API_SOCKET,
+): ChvBuilderOverrides {
+  if (!Number.isInteger(index) || index < 0) {
+    throw new Error(`concurrent instance index must be >= 0, got ${index}`);
+  }
+  return {
+    vsockSocketPath: shardSocketPath(baseVsock, index),
+    apiSocketPath: shardSocketPath(baseApi, index),
+    cid: 3 + index,
+  };
+}
+
+/**
+ * Insert `-N` before the `.sock` suffix (or append `.N` if no suffix).
+ *   /tmp/bsm-redteam.sock   + 2 -> /tmp/bsm-redteam-2.sock
+ *   /tmp/foo                + 5 -> /tmp/foo-5
+ */
+export function shardSocketPath(base: string, index: number): string {
+  const suffix = ".sock";
+  if (base.endsWith(suffix)) {
+    return base.slice(0, -suffix.length) + `-${index}` + suffix;
+  }
+  return `${base}-${index}`;
+}

--- a/packages/sandbox-redteam/src/index.ts
+++ b/packages/sandbox-redteam/src/index.ts
@@ -1,0 +1,71 @@
+// @brainst0rm/sandbox-redteam — P3.5a red-team test framework for the
+// Brainstorm endpoint-agent sandbox abstraction.
+//
+// This package is the validation layer that — once a real sandbox boots
+// (CHV on Linux per @brainst0rm/sandbox, VF on macOS per
+// @brainst0rm/sandbox-vz) — proves the boundary actually contains tool
+// execution. Today CHV and VF are scaffold-only; the framework runs end-
+// to-end against a `MockSandbox` so probes can be developed and the
+// runner / reporter can be exercised in CI.
+//
+// See README.md for the probe matrix, attacker-class mapping, and
+// honest gap list.
+
+export * from "./types.js";
+export { RedTeamRunner } from "./runner.js";
+export {
+  MockSandbox,
+  type MockSandboxConfig,
+  type MockToolContext,
+  type MockToolHandler,
+} from "./mock-sandbox.js";
+export { defenderToolBattery, attackerToolBattery } from "./mock-tools.js";
+export {
+  serializeReport,
+  reportIsClean,
+  summariseValidationProvenance,
+  type ValidationProvenanceSummary,
+} from "./reporter.js";
+export { aggregate as aggregateLatency, percentile } from "./latency.js";
+
+// Real-CHV (P3.5b) validation modes. These are intentionally separate
+// from the legacy `RedTeamRunner` because the lifecycle is different:
+// many sandboxes vs many probes.
+export {
+  runLatencyBattery,
+  runConcurrentBattery,
+  type SandboxFactory,
+  type LatencyBatteryOptions,
+  type ConcurrentBatteryOptions,
+} from "./real-chv-runner.js";
+
+export {
+  buildChvConfig,
+  concurrentOverrides,
+  shardSocketPath,
+  DEFAULT_VSOCK_SOCKET,
+  DEFAULT_API_SOCKET,
+  DEFAULT_GUEST_PORT,
+  DEFAULT_CID,
+  type ChvBuilderEnv,
+  type ChvBuilderOverrides,
+  type BuiltChvConfig,
+} from "./chv-config-builder.js";
+
+// Probe library
+export {
+  pA1NetEgress,
+  pA2FsEscape,
+  pA3ProcessEscape,
+  pA4ResourceExhaust,
+  pA5TimeBomb,
+  pA6SubstrateLie,
+  pA7StdoutInjection,
+  pA8VsockPoison,
+  makeLatencyProbe,
+  makeLatencyBattery,
+  ALL_ADVERSARIAL_PROBES,
+  allProbes,
+  HOST_SECRET_MARKER,
+  type LatencyProbeOptions,
+} from "./probes/index.js";

--- a/packages/sandbox-redteam/src/latency.ts
+++ b/packages/sandbox-redteam/src/latency.ts
@@ -1,0 +1,47 @@
+// Latency aggregation helpers for the LAT probe set.
+//
+// We compute p50/p90/p95/p99 by sorting the sample array and indexing.
+// For 1000 samples this is fine. For >100k samples we'd want a better
+// algorithm (e.g. t-digest); not needed at MVP.
+
+import type { LatencyDistribution } from "./types.js";
+
+/** Compute a percentile from a sorted ascending array of numbers. */
+export function percentile(sortedAsc: number[], p: number): number {
+  if (sortedAsc.length === 0) return 0;
+  if (p <= 0) return sortedAsc[0]!;
+  if (p >= 100) return sortedAsc[sortedAsc.length - 1]!;
+  // Nearest-rank method (R-1): index = ceil(p/100 * N) - 1, clamped.
+  const idx = Math.min(
+    sortedAsc.length - 1,
+    Math.max(0, Math.ceil((p / 100) * sortedAsc.length) - 1),
+  );
+  return sortedAsc[idx]!;
+}
+
+export function aggregate(samplesMs: number[]): LatencyDistribution {
+  if (samplesMs.length === 0) {
+    return {
+      samples: 0,
+      p50_ms: 0,
+      p90_ms: 0,
+      p95_ms: 0,
+      p99_ms: 0,
+      mean_ms: 0,
+      min_ms: 0,
+      max_ms: 0,
+    };
+  }
+  const sorted = [...samplesMs].sort((a, b) => a - b);
+  const sum = sorted.reduce((acc, v) => acc + v, 0);
+  return {
+    samples: sorted.length,
+    p50_ms: percentile(sorted, 50),
+    p90_ms: percentile(sorted, 90),
+    p95_ms: percentile(sorted, 95),
+    p99_ms: percentile(sorted, 99),
+    mean_ms: sum / sorted.length,
+    min_ms: sorted[0]!,
+    max_ms: sorted[sorted.length - 1]!,
+  };
+}

--- a/packages/sandbox-redteam/src/mock-sandbox.ts
+++ b/packages/sandbox-redteam/src/mock-sandbox.ts
@@ -1,0 +1,296 @@
+// MockSandbox — in-process Sandbox impl used to test the framework
+// itself, and as the default surface against which probes can be
+// developed before a real CHV/VF host is available.
+//
+// Behaviour model:
+//   - `boot()` flips state to "ready" after a configurable delay
+//   - `executeTool()` runs a per-tool handler synchronously and respects
+//     `deadline_ms` (throws SandboxToolTimeoutError when exceeded)
+//   - `reset()` consults a tracked "overlay" map and produces a
+//     ResetState with 3-source verification details. If something
+//     external mutated the overlay since baseline (the A6 substrate-lying
+//     case), divergence_action becomes "halt" and SandboxResetDivergenceError
+//     is thrown — exactly mirroring ChvSandbox semantics.
+//
+// This is NOT a security boundary. Probes that need a "real" attack
+// containment guarantee must be re-run against CHV/VF.
+
+import {
+  SandboxNotAvailableError,
+  SandboxResetDivergenceError,
+  SandboxResetError,
+  SandboxToolTimeoutError,
+  makeVerificationDetails,
+  type ResetState,
+  type Sandbox,
+  type SandboxBackend,
+  type SandboxState,
+  type ToolExecution,
+  type ToolInvocation,
+  type VerificationDetails,
+} from "@brainst0rm/sandbox";
+
+export type MockToolHandler = (
+  invocation: ToolInvocation,
+  // Mutators the handler can use to model attacker behaviour.
+  ctx: MockToolContext,
+) => Promise<ToolExecution> | ToolExecution;
+
+export interface MockToolContext {
+  /**
+   * Mutate the in-process "overlay" filesystem the next reset will hash.
+   * Used by P-A6 / containment probes that simulate tool-side persistence.
+   */
+  writeOverlay(path: string, contents: string): void;
+  /** Read overlay (mostly for tests). */
+  readOverlay(path: string): string | undefined;
+  /** Snapshot a host fact a probe may want to assert against. */
+  recordHostFact(key: string, value: unknown): void;
+}
+
+export interface MockSandboxConfig {
+  /** Tool name -> handler. Unknown tool names produce exit_code=127. */
+  tools?: Record<string, MockToolHandler>;
+  /** ms to wait inside boot() / reset(). Default 1ms each. */
+  bootLatencyMs?: number;
+  resetLatencyMs?: number;
+  /**
+   * If true, the next `reset()` reports divergence regardless of overlay
+   * state. Used by P-A6 probes that need a "lying VMM" scenario without
+   * actually mutating the overlay. Cleared after one use.
+   */
+  forceNextResetDivergence?: boolean;
+  /**
+   * If true, the next `reset()` throws SandboxResetError (machinery
+   * failure path, distinct from divergence).
+   */
+  forceNextResetError?: boolean;
+  /**
+   * Whether the mock should claim divergence when overlay diverges from
+   * baseline. Default true — set to false to model an A6 substrate-lying
+   * VMM that pretends nothing happened. P-A6 inverts this to verify the
+   * runner notices the lie via independent host-side evidence.
+   */
+  honestReset?: boolean;
+  /** Optional label override (default "stub"). */
+  backendLabel?: SandboxBackend;
+}
+
+export class MockSandbox implements Sandbox {
+  public readonly backend: SandboxBackend;
+
+  private status: SandboxState = "not_booted";
+  private readonly tools: Record<string, MockToolHandler>;
+  private readonly bootLatencyMs: number;
+  private readonly resetLatencyMs: number;
+  private honestReset: boolean;
+  private forceNextResetDivergence: boolean;
+  private forceNextResetError: boolean;
+
+  // The overlay represents the post-baseline mutable substrate. Both
+  // tools (via MockToolContext) and external host actors (via the
+  // public `hostMutateOverlay` method, modelling A6) can write here.
+  private overlay = new Map<string, string>();
+  // Snapshot of overlay at boot — the "golden" baseline.
+  private baseline = new Map<string, string>();
+  private hostFacts = new Map<string, unknown>();
+
+  constructor(config: MockSandboxConfig = {}) {
+    this.tools = config.tools ?? {};
+    this.bootLatencyMs = config.bootLatencyMs ?? 1;
+    this.resetLatencyMs = config.resetLatencyMs ?? 1;
+    this.honestReset = config.honestReset ?? true;
+    this.forceNextResetDivergence = config.forceNextResetDivergence ?? false;
+    this.forceNextResetError = config.forceNextResetError ?? false;
+    this.backend = config.backendLabel ?? "stub";
+  }
+
+  state(): SandboxState {
+    return this.status;
+  }
+
+  async boot(): Promise<void> {
+    if (this.status === "ready" || this.status === "booting") return;
+    this.status = "booting";
+    await sleep(this.bootLatencyMs);
+    // Capture baseline after "boot" so the first reset is a no-op.
+    this.baseline = new Map(this.overlay);
+    this.status = "ready";
+  }
+
+  async executeTool(invocation: ToolInvocation): Promise<ToolExecution> {
+    if (this.status !== "ready") {
+      throw new SandboxNotAvailableError(
+        `executeTool called with status=${this.status}`,
+      );
+    }
+    const handler = this.tools[invocation.tool];
+    if (handler === undefined) {
+      // Unknown tool — surface as nonzero exit (matches a real shell).
+      return {
+        exit_code: 127,
+        stdout: "",
+        stderr: `unknown tool: ${invocation.tool}`,
+      };
+    }
+    const ctx: MockToolContext = {
+      writeOverlay: (p, c) => {
+        this.overlay.set(p, c);
+      },
+      readOverlay: (p) => this.overlay.get(p),
+      recordHostFact: (k, v) => {
+        this.hostFacts.set(k, v);
+      },
+    };
+    return runWithDeadline(handler(invocation, ctx), invocation.deadline_ms);
+  }
+
+  async reset(): Promise<ResetState> {
+    if (this.status !== "ready") {
+      throw new SandboxResetError(
+        `reset called with status=${this.status}; sandbox must be ready`,
+      );
+    }
+    this.status = "resetting";
+    await sleep(this.resetLatencyMs);
+
+    if (this.forceNextResetError) {
+      this.forceNextResetError = false;
+      this.status = "failed";
+      throw new SandboxResetError("forced reset machinery failure");
+    }
+
+    // Compute fs_hash = serialized overlay. Honest impl reflects current
+    // overlay; lying impl pretends overlay matches baseline.
+    const trueHash = serializeOverlay(this.overlay);
+    const baselineHash = serializeOverlay(this.baseline);
+    const reportedHash = this.honestReset ? trueHash : baselineHash;
+
+    let verification: VerificationDetails = makeVerificationDetails({
+      fs_hash: reportedHash,
+      fs_hash_baseline: baselineHash,
+      open_fd_count: 0,
+      open_fd_count_baseline: 0,
+      vmm_api_state: "running",
+      expected_vmm_api_state: "running",
+    });
+
+    if (this.forceNextResetDivergence) {
+      this.forceNextResetDivergence = false;
+      verification = {
+        ...verification,
+        fs_hash: "sha256:" + "f".repeat(64),
+        fs_hash_match: false,
+        divergence_action: "halt",
+      };
+    }
+
+    const divergent = verification.divergence_action !== "none";
+    if (divergent) {
+      this.status = "failed";
+      throw new SandboxResetDivergenceError(
+        `mock reset detected divergence: fs_match=${verification.fs_hash_match}`,
+      );
+    }
+
+    // Honest reset: revert overlay to baseline.
+    this.overlay = new Map(this.baseline);
+    this.status = "ready";
+    return {
+      reset_at: new Date().toISOString(),
+      golden_hash: baselineHash,
+      verification_passed: true,
+      verification_details: verification,
+    };
+  }
+
+  async shutdown(): Promise<void> {
+    this.status = "not_booted";
+  }
+
+  // ---- mock-only helpers (NOT part of the Sandbox interface) -------------
+
+  /**
+   * Simulate the host substrate mutating the sandbox's overlay between
+   * dispatches. Pure A6 vector — no in-guest actor caused this. The
+   * next reset MUST detect divergence in the 3-source verification.
+   */
+  hostMutateOverlay(path: string, contents: string): void {
+    this.overlay.set(path, contents);
+  }
+
+  /**
+   * Configure the mock to lie on its NEXT reset call: the reported
+   * fs_hash will match baseline even though overlay diverges. This
+   * models a substrate-lying VMM. Independent host-side evidence (a
+   * file the *probe* wrote that the runner can re-read) is what should
+   * still surface the discrepancy.
+   */
+  beLyingResetOnce(): void {
+    this.honestReset = false;
+    queueMicrotask(() => {
+      // Re-honest after one cycle — keeps default behaviour clean.
+      this.honestReset = true;
+    });
+  }
+
+  /** Inspect host facts (for assertions). */
+  getHostFact(key: string): unknown {
+    return this.hostFacts.get(key);
+  }
+
+  /** Inspect overlay (for assertions). */
+  getOverlay(): ReadonlyMap<string, string> {
+    return this.overlay;
+  }
+
+  /** Force an outcome on next reset (test convenience). */
+  configureNextReset(opts: { divergence?: boolean; error?: boolean }): void {
+    if (opts.divergence) this.forceNextResetDivergence = true;
+    if (opts.error) this.forceNextResetError = true;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((res) => setTimeout(res, ms));
+}
+
+function serializeOverlay(m: Map<string, string>): string {
+  // Deterministic sort+concat. Real CHV does sha256 over disk image,
+  // not this — see threat-model §5.1.
+  const sorted = [...m.entries()].sort(([a], [b]) => a.localeCompare(b));
+  const blob = sorted.map(([k, v]) => `${k} ${v}`).join("");
+  return "mock-fs-hash:" + blob.length + ":" + simpleHash(blob);
+}
+
+function simpleHash(s: string): string {
+  // Non-cryptographic — sufficient for the mock. Real CHV uses SHA-256.
+  let h = 5381;
+  for (let i = 0; i < s.length; i += 1) {
+    h = ((h << 5) + h + s.charCodeAt(i)) >>> 0;
+  }
+  return h.toString(16).padStart(8, "0");
+}
+
+async function runWithDeadline<T>(
+  pOrValue: Promise<T> | T,
+  deadlineMs: number,
+): Promise<T> {
+  const p = Promise.resolve(pOrValue);
+  let timer: NodeJS.Timeout | null = null;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(
+        new SandboxToolTimeoutError(
+          deadlineMs,
+          `tool exceeded deadline_ms=${deadlineMs}`,
+        ),
+      );
+    }, deadlineMs);
+  });
+  try {
+    return await Promise.race([p, timeout]);
+  } finally {
+    if (timer !== null) clearTimeout(timer);
+  }
+}

--- a/packages/sandbox-redteam/src/mock-tools.ts
+++ b/packages/sandbox-redteam/src/mock-tools.ts
@@ -1,0 +1,112 @@
+// Standard mock tool handlers used by the probe battery against the
+// MockSandbox. Each handler emulates the *defender* posture (deny the
+// attack) so the probe expectations resolve to "passed".
+//
+// To verify the framework can also catch FAILURES, the test suite swaps
+// in attacker-friendly handlers and asserts the runner records `passed:
+// false` correctly.
+
+import type { ToolExecution } from "@brainst0rm/sandbox";
+
+import type { MockToolContext, MockToolHandler } from "./mock-sandbox.js";
+
+/** Default defender posture: refuses everything except `noop`. */
+export function defenderToolBattery(): Record<string, MockToolHandler> {
+  return {
+    noop: () => ok("", ""),
+    "stdout.echo": (inv): ToolExecution => {
+      // For the A7 probe: faithfully echo the requested content. This is
+      // benign behaviour — emitting bytes is not the attack; promoting
+      // those bytes to a protocol frame would be.
+      const content =
+        typeof inv.params.content === "string" ? inv.params.content : "";
+      return ok(content, "");
+    },
+    "net.tcp_connect": (inv): ToolExecution => {
+      return fail(
+        13,
+        "",
+        `net.tcp_connect denied: host=${String(inv.params.host)} not on allowlist`,
+      );
+    },
+    "fs.read": (inv): ToolExecution => {
+      return fail(
+        2,
+        "",
+        `fs.read denied: path=${String(inv.params.path)} not in mounted FS`,
+      );
+    },
+    "proc.signal": (inv): ToolExecution => {
+      return fail(
+        1,
+        "",
+        `proc.signal denied: PID namespace isolation (target=${String(inv.params.pid)})`,
+      );
+    },
+    "resource.alloc": (inv): ToolExecution => {
+      const bytes = Number(inv.params.bytes ?? 0);
+      // Cap at 64 MiB; anything larger gets refused.
+      const CAP = 64 * 1024 * 1024;
+      if (bytes > CAP) {
+        return fail(
+          137,
+          "",
+          `cgroup memory.max exceeded: requested=${bytes}B cap=${CAP}B (OOMKilled)`,
+        );
+      }
+      return ok(`allocated ${bytes}B`, "");
+    },
+    "time.sleep": async (inv): Promise<ToolExecution> => {
+      const ms = Number(inv.params.ms ?? 0);
+      await new Promise((r) => setTimeout(r, ms));
+      return ok(`slept ${ms}ms`, "");
+    },
+    "vsock.poison": (inv): ToolExecution => {
+      const mode = String(inv.params.mode ?? "unknown");
+      // Defender posture: every poison shape gets rejected with non-zero.
+      return fail(2, "", `vsock framing rejected: mode=${mode}`);
+    },
+  };
+}
+
+/**
+ * Attacker-friendly battery: makes EVERY probe's attack succeed. Used
+ * exclusively in the test suite to prove the runner reports "failed"
+ * outcomes faithfully.
+ */
+export function attackerToolBattery(): Record<string, MockToolHandler> {
+  const noopFromCtx = (_inv: unknown, _ctx: MockToolContext): ToolExecution =>
+    ok("", "");
+  return {
+    noop: noopFromCtx,
+    "stdout.echo": (inv): ToolExecution => {
+      // This handler "leaks" by promoting stdout to a structured field.
+      const content =
+        typeof inv.params.content === "string" ? inv.params.content : "";
+      return {
+        exit_code: 0,
+        stdout: "", // forge dropped — bad
+        stderr: "",
+        // The test will assert this DOES NOT escape ToolExecution shape.
+      } as ToolExecution & { type?: string; payload?: unknown };
+    },
+    "net.tcp_connect": () => ok("connected", ""),
+    "fs.read": () => ok("BSM_HOST_SECRET_MARKER_DO_NOT_LEAK\n", ""),
+    "proc.signal": () => ok("signaled pid 1", ""),
+    "resource.alloc": () => ok("allocated", ""),
+    "time.sleep": () => ok("done", ""),
+    "vsock.poison": () => ok("accepted", ""),
+  };
+}
+
+function ok(stdout: string, stderr: string): ToolExecution {
+  return { exit_code: 0, stdout, stderr };
+}
+
+function fail(
+  exit_code: number,
+  stdout: string,
+  stderr: string,
+): ToolExecution {
+  return { exit_code, stdout, stderr };
+}

--- a/packages/sandbox-redteam/src/probes/index.ts
+++ b/packages/sandbox-redteam/src/probes/index.ts
@@ -1,0 +1,54 @@
+// Probe library — all built-in probes for the P3.5a red-team battery.
+//
+// Most probes target a "should-fail" expectation (the attack must be
+// contained). The "all" battery is the default for CLI / CI; integrators
+// can compose smaller batteries from the named exports.
+
+export { pA1NetEgress } from "./p-a1-net-egress.js";
+export { pA2FsEscape, HOST_SECRET_MARKER } from "./p-a2-fs-escape.js";
+export { pA3ProcessEscape } from "./p-a3-process-escape.js";
+export { pA4ResourceExhaust } from "./p-a4-resource-exhaust.js";
+export { pA5TimeBomb } from "./p-a5-time-bomb.js";
+export { pA6SubstrateLie } from "./p-a6-substrate-lie.js";
+export { pA7StdoutInjection } from "./p-a7-stdout-injection.js";
+export { pA8VsockPoison } from "./p-a8-vsock-poison.js";
+export {
+  makeLatencyProbe,
+  makeLatencyBattery,
+  type LatencyProbeOptions,
+} from "./p-lat.js";
+
+import { pA1NetEgress } from "./p-a1-net-egress.js";
+import { pA2FsEscape } from "./p-a2-fs-escape.js";
+import { pA3ProcessEscape } from "./p-a3-process-escape.js";
+import { pA4ResourceExhaust } from "./p-a4-resource-exhaust.js";
+import { pA5TimeBomb } from "./p-a5-time-bomb.js";
+import { pA6SubstrateLie } from "./p-a6-substrate-lie.js";
+import { pA7StdoutInjection } from "./p-a7-stdout-injection.js";
+import { pA8VsockPoison } from "./p-a8-vsock-poison.js";
+import { makeLatencyBattery, type LatencyProbeOptions } from "./p-lat.js";
+import type { Probe } from "../types.js";
+
+/**
+ * All adversarial (A1-A8) probes, no latency battery.
+ *
+ * Ordering note: P-A6 is intentionally LAST. P-A6 drives the sandbox to a
+ * detected-divergence ("failed") state by design, which the runner
+ * honours by skipping subsequent probes. Putting P-A6 last lets the
+ * other 7 probes complete cleanly first.
+ */
+export const ALL_ADVERSARIAL_PROBES: Probe[] = [
+  pA1NetEgress,
+  pA2FsEscape,
+  pA3ProcessEscape,
+  pA4ResourceExhaust,
+  pA5TimeBomb,
+  pA7StdoutInjection,
+  pA8VsockPoison,
+  pA6SubstrateLie,
+];
+
+/** Full battery: adversarial + latency. */
+export function allProbes(latencyOpts?: LatencyProbeOptions): Probe[] {
+  return [...ALL_ADVERSARIAL_PROBES, ...makeLatencyBattery(latencyOpts)];
+}

--- a/packages/sandbox-redteam/src/probes/p-a1-net-egress.ts
+++ b/packages/sandbox-redteam/src/probes/p-a1-net-egress.ts
@@ -1,0 +1,59 @@
+// P-A1-net-egress
+// Threat model class: A3 (compromised tool inside sandbox) attempting
+//                     A1-style outbound traffic — but the *sandbox* boundary
+//                     is the defender (G3 in plan §2). We tag this probe
+//                     against A1 because the captured intent is "outbound
+//                     network egress" which in the threat model is the
+//                     observable of an outsider-with-credentials class.
+//
+// Mechanics: the probe asks the sandbox to run a tool whose payload tries
+// to open an arbitrary outbound TCP connection (to a non-allowlisted host).
+// The defender posture is deny-by-default proxy-only. So:
+//   - On a real sandbox: the in-guest TCP attempt MUST fail OR be visible
+//     in the host-side audit log as a denied connect attempt.
+//   - On the mock: the tool runs an in-process simulator that the test
+//     harness configures to "fail closed" — we assert the simulator
+//     refused to connect and the tool got a non-zero exit code.
+//
+// Honesty: validated against mock only. Real CHV egress block needs the
+// in-guest seccomp-bpf + agent-mediated proxy machinery, none of which is
+// in this checkout.
+
+import type { Sandbox } from "@brainst0rm/sandbox";
+
+import type { Probe, ProbeOutcome } from "../types.js";
+
+export const pA1NetEgress: Probe = {
+  name: "P-A1-net-egress",
+  attackerClass: "A1",
+  expectation: "should-fail",
+  validatedAgainst: "mock-only",
+  description:
+    "Compromised tool attempts arbitrary outbound TCP. Sandbox boundary " +
+    "should deny (G3 deny-by-default proxy). Tool exit_code MUST be non-zero " +
+    "AND no host-observable connect should succeed.",
+  async run(sandbox: Sandbox): Promise<ProbeOutcome> {
+    const exec = await sandbox.executeTool({
+      command_id: "redteam-A1-egress",
+      tool: "net.tcp_connect",
+      params: { host: "evil.example.invalid", port: 4242 },
+      deadline_ms: 2_000,
+    });
+    if (exec.exit_code === 0) {
+      return {
+        passed: false,
+        reason: `tool exited 0 — outbound TCP appears to have succeeded. stdout=${truncate(exec.stdout)}`,
+        evidence: { exit_code: exec.exit_code, stdout: exec.stdout },
+      };
+    }
+    return {
+      passed: true,
+      reason: `tool exit_code=${exec.exit_code}, stderr=${truncate(exec.stderr)}`,
+      evidence: { exit_code: exec.exit_code, stderr: exec.stderr },
+    };
+  },
+};
+
+function truncate(s: string, n = 200): string {
+  return s.length > n ? s.slice(0, n) + "..." : s;
+}

--- a/packages/sandbox-redteam/src/probes/p-a2-fs-escape.ts
+++ b/packages/sandbox-redteam/src/probes/p-a2-fs-escape.ts
@@ -1,0 +1,62 @@
+// P-A2-fs-escape
+// Threat model class: A3 inside the sandbox trying to read host FS. We tag
+//                     A2 because the observable behaviour ("path traversal
+//                     to host secrets") is the network-style outsider's
+//                     desired outcome.
+//
+// Mechanics: the tool tries to read /etc/shadow on the host. Real CHV
+// gives the guest a private rootfs — host /etc/shadow simply isn't
+// reachable. The probe passes iff the read fails (exit != 0) AND the
+// returned stdout does not contain the magic host marker the harness
+// embeds at "host /etc/shadow".
+//
+// Honesty: validated against mock only. The mock guarantees the marker
+// is unreachable through the tool API. Real CHV semantics require a
+// real rootfs separation test.
+
+import type { Sandbox } from "@brainst0rm/sandbox";
+
+import type { Probe, ProbeOutcome } from "../types.js";
+
+export const HOST_SECRET_MARKER = "BSM_HOST_SECRET_MARKER_DO_NOT_LEAK";
+
+export const pA2FsEscape: Probe = {
+  name: "P-A2-fs-escape",
+  attackerClass: "A2",
+  expectation: "should-fail",
+  validatedAgainst: "mock-only",
+  description:
+    "Compromised tool reads host /etc/shadow via path traversal. Sandbox " +
+    "MUST present a private rootfs; host secret marker MUST NOT appear in " +
+    "tool stdout/stderr.",
+  async run(sandbox: Sandbox): Promise<ProbeOutcome> {
+    const exec = await sandbox.executeTool({
+      command_id: "redteam-A2-fs",
+      tool: "fs.read",
+      params: { path: "/etc/shadow" },
+      deadline_ms: 2_000,
+    });
+    const leaked =
+      exec.stdout.includes(HOST_SECRET_MARKER) ||
+      exec.stderr.includes(HOST_SECRET_MARKER);
+    if (leaked) {
+      return {
+        passed: false,
+        reason: "host secret marker appeared in tool output — FS escape!",
+        evidence: { exit_code: exec.exit_code, stdout: exec.stdout },
+      };
+    }
+    if (exec.exit_code === 0) {
+      return {
+        passed: false,
+        reason: `read succeeded with exit 0 (marker absent but read should not succeed)`,
+        evidence: { exit_code: exec.exit_code, stdout: exec.stdout },
+      };
+    }
+    return {
+      passed: true,
+      reason: `read denied (exit=${exec.exit_code}); marker not present`,
+      evidence: { exit_code: exec.exit_code },
+    };
+  },
+};

--- a/packages/sandbox-redteam/src/probes/p-a3-process-escape.ts
+++ b/packages/sandbox-redteam/src/probes/p-a3-process-escape.ts
@@ -1,0 +1,50 @@
+// P-A3-process-escape
+// Threat model class: A3 (compromised tool inside sandbox) attempting to
+//                     reach the host process namespace.
+//
+// Mechanics: the tool tries to send SIGTERM to PID 1 of the *host*. In a
+// real microVM the guest has its own PID namespace; PID 1 in the guest is
+// the init shipped in the image. The probe's tool is wired so the host's
+// "real" PID 1 is recorded as a host fact at boot. The probe fails iff
+// the host's PID 1 is observably affected (in the mock, the tool can't
+// actually signal anything outside its handler closure — but it CAN be
+// caught lying by a forged claim of "I killed PID 1", which we then
+// disprove via the host fact).
+//
+// Honesty: validated against mock only. Real CHV requires kernel + PID
+// namespace verification.
+
+import type { Sandbox } from "@brainst0rm/sandbox";
+
+import type { Probe, ProbeOutcome } from "../types.js";
+
+export const pA3ProcessEscape: Probe = {
+  name: "P-A3-process-escape",
+  attackerClass: "A3",
+  expectation: "should-fail",
+  validatedAgainst: "mock-only",
+  description:
+    "Compromised tool sends SIGTERM to host PID 1. Sandbox PID namespace " +
+    "MUST isolate the guest; the host init MUST remain reachable / running.",
+  async run(sandbox: Sandbox): Promise<ProbeOutcome> {
+    const exec = await sandbox.executeTool({
+      command_id: "redteam-A3-proc",
+      tool: "proc.signal",
+      params: { pid: 1, signal: "SIGTERM" },
+      deadline_ms: 2_000,
+    });
+    // Pass conditions: tool got an error (operation not permitted, ESRCH,
+    // or a guest-only PID 1 != host PID 1).
+    if (exec.exit_code === 0) {
+      return {
+        passed: false,
+        reason: `tool exited 0 — apparent PID 1 signal succeeded. stdout=${exec.stdout}`,
+      };
+    }
+    return {
+      passed: true,
+      reason: `signal denied (exit=${exec.exit_code}, stderr=${exec.stderr})`,
+      evidence: { exit_code: exec.exit_code },
+    };
+  },
+};

--- a/packages/sandbox-redteam/src/probes/p-a4-resource-exhaust.ts
+++ b/packages/sandbox-redteam/src/probes/p-a4-resource-exhaust.ts
@@ -1,0 +1,48 @@
+// P-A4-resource-exhaust
+// Threat model class: A3 ("compromised tool") going for resource starvation.
+//                     We bin this as A4-class red-team because the failure
+//                     mode (host DoS via guest resource burn) is the same
+//                     space as a build-time-malicious image's behaviour.
+//
+// Mechanics: tool tries to allocate 100 GiB and/or fork-bomb. Real CHV
+// applies cgroup memory + pids limits. The probe passes iff the tool is
+// killed / refused with a recognised resource-error AND the host process
+// memory growth is bounded.
+//
+// Honesty: validated against mock only. The mock simulates the limit by
+// having the handler refuse allocations above a threshold.
+
+import type { Sandbox } from "@brainst0rm/sandbox";
+
+import type { Probe, ProbeOutcome } from "../types.js";
+
+export const pA4ResourceExhaust: Probe = {
+  name: "P-A4-resource-exhaust",
+  attackerClass: "A4",
+  expectation: "should-fail",
+  validatedAgainst: "mock-only",
+  description:
+    "Compromised tool allocates 100 GiB / fork-bombs. Sandbox cgroup limits " +
+    "MUST kill the runaway. Tool exit_code MUST be non-zero with an " +
+    "OOM/limit-style stderr signal.",
+  async run(sandbox: Sandbox): Promise<ProbeOutcome> {
+    const exec = await sandbox.executeTool({
+      command_id: "redteam-A4-rss",
+      tool: "resource.alloc",
+      params: { bytes: 100 * 1024 * 1024 * 1024 }, // 100 GiB
+      deadline_ms: 5_000,
+    });
+    if (exec.exit_code === 0) {
+      return {
+        passed: false,
+        reason: "tool reported successful 100 GiB allocation — limits absent",
+        evidence: { exit_code: exec.exit_code },
+      };
+    }
+    return {
+      passed: true,
+      reason: `allocation refused/killed (exit=${exec.exit_code}, stderr=${exec.stderr})`,
+      evidence: { exit_code: exec.exit_code },
+    };
+  },
+};

--- a/packages/sandbox-redteam/src/probes/p-a5-time-bomb.ts
+++ b/packages/sandbox-redteam/src/probes/p-a5-time-bomb.ts
@@ -1,0 +1,56 @@
+// P-A5-time-bomb
+// Threat model class: A5 (compromised host agent) — the surface a runaway
+//                     in-guest tool exercises in the host process is the
+//                     same as a buggy/malicious agent failing to enforce
+//                     deadline_ms. The defender posture (G2) is "hard
+//                     deadline kill". This probe asserts that posture.
+//
+// Mechanics: the tool sleeps for longer than `deadline_ms`. The Sandbox
+// MUST throw `SandboxToolTimeoutError`. If the call returns a result, the
+// deadline machinery is broken — red team wins.
+//
+// Honesty: validated against mock only. The mock implements deadline_ms
+// via Promise.race; ChvSandbox is expected to enforce via vsock-side
+// killing of the in-guest process. Real CHV not yet exercised here.
+
+import { SandboxToolTimeoutError, type Sandbox } from "@brainst0rm/sandbox";
+
+import type { Probe, ProbeOutcome } from "../types.js";
+
+export const pA5TimeBomb: Probe = {
+  name: "P-A5-time-bomb",
+  attackerClass: "A5",
+  expectation: "should-fail",
+  validatedAgainst: "mock-only",
+  description:
+    "Tool runs longer than deadline_ms. Sandbox MUST throw " +
+    "SandboxToolTimeoutError, NOT return a delayed-but-successful result.",
+  async run(sandbox: Sandbox): Promise<ProbeOutcome> {
+    const deadlineMs = 50;
+    try {
+      const exec = await sandbox.executeTool({
+        command_id: "redteam-A5-time",
+        tool: "time.sleep",
+        params: { ms: 5_000 },
+        deadline_ms: deadlineMs,
+      });
+      return {
+        passed: false,
+        reason: `tool returned within deadline despite sleeping 5s — exit=${exec.exit_code}`,
+        evidence: { exit_code: exec.exit_code },
+      };
+    } catch (e) {
+      if (e instanceof SandboxToolTimeoutError) {
+        return {
+          passed: true,
+          reason: `deadline enforced: ${(e as Error).message}`,
+          evidence: { deadline_ms: deadlineMs },
+        };
+      }
+      return {
+        passed: false,
+        reason: `unexpected error type: ${(e as Error).message}`,
+      };
+    }
+  },
+};

--- a/packages/sandbox-redteam/src/probes/p-a6-substrate-lie.ts
+++ b/packages/sandbox-redteam/src/probes/p-a6-substrate-lie.ts
@@ -1,0 +1,130 @@
+// P-A6-substrate-lie
+// Threat model class: A6 (substrate-lying attacker; threat-model §3.1).
+//
+// THE HEADLINE PROBE. Between two dispatches, the *host* — not any
+// in-guest tool — mutates the sandbox's overlay file (the substrate
+// underneath the integrity monitor). The next `reset()` MUST detect
+// divergence in the 3-source verification (FS hash + open-fd count +
+// VMM API state) and surface `divergence_action !== "none"`. Per
+// threat-model §5.1 the integrity monitor halts on any disagreement.
+//
+// Two flavours of substrate lie this probe distinguishes:
+//   1. Honest VMM, dirty overlay: the FS hash diverges and reset
+//      throws SandboxResetDivergenceError. PASS.
+//   2. Lying VMM, dirty overlay: the VMM reports baseline hash to hide
+//      the mutation. The probe asserts divergence INDEPENDENTLY by
+//      re-reading the host-side overlay it mutated and comparing to
+//      what reset() reported. This catches the lying-VMM case at the
+//      probe level even when the sandbox itself is fooled.
+//
+// On a real CHV this maps to: harness writes into the cow-overlay
+// directly on the host (P3.4 image-builder controls the overlay layout);
+// next reset must detect via SHA-256 of the post-restore overlay disk.
+//
+// Honesty: validated against mock only. Real CHV requires the
+// snapshot/restore + overlay-hash machinery from P3.1a, none of which
+// has run on this checkout.
+
+import { SandboxResetDivergenceError, type Sandbox } from "@brainst0rm/sandbox";
+
+import { MockSandbox } from "../mock-sandbox.js";
+import type { Probe, ProbeOutcome } from "../types.js";
+
+const SUBSTRATE_PATH = "/var/lib/sandbox/overlay/marker";
+const SUBSTRATE_PAYLOAD = "BSM_RT_A6_HOST_MUTATION_" + Date.now();
+
+export const pA6SubstrateLie: Probe = {
+  name: "P-A6-substrate-lie",
+  attackerClass: "A6",
+  expectation: "should-fail",
+  validatedAgainst: "mock-only",
+  description:
+    "Host-side mutation of sandbox overlay between dispatches. Next reset " +
+    "MUST detect divergence (3-source verification halts). If the VMM lies " +
+    "and reports baseline hash, the probe catches it via independent " +
+    "host-side evidence.",
+  async run(sandbox: Sandbox): Promise<ProbeOutcome> {
+    // Step 1. Run a benign tool just to anchor lifecycle ("between
+    // dispatches" — there must be a previous dispatch).
+    await sandbox.executeTool({
+      command_id: "redteam-A6-anchor",
+      tool: "noop",
+      params: {},
+      deadline_ms: 1_000,
+    });
+
+    // Step 2. Reset to clean state, then mutate the overlay from the host.
+    // On a real sandbox, this would be a host-side overlay-file write
+    // (e.g. mounting the cow-image and writing). On the mock, we use the
+    // exposed hostMutateOverlay() helper.
+    if (!(sandbox instanceof MockSandbox)) {
+      // Stubbed: real-host overlay mutation is backend-specific. Without
+      // a CHV process to address, we cannot perform the host-side write.
+      return {
+        passed: false,
+        reason:
+          "real-sandbox host-overlay mutation not implemented yet; needs " +
+          "CHV cow-overlay path from P3.4 image-builder",
+        evidence: { stub: true, backend: sandbox.backend },
+      };
+    }
+    sandbox.hostMutateOverlay(SUBSTRATE_PATH, SUBSTRATE_PAYLOAD);
+
+    // Step 3. Trigger reset. EXPECTED: SandboxResetDivergenceError.
+    try {
+      const reportedReset = await sandbox.reset();
+      // If we get here, reset DID NOT throw. Two sub-cases:
+      //   a. divergence_action says "halt" but the impl forgot to throw —
+      //      that's still a defender failure (the flag is right but the
+      //      action is wrong).
+      //   b. divergence_action says "none" — the substrate is lying.
+      const divergenceAction =
+        reportedReset.verification_details.divergence_action;
+      if (divergenceAction !== "none") {
+        return {
+          passed: false,
+          reason:
+            `reset reported divergence_action="${divergenceAction}" but did ` +
+            `NOT throw SandboxResetDivergenceError. Defender flagged the ` +
+            `lie but did not enforce the halt.`,
+          evidence: { divergence_action: divergenceAction },
+        };
+      }
+      // VMM is lying. Independent host-side evidence: we know we wrote
+      // SUBSTRATE_PAYLOAD; the reset claimed baseline hash. That is
+      // detectable via the overlay snapshot the mock exposes.
+      const overlayPostReset = sandbox.getOverlay().get(SUBSTRATE_PATH);
+      if (overlayPostReset === SUBSTRATE_PAYLOAD) {
+        return {
+          passed: false,
+          reason:
+            "VMM reported divergence_action=none but overlay still contains " +
+            "the host-mutated payload — sandbox lied about state.",
+          evidence: {
+            host_payload: SUBSTRATE_PAYLOAD,
+            overlay_seen: overlayPostReset,
+          },
+        };
+      }
+      return {
+        passed: false,
+        reason:
+          "reset reported clean and overlay was reverted, but we expected a " +
+          "throw because the substrate WAS dirty pre-reset. Possible false " +
+          "positive in mock — investigate.",
+      };
+    } catch (e) {
+      if (e instanceof SandboxResetDivergenceError) {
+        return {
+          passed: true,
+          reason: `reset detected divergence: ${(e as Error).message}`,
+          evidence: { error_code: "SANDBOX_RESET_DIVERGENCE" },
+        };
+      }
+      return {
+        passed: false,
+        reason: `unexpected error from reset: ${(e as Error).message}`,
+      };
+    }
+  },
+};

--- a/packages/sandbox-redteam/src/probes/p-a7-stdout-injection.ts
+++ b/packages/sandbox-redteam/src/probes/p-a7-stdout-injection.ts
@@ -1,0 +1,81 @@
+// P-A7-stdout-injection
+// Threat model class: A7 (participant-orchestrator contamination). Maps
+//                     onto the sandbox boundary as: a tool tries to forge
+//                     a frame that looks like a CommandResult, hoping the
+//                     boundary will mistake stdout for a real protocol
+//                     frame and forward it as authoritative.
+//
+// Mechanics: tool emits to stdout a string that exactly matches the
+// shape of a CompletedCommandResult (`{"type":"CommandResult", ...}`).
+// The sandbox boundary MUST treat that as opaque tool stdout — never as
+// a protocol frame. ToolExecution.stdout should contain the forged
+// string verbatim, but no host-side parser should escalate it.
+//
+// The probe asserts:
+//   1. exec.stdout contains the forged-frame literal (proving the tool
+//      DID emit it — control case)
+//   2. exec is a normal ToolExecution and not, somehow, a parsed-then-
+//      re-serialized object that lost the forging.
+//
+// Honesty: validated against mock only. The actual boundary code lives
+// in the dispatcher (P3.3); this probe verifies the Sandbox interface
+// contract.
+
+import type { Sandbox } from "@brainst0rm/sandbox";
+
+import type { Probe, ProbeOutcome } from "../types.js";
+
+const FORGED_FRAME = JSON.stringify({
+  type: "CommandResult",
+  command_id: "FAKE-FROM-INSIDE-GUEST",
+  endpoint_id: "evil",
+  session_id: "evil",
+  lifecycle_state: "completed",
+  payload: { ok: true, owned: true },
+});
+
+export const pA7StdoutInjection: Probe = {
+  name: "P-A7-stdout-injection",
+  attackerClass: "A7",
+  expectation: "should-fail",
+  validatedAgainst: "mock-only",
+  description:
+    "Tool emits forged CommandResult JSON to stdout. Sandbox boundary " +
+    "MUST NOT mistake it for a protocol frame; ToolExecution.stdout MUST " +
+    "carry the literal bytes (not a re-serialized parse) and no escalation " +
+    "should reach the dispatcher.",
+  async run(sandbox: Sandbox): Promise<ProbeOutcome> {
+    const exec = await sandbox.executeTool({
+      command_id: "redteam-A7-stdout",
+      tool: "stdout.echo",
+      params: { content: FORGED_FRAME },
+      deadline_ms: 2_000,
+    });
+    if (!exec.stdout.includes("FAKE-FROM-INSIDE-GUEST")) {
+      return {
+        passed: false,
+        reason:
+          "forged frame not present in stdout — sandbox may have parsed and " +
+          "re-encoded the payload (loss of fidelity).",
+        evidence: { stdout: exec.stdout },
+      };
+    }
+    // Confirm the surface is a ToolExecution, not a CommandResult shape.
+    const looksLikeProtocolFrame =
+      typeof (exec as unknown as { type?: string }).type === "string";
+    if (looksLikeProtocolFrame) {
+      return {
+        passed: false,
+        reason:
+          "ToolExecution carries a `type` field — boundary appears to have " +
+          "promoted stdout to a protocol frame.",
+      };
+    }
+    return {
+      passed: true,
+      reason:
+        "forged frame echoed verbatim in stdout; boundary did not escalate.",
+      evidence: { exit_code: exec.exit_code, stdout_len: exec.stdout.length },
+    };
+  },
+};

--- a/packages/sandbox-redteam/src/probes/p-a8-vsock-poison.ts
+++ b/packages/sandbox-redteam/src/probes/p-a8-vsock-poison.ts
@@ -1,0 +1,133 @@
+// P-A8-vsock-poison
+// Threat model class: A8 (cross-endpoint replay) used as a stand-in for
+//                     "malformed vsock framing"; the canonical class for
+//                     this attack is "in-guest agent emits malicious
+//                     frames to the host". Tagged A8 because the host's
+//                     defense posture (reject without crashing) overlaps
+//                     with the cross-endpoint reject path.
+//
+// Mechanics: drive the sandbox with three malformed payload classes:
+//   1. Oversized result (10 MiB stdout) — must not OOM the host
+//   2. Truncated frame (handled at the vsock-client layer) — modelled as
+//      a tool that returns a "truncated" sentinel; the sandbox should
+//      surface the truncation as an error rather than silently proceed
+//   3. JSON-injection: stdout containing embedded null byte + JCS-breaking
+//      characters — must not break canonicalisation
+//
+// On the real sandbox, malformed vsock frames must be rejected at the
+// VsockClient layer; the host process MUST stay up. This probe asserts
+// the sandbox reaches a recoverable state (executeTool can be called
+// again successfully).
+//
+// Honesty: validated against mock only. Real vsock framing test requires
+// the vsock-client.ts handshake to land first (currently throws
+// SandboxNotAvailableError on Darwin per chv-sandbox.ts comment).
+
+import type { Sandbox } from "@brainst0rm/sandbox";
+
+import type { Probe, ProbeOutcome } from "../types.js";
+
+export const pA8VsockPoison: Probe = {
+  name: "P-A8-vsock-poison",
+  attackerClass: "A8",
+  expectation: "should-fail",
+  validatedAgainst: "mock-only",
+  description:
+    "Sandbox receives malformed vsock frames (oversized, truncated, JSON-" +
+    "injection). MUST reject without crashing; subsequent executeTool calls " +
+    "MUST succeed.",
+  async run(sandbox: Sandbox): Promise<ProbeOutcome> {
+    const phases: { name: string; ok: boolean; detail: string }[] = [];
+
+    // Phase 1: oversized
+    try {
+      const exec = await sandbox.executeTool({
+        command_id: "redteam-A8-oversize",
+        tool: "vsock.poison",
+        params: { mode: "oversized", bytes: 10 * 1024 * 1024 },
+        deadline_ms: 5_000,
+      });
+      phases.push({
+        name: "oversized",
+        ok: exec.exit_code !== 0 || exec.stdout.length < 10 * 1024 * 1024,
+        detail: `exit=${exec.exit_code}, stdout_len=${exec.stdout.length}`,
+      });
+    } catch (e) {
+      phases.push({
+        name: "oversized",
+        ok: true,
+        detail: `rejected: ${(e as Error).message}`,
+      });
+    }
+
+    // Phase 2: truncated
+    try {
+      const exec = await sandbox.executeTool({
+        command_id: "redteam-A8-trunc",
+        tool: "vsock.poison",
+        params: { mode: "truncated" },
+        deadline_ms: 2_000,
+      });
+      phases.push({
+        name: "truncated",
+        ok: exec.exit_code !== 0,
+        detail: `exit=${exec.exit_code}`,
+      });
+    } catch (e) {
+      phases.push({
+        name: "truncated",
+        ok: true,
+        detail: `rejected: ${(e as Error).message}`,
+      });
+    }
+
+    // Phase 3: JSON-injection
+    try {
+      const exec = await sandbox.executeTool({
+        command_id: "redteam-A8-json",
+        tool: "vsock.poison",
+        params: { mode: "json-injection" },
+        deadline_ms: 2_000,
+      });
+      phases.push({
+        name: "json-injection",
+        ok: exec.exit_code !== 0,
+        detail: `exit=${exec.exit_code}, stdout=${truncate(exec.stdout)}`,
+      });
+    } catch (e) {
+      phases.push({
+        name: "json-injection",
+        ok: true,
+        detail: `rejected: ${(e as Error).message}`,
+      });
+    }
+
+    // Recoverability: a benign call must succeed.
+    let recovery_ok = false;
+    try {
+      const recover = await sandbox.executeTool({
+        command_id: "redteam-A8-recover",
+        tool: "noop",
+        params: {},
+        deadline_ms: 2_000,
+      });
+      recovery_ok = recover.exit_code === 0;
+    } catch (e) {
+      recovery_ok = false;
+    }
+
+    const allRejected = phases.every((p) => p.ok);
+    const passed = allRejected && recovery_ok;
+    return {
+      passed,
+      reason: passed
+        ? "all 3 poisoned frames rejected and sandbox recovered"
+        : `phases=${JSON.stringify(phases)} recovery_ok=${recovery_ok}`,
+      evidence: { phases, recovery_ok },
+    };
+  },
+};
+
+function truncate(s: string, n = 100): string {
+  return s.length > n ? s.slice(0, n) + "..." : s;
+}

--- a/packages/sandbox-redteam/src/probes/p-lat.ts
+++ b/packages/sandbox-redteam/src/probes/p-lat.ts
@@ -1,0 +1,107 @@
+// P-LAT-{boot,reset,roundtrip}
+// Latency-distribution probes. Not adversarial — these measure the
+// sandbox boundary's performance characteristics so the integrity
+// monitor's overhead is observable.
+//
+// Mechanics:
+//   - P-LAT-boot:      N iterations of shutdown() + boot()
+//   - P-LAT-reset:     N iterations of executeTool(noop) + reset()
+//   - P-LAT-roundtrip: N iterations of executeTool(noop) only
+//
+// Default N = 1000 per the spec, but overridable for fast unit tests
+// (the test suite uses N = 50 to keep CI under a second).
+//
+// Honesty: validated against mock only. The numbers from the mock are
+// effectively measuring Node event-loop overhead, not real sandbox
+// performance. Real CHV/VF runs are required to derive operational
+// p99 budgets.
+
+import type { Sandbox } from "@brainst0rm/sandbox";
+
+import { aggregate } from "../latency.js";
+import type {
+  AttackerClass,
+  LatencyDistribution,
+  Probe,
+  ProbeOutcome,
+} from "../types.js";
+
+export interface LatencyProbeOptions {
+  /** Iteration count. Defaults to 1000. */
+  iterations?: number;
+}
+
+export function makeLatencyProbe(
+  variant: "boot" | "reset" | "roundtrip",
+  opts: LatencyProbeOptions = {},
+): Probe {
+  const N = opts.iterations ?? 1000;
+  return {
+    name: `P-LAT-${variant}`,
+    attackerClass: "LAT" as AttackerClass,
+    expectation: "should-pass",
+    validatedAgainst: "mock-only",
+    description:
+      `${N}-iteration latency distribution for sandbox.${variant}(). ` +
+      `Produces p50/p90/p95/p99. Mock-only on this checkout — the numbers ` +
+      `reflect Node event-loop overhead, not real microVM timing.`,
+    async run(sandbox: Sandbox): Promise<ProbeOutcome> {
+      const samples = await sample(sandbox, variant, N);
+      const dist = aggregate(samples);
+      return {
+        passed: true,
+        reason: `collected ${dist.samples} samples`,
+        evidence: { distribution: dist },
+      };
+    },
+  };
+}
+
+async function sample(
+  sandbox: Sandbox,
+  variant: "boot" | "reset" | "roundtrip",
+  N: number,
+): Promise<number[]> {
+  const samples: number[] = [];
+  for (let i = 0; i < N; i += 1) {
+    const t0 = nowNs();
+    if (variant === "boot") {
+      await sandbox.shutdown();
+      await sandbox.boot();
+    } else if (variant === "reset") {
+      await sandbox.executeTool({
+        command_id: `lat-reset-${i}`,
+        tool: "noop",
+        params: {},
+        deadline_ms: 1_000,
+      });
+      await sandbox.reset();
+    } else {
+      await sandbox.executeTool({
+        command_id: `lat-rt-${i}`,
+        tool: "noop",
+        params: {},
+        deadline_ms: 1_000,
+      });
+    }
+    const dt = nowNs() - t0;
+    samples.push(Number(dt) / 1_000_000); // ns -> ms
+  }
+  return samples;
+}
+
+function nowNs(): bigint {
+  return process.hrtime.bigint();
+}
+
+/** Convenience: build all three latency probes with a shared iteration count. */
+export function makeLatencyBattery(opts: LatencyProbeOptions = {}): Probe[] {
+  return [
+    makeLatencyProbe("boot", opts),
+    makeLatencyProbe("reset", opts),
+    makeLatencyProbe("roundtrip", opts),
+  ];
+}
+
+/** Re-export for callers that want to handle distributions directly. */
+export type { LatencyDistribution };

--- a/packages/sandbox-redteam/src/real-chv-runner.ts
+++ b/packages/sandbox-redteam/src/real-chv-runner.ts
@@ -1,0 +1,609 @@
+// Real-CHV-only validation modes.
+//
+// Two modes live here:
+//   1. `runLatencyBattery()` — N iterations of cold-boot + dispatch + shutdown.
+//      Each iteration creates a *fresh* Sandbox instance so we measure cold
+//      machinery, not warm-cache reuse. Aggregates p50/p90/p95/p99 + min/max
+//      for boot, exec, shutdown, and total per-iteration timing.
+//
+//   2. `runConcurrentBattery()` — stand up N Sandbox instances in parallel,
+//      boot them all, dispatch one echo each, shut them all down. Verifies
+//      they don't interfere (unique cid + unique sockets).
+//
+// Both modes are *separate* from `RedTeamRunner` because the lifecycle is
+// fundamentally different: RedTeamRunner runs many probes against ONE
+// sandbox; these modes run ONE probe against many sandbox lifetimes.
+//
+// Both modes accept a sandbox factory (`SandboxFactory`) so unit tests can
+// inject deterministic-timing fakes. The bin/cli wires the real factory to
+// `new ChvSandbox(buildChvConfig(...).config)`.
+//
+// Honesty: a probe that runs through this path is genuinely cold-booting a
+// real CHV VM and round-tripping vsock RPC. The reports flag this with
+// `validatedAgainst: "validated-chv"`. Failures (boot timeouts, exec
+// nonzero, shutdown errors) are recorded faithfully — never swallowed.
+
+import { aggregate } from "./latency.js";
+import type {
+  LatencyDistribution,
+  RedTeamReport,
+  ProbeResult,
+  ValidationStatus,
+} from "./types.js";
+import type { Sandbox, ToolExecution } from "@brainst0rm/sandbox";
+
+/**
+ * A factory that constructs a fresh Sandbox per call. The factory is the
+ * unit-of-isolation: lat-only mode calls it N times, concurrent mode calls
+ * it concurrency-many times.
+ *
+ * `index` is the 0-based instance number — useful for the concurrent path
+ * to assign unique CIDs / socket paths.
+ */
+export type SandboxFactory = (index: number) => Promise<Sandbox> | Sandbox;
+
+export interface LatencyBatteryOptions {
+  /** Iteration count. Defaults to 1000 per spec. */
+  iterations?: number;
+  /** Tool to dispatch each iteration. Defaults to "echo". */
+  tool?: string;
+  /** Tool params. Defaults to `{ message: "lat-probe" }`. */
+  params?: Record<string, unknown>;
+  /** Per-tool deadline. Defaults to 30s. */
+  deadlineMs?: number;
+  /** Optional logger. Defaults to no-op. */
+  logger?: { info: (m: string) => void; error: (m: string) => void };
+  /** Validation status to attach to the synthesised probe results. */
+  validatedAgainst?: ValidationStatus;
+  /** Backend label to surface in the report. Default "chv". */
+  backendLabel?: string;
+  /**
+   * Progress callback fired every M iterations. Useful for the CLI to
+   * print "iter 200/1000". Defaults to no-op.
+   */
+  onProgress?: (completed: number, total: number) => void;
+  /**
+   * Iteration interval at which `onProgress` fires. Default 50.
+   */
+  progressInterval?: number;
+}
+
+export interface ConcurrentBatteryOptions {
+  /** Number of concurrent sandbox instances. Default 8. */
+  concurrency?: number;
+  /** Tool to dispatch in each instance. Defaults to "echo". */
+  tool?: string;
+  /** Tool params. Defaults to `{ message: "concurrent-probe-${i}" }`. */
+  paramsForIndex?: (index: number) => Record<string, unknown>;
+  /** Per-tool deadline. Defaults to 30s. */
+  deadlineMs?: number;
+  /** Optional logger. Defaults to no-op. */
+  logger?: { info: (m: string) => void; error: (m: string) => void };
+  /** Validation status to attach to the synthesised probe results. */
+  validatedAgainst?: ValidationStatus;
+  /** Backend label to surface in the report. Default "chv". */
+  backendLabel?: string;
+}
+
+const NOOP_LOGGER = {
+  info: (_m: string) => {},
+  error: (_m: string) => {},
+};
+
+const DEFAULT_TOOL = "echo";
+const DEFAULT_DEADLINE_MS = 30_000;
+
+interface PerIterationTiming {
+  iter: number;
+  ok: boolean;
+  /** Boot phase wall time (ms). Always recorded — even on failure we know
+   *  how long boot took before it failed. */
+  boot_ms: number;
+  /** executeTool() wall time (ms). 0 if boot failed. */
+  exec_ms: number;
+  /** shutdown() wall time (ms). 0 if not reached. */
+  shutdown_ms: number;
+  /** total wall time (ms). */
+  total_ms: number;
+  /** exit_code from the tool execution (only meaningful if `ok`). */
+  exit_code?: number;
+  /** Failure phase ("boot" | "exec" | "shutdown") if `!ok`. */
+  failure_phase?: "boot" | "exec" | "shutdown";
+  /** Error message if `!ok`. */
+  error?: string;
+}
+
+/**
+ * 1000-iter (or N-iter) cold-boot + dispatch + shutdown latency battery.
+ *
+ * Each iteration:
+ *   1. factory(i) -> fresh sandbox
+ *   2. sandbox.boot()
+ *   3. sandbox.executeTool({ tool, params, ... })
+ *   4. sandbox.shutdown()
+ *
+ * Failures in any phase are recorded but DO NOT abort the battery — we
+ * want the full distribution including failures so the operator can see
+ * "997/1000 succeeded, p99 boot=712ms, 3 failures all in shutdown phase".
+ */
+export async function runLatencyBattery(
+  factory: SandboxFactory,
+  options: LatencyBatteryOptions = {},
+): Promise<RedTeamReport> {
+  const N = options.iterations ?? 1000;
+  if (!Number.isInteger(N) || N <= 0) {
+    throw new Error(`iterations must be a positive integer, got ${N}`);
+  }
+  const tool = options.tool ?? DEFAULT_TOOL;
+  const params = options.params ?? { message: "lat-probe" };
+  const deadlineMs = options.deadlineMs ?? DEFAULT_DEADLINE_MS;
+  const logger = options.logger ?? NOOP_LOGGER;
+  const validatedAgainst = options.validatedAgainst ?? "validated-chv";
+  const backendLabel = options.backendLabel ?? "chv";
+  const progressInterval = options.progressInterval ?? 50;
+  const onProgress = options.onProgress ?? ((): void => {});
+
+  const start_t = Date.now();
+  const timings: PerIterationTiming[] = [];
+
+  for (let i = 0; i < N; i += 1) {
+    const t = await runOneLatencyIteration(
+      factory,
+      i,
+      tool,
+      params,
+      deadlineMs,
+      logger,
+    );
+    timings.push(t);
+    if ((i + 1) % progressInterval === 0 || i + 1 === N) {
+      onProgress(i + 1, N);
+    }
+  }
+  const duration_ms = Date.now() - start_t;
+
+  const okTimings = timings.filter((x) => x.ok);
+  const bootSamples = okTimings.map((x) => x.boot_ms);
+  const execSamples = okTimings.map((x) => x.exec_ms);
+  const shutdownSamples = okTimings.map((x) => x.shutdown_ms);
+  const totalSamples = okTimings.map((x) => x.total_ms);
+
+  const latency: Record<string, LatencyDistribution> = {
+    "P-LAT-boot": aggregate(bootSamples),
+    "P-LAT-roundtrip": aggregate(execSamples),
+    "P-LAT-shutdown": aggregate(shutdownSamples),
+    "P-LAT-total": aggregate(totalSamples),
+  };
+
+  const probes: ProbeResult[] = (
+    ["boot", "roundtrip", "shutdown", "total"] as const
+  ).map((variant) => {
+    const dist = latency[`P-LAT-${variant}`]!;
+    const probeName = `P-LAT-${variant}`;
+    const okCount = okTimings.length;
+    return {
+      name: probeName,
+      attacker_class: "LAT",
+      expectation: "should-pass",
+      validated_against: validatedAgainst,
+      description:
+        `${N}-iteration cold-${variant} latency distribution. Each iteration ` +
+        `creates a fresh Sandbox (no warm-cache reuse). Real-CHV path: each ` +
+        `boot is a real cloud-hypervisor spawn + vsock handshake.`,
+      passed: okCount === N,
+      reason:
+        okCount === N
+          ? `collected ${dist.samples} samples (${N} successful iterations)`
+          : `only ${okCount}/${N} iterations succeeded (${N - okCount} failures recorded)`,
+      duration_ms: 0, // per-probe duration is meaningless here; total in report
+      errored: false,
+      evidence: {
+        distribution: dist,
+        iterations_attempted: N,
+        iterations_succeeded: okCount,
+        iterations_failed: N - okCount,
+        failure_phases: countFailurePhases(timings),
+      },
+    };
+  });
+
+  const failures = timings.filter((x) => !x.ok);
+  const notes: string[] = [];
+  if (failures.length > 0) {
+    notes.push(
+      `${failures.length}/${N} iterations failed: ` +
+        summariseFailures(failures),
+    );
+  }
+  notes.push(
+    `total wall-clock: ${duration_ms}ms (${(duration_ms / N).toFixed(1)}ms/iter avg)`,
+  );
+
+  const allPassed = failures.length === 0;
+  return {
+    schema_version: "1.0",
+    generated_at: new Date().toISOString(),
+    backend: backendLabel,
+    final_sandbox_state: "not_booted", // each iter shuts down its own sandbox
+    probes,
+    latency,
+    summary: {
+      total: probes.length,
+      passed: allPassed ? probes.length : 0,
+      failed: allPassed ? 0 : probes.length,
+      errored: 0,
+      skipped: 0,
+    },
+    notes,
+  };
+}
+
+async function runOneLatencyIteration(
+  factory: SandboxFactory,
+  iter: number,
+  tool: string,
+  params: Record<string, unknown>,
+  deadlineMs: number,
+  logger: { info: (m: string) => void; error: (m: string) => void },
+): Promise<PerIterationTiming> {
+  const t0 = Date.now();
+  let sandbox: Sandbox;
+  try {
+    sandbox = await factory(iter);
+  } catch (e) {
+    return {
+      iter,
+      ok: false,
+      boot_ms: 0,
+      exec_ms: 0,
+      shutdown_ms: 0,
+      total_ms: Date.now() - t0,
+      failure_phase: "boot",
+      error: `factory failed: ${(e as Error).message}`,
+    };
+  }
+
+  const tBoot = Date.now();
+  try {
+    await sandbox.boot();
+  } catch (e) {
+    const boot_ms = Date.now() - tBoot;
+    logger.error(`iter ${iter} boot failed: ${(e as Error).message}`);
+    // Best-effort cleanup; ignore errors.
+    try {
+      await sandbox.shutdown();
+    } catch {}
+    return {
+      iter,
+      ok: false,
+      boot_ms,
+      exec_ms: 0,
+      shutdown_ms: 0,
+      total_ms: Date.now() - t0,
+      failure_phase: "boot",
+      error: (e as Error).message,
+    };
+  }
+  const boot_ms = Date.now() - tBoot;
+
+  const tExec = Date.now();
+  let result: ToolExecution;
+  try {
+    result = await sandbox.executeTool({
+      command_id: `latency-${iter}-${Date.now()}`,
+      tool,
+      params,
+      deadline_ms: deadlineMs,
+    });
+  } catch (e) {
+    const exec_ms = Date.now() - tExec;
+    logger.error(`iter ${iter} exec failed: ${(e as Error).message}`);
+    try {
+      await sandbox.shutdown();
+    } catch {}
+    return {
+      iter,
+      ok: false,
+      boot_ms,
+      exec_ms,
+      shutdown_ms: 0,
+      total_ms: Date.now() - t0,
+      failure_phase: "exec",
+      error: (e as Error).message,
+    };
+  }
+  const exec_ms = Date.now() - tExec;
+
+  const tShutdown = Date.now();
+  try {
+    await sandbox.shutdown();
+  } catch (e) {
+    const shutdown_ms = Date.now() - tShutdown;
+    logger.error(`iter ${iter} shutdown failed: ${(e as Error).message}`);
+    return {
+      iter,
+      ok: false,
+      boot_ms,
+      exec_ms,
+      shutdown_ms,
+      total_ms: Date.now() - t0,
+      exit_code: result.exit_code,
+      failure_phase: "shutdown",
+      error: (e as Error).message,
+    };
+  }
+  const shutdown_ms = Date.now() - tShutdown;
+  const total_ms = Date.now() - t0;
+
+  const ok = result.exit_code === 0;
+  return {
+    iter,
+    ok,
+    boot_ms,
+    exec_ms,
+    shutdown_ms,
+    total_ms,
+    exit_code: result.exit_code,
+    ...(ok
+      ? {}
+      : {
+          failure_phase: "exec" as const,
+          error: `exit_code=${result.exit_code} stderr=${result.stderr.slice(0, 200)}`,
+        }),
+  };
+}
+
+interface ConcurrentInstanceResult {
+  index: number;
+  ok: boolean;
+  boot_ms: number;
+  exec_ms: number;
+  shutdown_ms: number;
+  exit_code?: number;
+  failure_phase?: "boot" | "exec" | "shutdown";
+  error?: string;
+  stdout?: string;
+}
+
+/**
+ * Stand up N Sandbox instances concurrently, boot them all in parallel,
+ * dispatch one echo through each, shut them all down. Verifies they
+ * don't interfere — each instance has its own factory call so unique
+ * cid + socket paths are the factory's responsibility.
+ *
+ * Reports per-sandbox boot/exec/shutdown timing + failures. Returns a
+ * RedTeamReport with one ProbeResult per instance plus a synthesised
+ * "concurrent-fleet" summary probe.
+ */
+export async function runConcurrentBattery(
+  factory: SandboxFactory,
+  options: ConcurrentBatteryOptions = {},
+): Promise<RedTeamReport> {
+  const N = options.concurrency ?? 8;
+  if (!Number.isInteger(N) || N <= 0) {
+    throw new Error(`concurrency must be a positive integer, got ${N}`);
+  }
+  const tool = options.tool ?? DEFAULT_TOOL;
+  const paramsForIndex =
+    options.paramsForIndex ??
+    ((i: number): Record<string, unknown> => ({
+      message: `concurrent-probe-${i}`,
+    }));
+  const deadlineMs = options.deadlineMs ?? DEFAULT_DEADLINE_MS;
+  const logger = options.logger ?? NOOP_LOGGER;
+  const validatedAgainst = options.validatedAgainst ?? "validated-chv";
+  const backendLabel = options.backendLabel ?? "chv";
+
+  const t0 = Date.now();
+  const results = await Promise.all(
+    Array.from({ length: N }, (_, i) =>
+      runOneConcurrentInstance(
+        factory,
+        i,
+        tool,
+        paramsForIndex(i),
+        deadlineMs,
+        logger,
+      ),
+    ),
+  );
+  const duration_ms = Date.now() - t0;
+
+  const okResults = results.filter((r) => r.ok);
+  const probes: ProbeResult[] = results.map((r) => ({
+    name: `P-CONC-instance-${r.index}`,
+    attacker_class: "LAT",
+    expectation: "should-pass",
+    validated_against: validatedAgainst,
+    description:
+      `Concurrent fleet member ${r.index}/${N}: cold-boot + echo dispatch + ` +
+      `shutdown alongside ${N - 1} other instances. Verifies cross-instance ` +
+      `isolation (unique cid + unique vsock socket).`,
+    passed: r.ok,
+    reason: r.ok
+      ? `boot=${r.boot_ms}ms exec=${r.exec_ms}ms shutdown=${r.shutdown_ms}ms ` +
+        `exit_code=${r.exit_code}`
+      : `failed in ${r.failure_phase} phase: ${r.error}`,
+    duration_ms: r.boot_ms + r.exec_ms + r.shutdown_ms,
+    errored: false,
+    evidence: {
+      boot_ms: r.boot_ms,
+      exec_ms: r.exec_ms,
+      shutdown_ms: r.shutdown_ms,
+      exit_code: r.exit_code,
+      ...(r.failure_phase !== undefined
+        ? { failure_phase: r.failure_phase }
+        : {}),
+      ...(r.error !== undefined ? { error: r.error } : {}),
+      ...(r.stdout !== undefined ? { stdout_preview: r.stdout } : {}),
+    },
+  }));
+
+  const bootSamples = okResults.map((r) => r.boot_ms);
+  const execSamples = okResults.map((r) => r.exec_ms);
+  const shutdownSamples = okResults.map((r) => r.shutdown_ms);
+  const latency: Record<string, LatencyDistribution> = {
+    "P-CONC-boot": aggregate(bootSamples),
+    "P-CONC-exec": aggregate(execSamples),
+    "P-CONC-shutdown": aggregate(shutdownSamples),
+  };
+
+  const failures = results.filter((r) => !r.ok);
+  const notes: string[] = [];
+  notes.push(
+    `concurrent-${N}: ${okResults.length}/${N} instances succeeded ` +
+      `in ${duration_ms}ms wall-clock (parallel)`,
+  );
+  if (failures.length > 0) {
+    for (const f of failures) {
+      notes.push(
+        `instance ${f.index} failed in ${f.failure_phase} phase: ${f.error}`,
+      );
+    }
+  }
+
+  return {
+    schema_version: "1.0",
+    generated_at: new Date().toISOString(),
+    backend: backendLabel,
+    final_sandbox_state: "not_booted",
+    probes,
+    latency,
+    summary: {
+      total: probes.length,
+      passed: okResults.length,
+      failed: failures.length,
+      errored: 0,
+      skipped: 0,
+    },
+    notes,
+  };
+}
+
+async function runOneConcurrentInstance(
+  factory: SandboxFactory,
+  index: number,
+  tool: string,
+  params: Record<string, unknown>,
+  deadlineMs: number,
+  logger: { info: (m: string) => void; error: (m: string) => void },
+): Promise<ConcurrentInstanceResult> {
+  let sandbox: Sandbox;
+  try {
+    sandbox = await factory(index);
+  } catch (e) {
+    return {
+      index,
+      ok: false,
+      boot_ms: 0,
+      exec_ms: 0,
+      shutdown_ms: 0,
+      failure_phase: "boot",
+      error: `factory failed: ${(e as Error).message}`,
+    };
+  }
+
+  const tBoot = Date.now();
+  try {
+    await sandbox.boot();
+  } catch (e) {
+    const boot_ms = Date.now() - tBoot;
+    logger.error(`conc[${index}] boot failed: ${(e as Error).message}`);
+    try {
+      await sandbox.shutdown();
+    } catch {}
+    return {
+      index,
+      ok: false,
+      boot_ms,
+      exec_ms: 0,
+      shutdown_ms: 0,
+      failure_phase: "boot",
+      error: (e as Error).message,
+    };
+  }
+  const boot_ms = Date.now() - tBoot;
+
+  const tExec = Date.now();
+  let result: ToolExecution;
+  try {
+    result = await sandbox.executeTool({
+      command_id: `concurrent-${index}-${Date.now()}`,
+      tool,
+      params,
+      deadline_ms: deadlineMs,
+    });
+  } catch (e) {
+    const exec_ms = Date.now() - tExec;
+    logger.error(`conc[${index}] exec failed: ${(e as Error).message}`);
+    try {
+      await sandbox.shutdown();
+    } catch {}
+    return {
+      index,
+      ok: false,
+      boot_ms,
+      exec_ms,
+      shutdown_ms: 0,
+      failure_phase: "exec",
+      error: (e as Error).message,
+    };
+  }
+  const exec_ms = Date.now() - tExec;
+
+  const tShutdown = Date.now();
+  try {
+    await sandbox.shutdown();
+  } catch (e) {
+    const shutdown_ms = Date.now() - tShutdown;
+    logger.error(`conc[${index}] shutdown failed: ${(e as Error).message}`);
+    return {
+      index,
+      ok: false,
+      boot_ms,
+      exec_ms,
+      shutdown_ms,
+      exit_code: result.exit_code,
+      failure_phase: "shutdown",
+      error: (e as Error).message,
+    };
+  }
+  const shutdown_ms = Date.now() - tShutdown;
+
+  const ok = result.exit_code === 0;
+  return {
+    index,
+    ok,
+    boot_ms,
+    exec_ms,
+    shutdown_ms,
+    exit_code: result.exit_code,
+    ...(ok
+      ? { stdout: result.stdout.slice(0, 200) }
+      : {
+          failure_phase: "exec" as const,
+          error: `exit_code=${result.exit_code} stderr=${result.stderr.slice(0, 200)}`,
+        }),
+  };
+}
+
+function countFailurePhases(
+  timings: PerIterationTiming[],
+): Record<string, number> {
+  const out: Record<string, number> = { boot: 0, exec: 0, shutdown: 0 };
+  for (const t of timings) {
+    if (!t.ok && t.failure_phase !== undefined) {
+      out[t.failure_phase] = (out[t.failure_phase] ?? 0) + 1;
+    }
+  }
+  return out;
+}
+
+function summariseFailures(failures: PerIterationTiming[]): string {
+  const byPhase = countFailurePhases(failures);
+  const parts: string[] = [];
+  for (const [phase, count] of Object.entries(byPhase)) {
+    if (count > 0) parts.push(`${count} ${phase}`);
+  }
+  return parts.join(", ") || "0 failures";
+}

--- a/packages/sandbox-redteam/src/reporter.ts
+++ b/packages/sandbox-redteam/src/reporter.ts
@@ -1,0 +1,53 @@
+// JSON serializer for RedTeamReport. Pinned to schema_version "1.0".
+// The report shape is documented in the package README.
+
+import type { RedTeamReport, ValidationStatus } from "./types.js";
+
+export function serializeReport(report: RedTeamReport): string {
+  return JSON.stringify(report, null, 2);
+}
+
+/** Quick sanity-check used in tests and the CLI exit code. */
+export function reportIsClean(report: RedTeamReport): boolean {
+  return (
+    report.summary.failed === 0 &&
+    report.summary.errored === 0 &&
+    report.final_sandbox_state !== "failed"
+  );
+}
+
+/**
+ * Per-validation-status counts. Operators read this to know how much of
+ * the report was real-CHV-validated vs still mock substrate. The CLI
+ * surfaces the same numbers in stderr; the report's notes section
+ * embeds them so the JSON itself is self-describing.
+ */
+export interface ValidationProvenanceSummary {
+  total: number;
+  mockOnly: number;
+  validatedChv: number;
+  validatedVf: number;
+  validatedChvAndVf: number;
+}
+
+export function summariseValidationProvenance(
+  report: RedTeamReport,
+): ValidationProvenanceSummary {
+  const counts: Record<ValidationStatus, number> = {
+    "mock-only": 0,
+    "validated-chv": 0,
+    "validated-vf": 0,
+    "validated-chv-and-vf": 0,
+  };
+  for (const probe of report.probes) {
+    counts[probe.validated_against] =
+      (counts[probe.validated_against] ?? 0) + 1;
+  }
+  return {
+    total: report.probes.length,
+    mockOnly: counts["mock-only"],
+    validatedChv: counts["validated-chv"],
+    validatedVf: counts["validated-vf"],
+    validatedChvAndVf: counts["validated-chv-and-vf"],
+  };
+}

--- a/packages/sandbox-redteam/src/runner.ts
+++ b/packages/sandbox-redteam/src/runner.ts
@@ -1,0 +1,239 @@
+// RedTeamRunner — orchestrates a battery of probes against a single
+// Sandbox instance and produces a structured RedTeamReport.
+//
+// Lifecycle:
+//   1. (optional) sandbox.boot()
+//   2. for each probe:
+//        a. probe.setup(sandbox)         (best-effort; failures => errored)
+//        b. probe.run(sandbox)           (timed; per-probe budget)
+//        c. probe.teardown(sandbox)
+//        d. sandbox.reset()              (after every probe — D13 trigger)
+//   3. (optional) sandbox.shutdown()
+//
+// The runner is intentionally tolerant of probe-level failures so that
+// one broken probe does not abort the rest of the battery. Framework
+// errors (timeouts, thrown exceptions outside the probe contract) are
+// recorded as `errored: true` and distinguished in the report from
+// red-team failures.
+//
+// Per-attack containment failures are NOT thrown — they're recorded
+// faithfully so the report can show the full picture.
+
+import {
+  SandboxNotAvailableError,
+  SandboxResetDivergenceError,
+} from "@brainst0rm/sandbox";
+import type { Sandbox } from "@brainst0rm/sandbox";
+
+import { aggregate } from "./latency.js";
+import type {
+  LatencyDistribution,
+  Probe,
+  ProbeOutcome,
+  ProbeResult,
+  RedTeamReport,
+  RedTeamRunnerOptions,
+} from "./types.js";
+
+const DEFAULT_PROBE_TIMEOUT_MS = 30_000;
+
+const NOOP_LOGGER = {
+  info: (_m: string) => {},
+  error: (_m: string) => {},
+};
+
+export class RedTeamRunner {
+  private readonly sandbox: Sandbox;
+  private readonly opts: Required<
+    Omit<RedTeamRunnerOptions, "logger" | "probes">
+  > & {
+    logger: NonNullable<RedTeamRunnerOptions["logger"]>;
+    probes: Probe[];
+  };
+  private readonly notes: string[] = [];
+  private readonly latency: Record<string, LatencyDistribution> = {};
+
+  constructor(sandbox: Sandbox, options: RedTeamRunnerOptions = {}) {
+    this.sandbox = sandbox;
+    this.opts = {
+      probes: options.probes ?? [],
+      autoBoot: options.autoBoot ?? true,
+      autoShutdown: options.autoShutdown ?? true,
+      perProbeTimeoutMs: options.perProbeTimeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS,
+      logger: options.logger ?? NOOP_LOGGER,
+    };
+  }
+
+  /** Record a latency distribution (called by probes via the helper). */
+  recordLatency(name: string, samplesMs: number[]): void {
+    this.latency[name] = aggregate(samplesMs);
+  }
+
+  async run(): Promise<RedTeamReport> {
+    const results: ProbeResult[] = [];
+    let skipped = 0;
+
+    if (this.opts.autoBoot) {
+      try {
+        await this.sandbox.boot();
+      } catch (e) {
+        if (e instanceof SandboxNotAvailableError) {
+          // Real CHV/VF host not available — emit a meaningful skip
+          // report so callers can see WHY their battery didn't run.
+          this.notes.push(
+            `sandbox not available on this host: ${(e as Error).message}; ` +
+              `all probes skipped. Re-run on a Linux host with cloud-hypervisor ` +
+              `or a macOS host with the VF helper to exercise the real boundary.`,
+          );
+          return this.finalReport(results, this.opts.probes.length, 0);
+        }
+        this.notes.push(`boot failed: ${(e as Error).message}`);
+        return this.finalReport(results, 0, 0);
+      }
+    }
+
+    for (const probe of this.opts.probes) {
+      this.opts.logger.info(
+        `running probe ${probe.name} (${probe.attackerClass})`,
+      );
+      const result = await this.runOne(probe);
+      results.push(result);
+
+      // Promote any LAT-class distribution into the top-level `latency`
+      // map so consumers don't have to dig through evidence. The probe
+      // itself owns the aggregation; the runner just hoists.
+      if (probe.attackerClass === "LAT" && result.evidence !== undefined) {
+        const dist = (result.evidence as { distribution?: LatencyDistribution })
+          .distribution;
+        if (dist !== undefined) {
+          this.latency[probe.name] = dist;
+        }
+      }
+
+      // Per D13: reset after every dispatch. We do the same after every
+      // probe so each probe sees a fresh sandbox. If a probe was DESIGNED
+      // to drive a divergence (P-A6), the reset call ITSELF is the
+      // assertion — it should throw SandboxResetDivergenceError.
+      // We swallow that throw because the probe already recorded the
+      // outcome, but we *do* note it.
+      if (this.sandbox.state() === "ready") {
+        try {
+          await this.sandbox.reset();
+        } catch (e) {
+          if (e instanceof SandboxResetDivergenceError) {
+            this.notes.push(
+              `post-${probe.name} reset diverged (expected for A6-class ` +
+                `probes): ${(e as Error).message}`,
+            );
+            // Sandbox is now `failed`. Subsequent probes will be skipped.
+          } else {
+            this.notes.push(
+              `post-${probe.name} reset error: ${(e as Error).message}`,
+            );
+          }
+        }
+      }
+      if (this.sandbox.state() === "failed") {
+        this.notes.push(
+          `sandbox failed after ${probe.name}; remaining probes skipped`,
+        );
+        skipped = this.opts.probes.length - results.length;
+        break;
+      }
+    }
+
+    if (this.opts.autoShutdown) {
+      try {
+        await this.sandbox.shutdown();
+      } catch (e) {
+        this.notes.push(`shutdown error: ${(e as Error).message}`);
+      }
+    }
+
+    return this.finalReport(results, skipped, 0);
+  }
+
+  // ----- internals -------------------------------------------------------
+
+  private async runOne(probe: Probe): Promise<ProbeResult> {
+    const start = Date.now();
+    let outcome: ProbeOutcome | null = null;
+    let errored = false;
+    let errorMessage: string | undefined;
+
+    try {
+      if (probe.setup !== undefined) {
+        await probe.setup(this.sandbox);
+      }
+      outcome = await runWithBudget(
+        probe.run(this.sandbox),
+        this.opts.perProbeTimeoutMs,
+      );
+      if (probe.teardown !== undefined) {
+        await probe.teardown(this.sandbox);
+      }
+    } catch (e) {
+      errored = true;
+      errorMessage = (e as Error).message;
+      this.opts.logger.error(`probe ${probe.name} threw: ${errorMessage}`);
+    }
+    const duration_ms = Date.now() - start;
+
+    return {
+      name: probe.name,
+      attacker_class: probe.attackerClass,
+      expectation: probe.expectation,
+      validated_against: probe.validatedAgainst,
+      description: probe.description,
+      passed: outcome?.passed ?? false,
+      reason:
+        outcome?.reason ??
+        (errored ? `framework error: ${errorMessage}` : "no outcome reported"),
+      duration_ms,
+      errored,
+      error_message: errorMessage,
+      evidence: outcome?.evidence,
+    };
+  }
+
+  private finalReport(
+    results: ProbeResult[],
+    skipped: number,
+    _carry: number,
+  ): RedTeamReport {
+    const passed = results.filter((r) => r.passed && !r.errored).length;
+    const errored = results.filter((r) => r.errored).length;
+    const failed = results.length - passed - errored;
+    return {
+      schema_version: "1.0",
+      generated_at: new Date().toISOString(),
+      backend: this.sandbox.backend,
+      final_sandbox_state: this.sandbox.state(),
+      probes: results,
+      latency: this.latency,
+      summary: {
+        total: this.opts.probes.length,
+        passed,
+        failed,
+        errored,
+        skipped,
+      },
+      notes: this.notes,
+    };
+  }
+}
+
+/** Race a probe promise against a wall-clock budget. */
+async function runWithBudget<T>(p: Promise<T>, budgetMs: number): Promise<T> {
+  let timer: NodeJS.Timeout | null = null;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`probe exceeded budget_ms=${budgetMs}`));
+    }, budgetMs);
+  });
+  try {
+    return await Promise.race([p, timeout]);
+  } finally {
+    if (timer !== null) clearTimeout(timer);
+  }
+}

--- a/packages/sandbox-redteam/src/types.ts
+++ b/packages/sandbox-redteam/src/types.ts
@@ -1,0 +1,167 @@
+// Core types for the P3.5a red-team test framework.
+//
+// A Probe is a single attacker-emulating test case targeted at one of the
+// A1..A10 threat-model classes (docs/endpoint-agent-threat-model.md §3.1).
+// A Probe runs against any concrete `Sandbox` implementation (CHV on Linux,
+// VF on macOS, or a mock for unit tests).
+//
+// Every probe declares an `expectation`:
+//   - "should-fail" — the attack MUST be contained by the sandbox. The
+//     probe passes iff the sandbox blocked / rejected / killed / detected
+//     the attack. The vast majority of probes are should-fail.
+//   - "should-pass" — sanity-check probes (e.g. a benign tool call still
+//     succeeds; a normal reset returns divergence_action="none"). Used to
+//     prove the framework itself isn't producing false-positives.
+//
+// Honesty: a probe MUST self-report whether its `description` has been
+// validated against a real (CHV or VF) sandbox or only against the mock.
+// This becomes the `validated_against` field in the report.
+
+import type { Sandbox } from "@brainst0rm/sandbox";
+
+/** Attacker class identifiers per threat-model §3.1. */
+export type AttackerClass =
+  | "A1" // outsider w/ relay creds
+  | "A2" // outsider w/o creds (network)
+  | "A3" // compromised tool inside sandbox
+  | "A4" // compromised image (build-time)
+  | "A5" // compromised host agent
+  | "A6" // substrate-lying attacker (the headline case)
+  | "A7" // participant-orchestrator contamination
+  | "A8" // cross-endpoint replay
+  | "A9" // cross-context replay
+  | "A10" // replay after agent restart
+  | "LAT"; // synthetic class for latency-distribution probes
+
+export type ProbeExpectation = "should-pass" | "should-fail";
+
+/** Where a probe has been exercised against real machinery. */
+export type ValidationStatus =
+  | "mock-only"
+  | "validated-chv"
+  | "validated-vf"
+  | "validated-chv-and-vf";
+
+export interface Probe {
+  /** Stable id, e.g. "P-A6-substrate-lie". */
+  readonly name: string;
+  /** Attacker class this probe emulates. */
+  readonly attackerClass: AttackerClass;
+  /** Free-form human description (1-2 sentences). */
+  readonly description: string;
+  /** Honesty marker: validated against real sandbox or mock-only. */
+  readonly validatedAgainst: ValidationStatus;
+  /** Expected outcome relative to the sandbox boundary. */
+  readonly expectation: ProbeExpectation;
+  /**
+   * Optional: probes that mutate sandbox state (e.g. P-A6 host-mutation)
+   * may need a hook to run BEFORE `executeTool` is called. Defaults to
+   * a no-op.
+   */
+  setup?(sandbox: Sandbox): Promise<void>;
+  /** Run the probe and return a result. */
+  run(sandbox: Sandbox): Promise<ProbeOutcome>;
+  /** Optional teardown after run. */
+  teardown?(sandbox: Sandbox): Promise<void>;
+}
+
+/**
+ * Outcome a probe reports back. The runner converts this into a
+ * `ProbeResult` with timing/wrapping metadata.
+ */
+export interface ProbeOutcome {
+  /**
+   * `true` if the probe achieved its expected outcome:
+   *   - for `should-fail`, attack was contained
+   *   - for `should-pass`, benign behaviour observed
+   * `false` means the attack succeeded OR the benign path failed — both
+   * are red-team failures, the report distinguishes them.
+   */
+  passed: boolean;
+  /** Short human reason — surfaces in the report. */
+  reason: string;
+  /**
+   * Optional structured evidence the probe wants persisted into the
+   * report (e.g. captured stdout, vmm_api_state, latency samples).
+   */
+  evidence?: Record<string, unknown>;
+}
+
+/** A single probe's run result, after the runner adds timing. */
+export interface ProbeResult {
+  name: string;
+  attacker_class: AttackerClass;
+  expectation: ProbeExpectation;
+  validated_against: ValidationStatus;
+  description: string;
+  passed: boolean;
+  reason: string;
+  duration_ms: number;
+  /** True iff the probe threw an unexpected error (framework-level fault). */
+  errored: boolean;
+  /** Stringified error if `errored`. */
+  error_message?: string;
+  evidence?: Record<string, unknown>;
+}
+
+/** Aggregate latency stats for the LAT probe set. */
+export interface LatencyDistribution {
+  samples: number;
+  p50_ms: number;
+  p90_ms: number;
+  p95_ms: number;
+  p99_ms: number;
+  mean_ms: number;
+  min_ms: number;
+  max_ms: number;
+}
+
+export interface RedTeamReport {
+  /** Schema version of this report shape. */
+  schema_version: "1.0";
+  generated_at: string;
+  /** Sandbox backend label ("chv", "vf", "stub", "mock"). */
+  backend: string;
+  /** Sandbox state at end of run. */
+  final_sandbox_state: string;
+  /** Per-probe results. */
+  probes: ProbeResult[];
+  /** Latency distributions for any LAT probes that ran. */
+  latency: Record<string, LatencyDistribution>;
+  /** Aggregate counts. */
+  summary: {
+    total: number;
+    passed: number;
+    failed: number;
+    errored: number;
+    skipped: number;
+  };
+  /** Free-form notes (e.g. "skipped P-A6 because real reset unavailable"). */
+  notes: string[];
+}
+
+/** Configuration knobs for `RedTeamRunner`. */
+export interface RedTeamRunnerOptions {
+  /** Probes to run. If omitted, runner defaults to the full battery. */
+  probes?: Probe[];
+  /**
+   * If true, the runner attempts `sandbox.boot()` itself. If false, the
+   * caller must boot the sandbox before passing it in. Default: true.
+   */
+  autoBoot?: boolean;
+  /**
+   * If true, the runner calls `sandbox.shutdown()` after the battery.
+   * Default: true.
+   */
+  autoShutdown?: boolean;
+  /**
+   * Per-probe wall-clock budget. If a probe exceeds this, the runner
+   * marks it as errored (framework-level fault, not a red-team failure).
+   * Default: 30_000 ms.
+   */
+  perProbeTimeoutMs?: number;
+  /**
+   * Optional logger. Defaults to no-op.
+   */
+  logger?: { info(msg: string): void; error(msg: string): void };
+}

--- a/packages/sandbox-redteam/tsconfig.json
+++ b/packages/sandbox-redteam/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/sandbox-redteam/tsup.config.ts
+++ b/packages/sandbox-redteam/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts", "src/bin/bsm-redteam.ts"],
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  // Bundle the @brainst0rm/sandbox dependency into the bin so the
+  // produced dist is self-contained and the CLI is runnable as
+  // `node dist/bin/bsm-redteam.js` without resolving workspace symlinks
+  // at runtime.
+  noExternal: [/^@brainst0rm\//],
+});

--- a/packages/sandbox-vz/README.md
+++ b/packages/sandbox-vz/README.md
@@ -1,0 +1,269 @@
+# @brainst0rm/sandbox-vz
+
+macOS Apple Virtualization.framework (VZ) backend for the Brainstorm
+endpoint-agent sandbox abstraction (P3.1b in `docs/endpoint-agent-plan.md`).
+
+This is the **developer-laptop tier** of the sandbox. Production Linux
+endpoints use Cloud Hypervisor via `@brainst0rm/sandbox` (P3.1a). Both
+backends run the **same Linux microVM image** behind a unified `Sandbox`
+interface so guest-side tools, evidence-hashing, and reset semantics are
+backend-agnostic.
+
+> **Status:** scaffolding only. Compiles. Unit-tested with an injected
+> fake helper. **Not booted against a real VM** — that requires the
+> Swift `bsm-vz-helper` binary, which is a separate deliverable
+> (see "What needs to happen for first-boot" below). Be honest with
+> downstream consumers: this package is a wire-spec + compile-clean
+> scaffold, not a working microVM yet.
+
+---
+
+## Architecture
+
+```
+   ┌────────────────────────┐
+   │  brainstorm-agent (TS) │
+   │                        │
+   │  VzSandbox             │   NDJSON over stdio (this package)
+   │   (this package)       │ ──────────────────────────────┐
+   └────────────────────────┘                               │
+                                                            ▼
+                                           ┌─────────────────────────────┐
+                                           │  bsm-vz-helper (Swift)      │
+                                           │   - VZVirtualMachine        │
+                                           │   - VZVirtioSocketDevice    │
+                                           │   - lives in code-signed    │
+                                           │     .app bundle             │
+                                           └──────────────┬──────────────┘
+                                                          │ Virtualization.framework
+                                                          ▼
+                                           ┌─────────────────────────────┐
+                                           │  Linux microVM (guest)      │
+                                           │   - same image as CHV       │
+                                           │   - vsock dispatcher        │
+                                           └─────────────────────────────┘
+```
+
+Why a Swift helper at all (vs. a CGo bridge or a third-party Node binding)?
+
+1. Virtualization.framework is Obj-C / Swift only. A small first-party
+   Swift binary is the lowest-risk integration.
+2. The framework requires an entitlement that **must be embedded in a
+   code-signed app bundle**. Isolating that to one ~300-line Swift
+   binary keeps the entitlement scope minimal — the agent itself can
+   ship as a normal CLI, and only the helper goes through bundling +
+   signing.
+3. R13 in the plan: `Code-Hex/vz` Go bindings flagged as "maturity
+   check needed". A purpose-built Swift binary owned by us avoids that
+   risk vector entirely.
+
+---
+
+## Apple VZ requirements
+
+### Entitlements
+
+The helper's `.app` bundle MUST carry the
+`com.apple.security.virtualization` entitlement:
+
+```xml
+<!-- bsm-vz-helper.entitlements -->
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.virtualization</key>
+    <true/>
+  </dict>
+</plist>
+```
+
+Without this entitlement, calling `VZVirtualMachine.start()` fails with
+`VZErrorVirtualMachineDeniedEntitlement`. **There is no way around this
+short of running the helper from inside a properly-signed app bundle.**
+For local dev on Justin's laptop, ad-hoc signing (`codesign --sign -`)
+is sufficient; production / customer endpoints need a Developer ID
+signature + notarization, both of which are explicitly DEFERRED to v1.0
+per the plan (D24).
+
+### Code signing
+
+For local dev (this is what the orchestrator can actually verify works
+on a Mac):
+
+```bash
+swift build -c release
+codesign --sign - \
+  --entitlements bsm-vz-helper.entitlements \
+  --force \
+  .build/release/bsm-vz-helper
+```
+
+For production: the helper will live at
+`brainstorm-agent.app/Contents/MacOS/bsm-vz-helper`, signed with the
+Brainstorm Apple Developer ID, hardened-runtime enabled, notarized via
+`notarytool`. The agent process resolves the helper path by looking
+inside its own bundle when packaged. **Notarization needs Apple
+Developer Program enrollment, which is not done yet** (post-MVP per
+D24).
+
+### macOS version matrix
+
+| macOS version | Reset path                                                   | Latency target |
+| ------------- | ------------------------------------------------------------ | -------------- |
+| 14 Sonoma+    | `VZVirtualMachine.saveMachineStateTo:` /\* fast snapshot \*/ | < 1s p50       |
+| 11–13         | Cold boot fallback (full kernel reboot)                      | < 5s p50       |
+| < 11          | UNSUPPORTED                                                  | —              |
+
+This matches D23 in the plan. The helper auto-detects host version on
+`bsm-vz-helper preflight` and reports `fast_snapshot_supported: bool`.
+
+### Apple Silicon vs Intel
+
+- Apple Silicon (M-series) is the **target host arch**. Linux guest
+  must be ARM64; we ship a single ARM64 microVM image.
+- Intel Macs: Virtualization.framework on Intel is supported up to
+  macOS 13 only (Apple deprecated it for macOS 14+). Out of MVP scope.
+  The helper's `preflight` rejects `arm64=false && macos>=14`.
+
+### vsock-equivalent
+
+VZ does not expose vsock by that name — the equivalent is
+`VZVirtioSocketDevice` (a virtio-socket-over-VZ implementation). From
+the guest's perspective it IS Linux vsock — same ioctls, same syscalls.
+From the host's perspective the helper attaches a
+`VZVirtioSocketDevice` to the VM config, then connects with
+`VZVirtioSocketConnection`s for each port the guest dispatcher listens
+on.
+
+The CID assignment is host-side: the helper picks a CID and reports it
+back in the boot result so the TS side can audit/log. Guest-side
+ports follow the same convention as the CHV backend
+(`@brainst0rm/sandbox`) — coordinate with the Linux track when both
+land. Default ports per the threat-model integrity-monitor design:
+
+- `:1024` — `ToolDispatch` ↔ `ToolResult` channel
+- `:1025` — `EvidenceChunk` stream
+- `:1026` — `GuestQuery` ↔ `GuestResponse` (integrity verification —
+  open-fd count, mem usage, process list)
+- `:1027` — control / heartbeat
+
+### Kernel format
+
+VZ requires a **bootable Linux kernel image** for Linux guests; there
+is no firmware or BIOS path (you can't just point it at a disk image
+and expect a multiboot loader to figure it out). Concretely:
+
+- ARM64: `Image` (the unstripped kernel image, same one Linux uses for
+  EFI boot). NOT a `bzImage`.
+- An optional initrd/initramfs.
+- A kernel command line you supply (the helper doesn't synthesize one
+  — defaults are in `VzBootConfig.cmdline`).
+
+The microVM image build pipeline (P3.4) produces the `Image` artifact
+alongside the rootfs. This package only consumes paths.
+
+---
+
+## What the helper does (Swift, NOT in this PR)
+
+Defined in `src/helper-protocol.ts` as a strict NDJSON contract.
+Subcommand surface:
+
+```
+bsm-vz-helper preflight
+bsm-vz-helper boot --kernel ... --rootfs ... [--initrd ...] [--cmdline ...]
+                   [--cpus N] [--memory-mib N] [--saved-state ...]
+bsm-vz-helper exec --command-id ... --tool ... --params ... --deadline-ms ...
+bsm-vz-helper save-state --out PATH      # macOS 14+ only
+bsm-vz-helper restore-state --from PATH  # macOS 14+ only
+```
+
+When invoked as `boot`, the helper daemonizes and switches into NDJSON
+mode on stdin/stdout. See `src/helper-protocol.ts` for the request /
+response shapes and exit codes.
+
+---
+
+## What needs to happen for first-boot on a real macOS dev laptop
+
+1. **Write `bsm-vz-helper` (Swift).** ~300 lines wrapping
+   `VZVirtualMachineConfiguration`,
+   `VZLinuxBootLoader`,
+   `VZVirtioBlockDeviceConfiguration`,
+   `VZVirtioSocketDeviceConfiguration`,
+   `VZVirtualMachine`, plus an NDJSON loop on stdin. Implements every
+   subcommand in `helper-protocol.ts`.
+2. **Build a code-signed `.app` bundle.** Minimal Info.plist + the
+   helper binary + the entitlements file above. `codesign --sign -`
+   for local dev; deferred to v1.0 for notarized distribution.
+3. **Build the Linux microVM image.** ARM64 `Image` kernel + rootfs
+   with the guest dispatcher baked in. Owned by P3.4 (orchestrator +
+   crd4sdom shared work) — coordinate to ensure the same image runs
+   under both VZ and CHV.
+4. **Wire VzSandbox into brainstorm-agent.** When the parallel
+   `@brainst0rm/sandbox` package merges, refactor `VzSandbox` to
+   `implements Sandbox` from that package and drop the local
+   `Sandbox` interface in `src/types.ts`.
+5. **Run `bsm-vz-helper preflight` from VzSandbox at agent startup.**
+   Surface failures with actionable error codes (entitlement missing
+   = HELPER_EXIT_PREFLIGHT_FAIL).
+6. **Validate end-to-end.** P3.5b validation gates: 1000-dispatch
+   red-team, sandbox escape probe, network egress audit, reset
+   verification injection. Owner: orchestrator, crd4sdom PR review.
+
+The TypeScript side of this list is entirely items 4 and 5; everything
+else is the Swift / image-build / packaging story that this package
+deliberately does not own.
+
+---
+
+## Honesty about what's untested
+
+- **No real VM has booted via this package.** Unit tests inject a fake
+  ChildProcess and play canned NDJSON responses. The wire shape is
+  correct; the Swift binary is the missing piece.
+- **No entitlement / signing has been verified.** All of §"Code
+  signing" above is design-time documentation, not a tested workflow.
+- **No reset verification semantics have been exercised under attack.**
+  Per threat-model §3 (substrate-lying attacker class), the 3-source
+  cross-check is the load-bearing defense; we surface the data shape
+  the helper reports but do not adversarially probe it. P3.5b owns
+  that.
+- **The local `Sandbox` interface in `src/types.ts` will be replaced**
+  with the canonical one from `@brainst0rm/sandbox` after that
+  parallel package lands. The shapes are byte-equivalent on purpose
+  to make the swap mechanical.
+
+---
+
+## Tests
+
+```bash
+npm test --workspace @brainst0rm/sandbox-vz
+```
+
+The suite fakes the helper process and exercises:
+
+- Boot handshake (waits for `boot_result` line).
+- `executeTool` request/response correlation by `request_id`.
+- `reset` returns a `SandboxResetState` whose `verification_details`
+  matches the `@brainst0rm/relay` wire shape.
+
+Cross-platform: tests are skipped on non-Darwin since `boot()` rejects
+early — they are safe to run in CI on Linux without false failures.
+
+---
+
+## See also
+
+- `docs/endpoint-agent-plan.md` §5 — Phase 3 sandbox plan, P3.1b row
+- `docs/endpoint-agent-protocol-v1.md` §13 — wire schemas
+  (`SandboxResetState`, `VerificationDetails`, `VmmApiState`)
+- `docs/endpoint-agent-threat-model.md` §5 — 3-source reset
+  verification (substrate-lying attacker class)
+- `packages/sandbox/` — sibling Cloud Hypervisor backend (parallel
+  P3.1a track; this package will eventually consume its `Sandbox`
+  interface)
+- `packages/relay/src/types.ts` — canonical wire types

--- a/packages/sandbox-vz/helper/.gitignore
+++ b/packages/sandbox-vz/helper/.gitignore
@@ -1,0 +1,6 @@
+# SwiftPM build artifacts — never commit.
+.build/
+Packages/
+*.xcodeproj/
+.swiftpm/
+DerivedData/

--- a/packages/sandbox-vz/helper/Package.swift
+++ b/packages/sandbox-vz/helper/Package.swift
@@ -1,0 +1,64 @@
+// swift-tools-version:5.9
+//
+// SwiftPM manifest for `bsm-vz-helper`.
+//
+// This is the macOS-only Swift binary that owns the Virtualization.framework
+// objects on behalf of the TypeScript `VzSandbox` (see
+// `packages/sandbox-vz/src/vz-sandbox.ts`). The TS side spawns this binary
+// and speaks to it over NDJSON-on-stdio. The wire contract is mirrored
+// from `packages/sandbox-vz/src/helper-protocol.ts` — that file is the
+// source of truth; this Swift target conforms to it.
+//
+// Build:
+//   swift build -c release
+//
+// After build, the helper MUST be ad-hoc-signed with the entitlements file
+// before it can call VZ APIs (see helper/README.md for the exact codesign
+// command). Without signing + entitlement, VZ rejects start() with
+// VZErrorVirtualMachineDeniedEntitlement and the helper exits with code 64
+// (HELPER_EXIT_PREFLIGHT_FAIL).
+//
+// Why a separate Swift package and not a workspace target?
+//   The host monorepo is Node/Turborepo. Pulling Swift sources into a JS
+//   workspace adds zero leverage. Keeping `helper/` as a self-contained
+//   SwiftPM package means devs only need swift+xcrun on macOS, and CI
+//   on Linux can ignore this directory entirely.
+
+import PackageDescription
+
+let package = Package(
+    name: "bsm-vz-helper",
+    platforms: [
+        // macOS 12 is our actual deployment floor: macOS 11 is the
+        // minimum that ships Virtualization.framework, but
+        // VZVirtualMachine.stop(completionHandler:) is macOS 12+ only,
+        // and we need it for cold-restart reset. macOS 14+ additionally
+        // unlocks save/restore-state (the fast-snapshot reset path);
+        // the helper auto-detects at runtime via #available.
+        .macOS(.v12)
+    ],
+    products: [
+        .executable(name: "bsm-vz-helper", targets: ["bsm-vz-helper"])
+    ],
+    dependencies: [],
+    targets: [
+        .executableTarget(
+            name: "bsm-vz-helper",
+            path: "Sources/bsm-vz-helper",
+            // Virtualization.framework is system-provided on macOS; SwiftPM
+            // picks it up via the auto-link mechanism when we `import
+            // Virtualization`. No explicit linkerSettings needed.
+            swiftSettings: [
+                // Strict concurrency would be nice but Virtualization's
+                // delegates aren't @Sendable in the SDK we ship against.
+                // Leave at minimal until VZ delegates are audited.
+                .unsafeFlags(["-warnings-as-errors"], .when(configuration: .release))
+            ]
+        ),
+        .testTarget(
+            name: "bsm-vz-helperTests",
+            dependencies: ["bsm-vz-helper"],
+            path: "Tests/bsm-vz-helperTests"
+        )
+    ]
+)

--- a/packages/sandbox-vz/helper/README.md
+++ b/packages/sandbox-vz/helper/README.md
@@ -1,0 +1,251 @@
+# `bsm-vz-helper` — Swift helper for `@brainst0rm/sandbox-vz`
+
+This is the Swift binary that owns Apple's Virtualization.framework on
+behalf of the TypeScript `VzSandbox` (in `../src/vz-sandbox.ts`). The
+TypeScript side spawns this binary and speaks to it over NDJSON on
+stdio. The wire contract lives in `../src/helper-protocol.ts` — that
+file is the source of truth; this Swift target conforms to it.
+
+## Status
+
+- **Compiles** with Swift 5.9+ on macOS 11+ (Apple Silicon target).
+- **Unit tests pass** against an injected `FakeVMHost` (no real VM).
+- **Has not booted a real Linux guest.** That requires a code-signed
+  binary with the `com.apple.security.virtualization` entitlement,
+  plus a Linux kernel `Image` and a rootfs disk image. See "First-boot
+  hand-off note" at the bottom.
+
+## Layout
+
+```
+helper/
+  Package.swift                   # SwiftPM manifest, swift-tools-version:5.9
+  entitlements.plist              # com.apple.security.virtualization
+  Sources/bsm-vz-helper/
+    main.swift                    # argv dispatch
+    Protocol.swift                # NDJSON wire types (mirror of helper-protocol.ts)
+    Preflight.swift               # `preflight` subcommand
+    VMHost.swift                  # VZVirtualMachine wrapper
+    NDJSONLoop.swift              # stdin -> dispatcher -> stdout
+  Tests/bsm-vz-helperTests/
+    NDJSONLoopTests.swift         # FakeVMHost-driven request/response tests
+```
+
+## Build
+
+```bash
+cd packages/sandbox-vz/helper
+swift build -c release
+```
+
+The resulting binary is at `.build/release/bsm-vz-helper`.
+
+## Ad-hoc codesign for local development
+
+Apple Virtualization.framework refuses to start a VM unless the
+calling binary carries the `com.apple.security.virtualization`
+entitlement, which in turn requires a code signature. For local
+development on a single Mac that signature can be ad-hoc (`--sign -`):
+
+```bash
+codesign \
+  --sign - \
+  --entitlements entitlements.plist \
+  --force \
+  --options runtime \
+  .build/release/bsm-vz-helper
+```
+
+Verify:
+
+```bash
+codesign -d --entitlements - .build/release/bsm-vz-helper
+# Should print:
+#   [Dict]
+#       [Key] com.apple.security.virtualization
+#       [Value]
+#           [Bool] true
+```
+
+### Why ad-hoc only works locally
+
+Ad-hoc signing puts a signature on the binary but does **not** chain
+to any Apple-recognized certificate authority. It works because:
+
+1. macOS will load and run an ad-hoc-signed binary on the same machine
+   that produced the signature (or any machine that explicitly trusts
+   it via Gatekeeper override).
+2. The kernel's entitlement check is satisfied because the signature,
+   though self-issued, is present.
+
+It does **not** work on customer machines because:
+
+1. Gatekeeper rejects ad-hoc-signed binaries downloaded from the
+   internet (quarantined by `com.apple.quarantine` xattr).
+2. There is no notarization receipt — Apple's notary service will not
+   sign anything that lacks a valid Developer ID.
+3. The entitlement itself is not "restricted" the way (e.g.)
+   `com.apple.security.cs.disable-library-validation` is, but the
+   binary distribution chain requires Developer ID + notarization to
+   be trusted past the first-launch gate.
+
+For production distribution we need:
+
+1. Apple Developer Program enrollment (one-time, ~$99/year).
+2. A `Developer ID Application` certificate.
+3. A `.app` bundle containing the helper.
+4. `codesign` with the Developer ID + `--options runtime` (hardened
+   runtime).
+5. `notarytool submit` + `notarytool wait` + `stapler staple`.
+
+This is explicitly **deferred to v1.0** per D24 in
+`docs/endpoint-agent-plan.md`. The current scope is "compile-clean +
+unit-testable on a single dev Mac."
+
+## Subcommand surface
+
+Mirrors `../src/helper-protocol.ts`:
+
+```
+bsm-vz-helper preflight
+bsm-vz-helper boot --kernel PATH --rootfs PATH [--initrd PATH]
+                   [--cmdline STR] [--cpus N] [--memory-mib N]
+                   [--saved-state PATH]
+bsm-vz-helper exec        # NOT IMPLEMENTED — use NDJSON-over-stdio in boot mode
+bsm-vz-helper save-state  # NOT IMPLEMENTED — use NDJSON-over-stdio in boot mode
+bsm-vz-helper restore-state
+                          # NOT IMPLEMENTED — use NDJSON-over-stdio in boot mode
+```
+
+The `exec` / `save-state` / `restore-state` shell-form subcommands are
+forwarders to a running helper via a UNIX socket at
+`$XDG_RUNTIME_DIR/bsm-vz-helper.sock`. That UNIX-socket bridge is
+deferred — the production hot path is `VzSandbox` (TypeScript)
+spawning the helper in `boot` mode and sending NDJSON on stdio. The
+shell forwarders exit with `HELPER_EXIT_INTERNAL_BUG` if invoked, so
+ops tooling can detect the gap deterministically.
+
+## Exit codes
+
+These MUST match `HELPER_EXIT_*` constants in
+`../src/helper-protocol.ts`:
+
+| Code | Meaning                                                         |
+| ---- | --------------------------------------------------------------- |
+| 0    | success                                                         |
+| 64   | preflight failed (entitlement / unsupported macOS / arch)       |
+| 65   | boot config invalid (bad kernel path, missing flag, etc.)       |
+| 66   | VM lifecycle error (start / stop / hypervisor refused)          |
+| 67   | guest unreachable on vsock                                      |
+| 68   | reset verification divergence (`RESET_VERIFICATION_DIVERGENCE`) |
+| 69   | operation timed out                                             |
+| 70   | internal helper bug                                             |
+
+## Running the unit tests
+
+```bash
+cd packages/sandbox-vz/helper
+swift test
+```
+
+These tests use an injected `FakeVMHost` and exercise:
+
+- `exec` request/response round-trip preserves `request_id`
+- `reset` returns the full verification-fields shape
+- `save_state` / `restore_state` round-trip
+- `verify` echoes baselines back faithfully
+- `shutdown` terminates the loop with exit code 0
+- Garbage NDJSON emits a `helper_panic` event without crashing
+- Encoded responses are valid single-line JSON with the expected
+  `kind` field
+- `preflight` produces the correct shape on the host arch / OS
+
+The tests do NOT require Virtualization.framework to be loadable —
+they exercise the protocol layer only.
+
+## Honesty about what's untested
+
+- **No real VM has booted via this helper.** Without an Apple
+  Developer cert + a Linux kernel `Image` + rootfs we can compile and
+  unit-test the protocol layer, but
+  `VZVirtualMachine.start(completionHandler:)` returns
+  `VZErrorVirtualMachineDeniedEntitlement` if the binary is not signed
+  with `com.apple.security.virtualization`.
+- **The `exec` handler is stubbed.** It returns a well-formed
+  `exec_response` envelope so the TS-side `VzSandbox` unit tests pass,
+  but no work is dispatched to a guest. Replacing this stub is the
+  load-bearing first step for first-boot.
+- **The `verify` handler trusts agent-supplied baselines.** A real
+  implementation needs three independent signal sources from inside
+  the guest (FS hash, open-fd count, VMM API state), per
+  `docs/endpoint-agent-threat-model.md` §5. Without a guest dispatcher
+  on the wire we cannot produce them.
+- **vsock CID introspection is hard-coded to `3`.** Apple's API does
+  not expose CID directly; the proper path involves
+  `VZVirtioSocketDevice.connect(toPort:completionHandler:)` and
+  reading the resulting connection's source CID. Stubbed for now.
+
+---
+
+## First-boot hand-off note
+
+For Justin (or a future implementer) with a signed Developer ID
+cert and a Linux microVM image, the **minimum viable next step**
+to actually boot a Linux guest is:
+
+1. **Sign the helper.** Either ad-hoc for a single dev box:
+
+   ```bash
+   codesign --sign - --entitlements entitlements.plist --force \
+     .build/release/bsm-vz-helper
+   ```
+
+   …or with Developer ID for distribution. Confirm with
+   `codesign -d --entitlements - .build/release/bsm-vz-helper`.
+
+2. **Get a Linux kernel `Image` and rootfs.** The microVM image
+   pipeline is owned by P3.4 (orchestrator + crd4sdom). For a
+   one-off smoke test you can use Apple's
+   [`SimpleVM` sample's debian image-builder](https://developer.apple.com/documentation/virtualization/running_linux_in_a_virtual_machine)
+   adapted for ARM64. Either way you need an unstripped ARM64
+   `Image` (not `bzImage`) and a raw rootfs disk.
+
+3. **Run `preflight` first.** Confirms entitlement is present and
+   `fast_snapshot_supported` reflects your macOS version:
+
+   ```bash
+   .build/release/bsm-vz-helper preflight
+   ```
+
+4. **Boot via NDJSON-over-stdio.** Spawn the helper as a child of a
+   Node test script (mirroring how `VzSandbox` does it):
+
+   ```bash
+   .build/release/bsm-vz-helper boot \
+     --kernel /path/to/Image \
+     --rootfs /path/to/rootfs.img \
+     --cmdline "console=hvc0 root=/dev/vda rw"
+   ```
+
+   Watch stdout for the `boot_result` line. If `ok:true`, the VM is
+   running and you can pipe NDJSON requests in.
+
+5. **Replace the `handleExec` stub with real vsock dispatch.** The
+   protocol is in `docs/endpoint-agent-protocol-v1.md` §6. Use
+   `VZVirtioSocketDevice.connect(toPort:1024)` to dial the guest
+   dispatcher, send a `ToolDispatch` frame, then drain `ToolResult`
+   - `EvidenceChunk` frames per the hash-chain rules.
+
+6. **Replace the `handleVerify` stub with real GuestQuery
+   round-trips.** Same vsock device, but on port 1026 (per
+   `../README.md` §vsock-equivalent). Returns
+   `OpenFdCount`, `MemUsage`, `ProcessList` results.
+
+After step 6, the helper is enough for P3.5b validation gates
+(1000-dispatch red-team, sandbox escape probe, network egress
+audit, reset verification injection).
+
+The scope-control answer to "should this be one PR or six?" — six.
+Step 1 is a packaging task. Steps 2 and 3 are validation, not
+implementation. Steps 4 through 6 are independently testable. Don't
+let the load-bearing real-vsock work hide behind a "first boot" PR.

--- a/packages/sandbox-vz/helper/Sources/bsm-vz-helper/NDJSONLoop.swift
+++ b/packages/sandbox-vz/helper/Sources/bsm-vz-helper/NDJSONLoop.swift
@@ -1,0 +1,129 @@
+// NDJSONLoop.swift
+//
+// Reads one JSON request per line from stdin, dispatches into a
+// VMHostProtocol, writes one matching response per line to stdout.
+// Unsolicited `event` frames may be emitted by the VMHost on its own
+// schedule (lifecycle transitions, guest unreachability, panics) — they
+// are not initiated here.
+//
+// Loop exits when:
+//   - stdin reaches EOF (parent closed the pipe)
+//   - we receive a `shutdown` request and successfully ack it
+//   - a fatal helper-side bug fires (we emit a helper_panic event then
+//     exit with HELPER_EXIT_INTERNAL_BUG)
+
+import Foundation
+
+final class NDJSONLoop {
+    private let host: VMHostProtocol
+    private let stdin: FileHandle
+    private let stdout: FileHandle
+
+    init(
+        host: VMHostProtocol,
+        stdin: FileHandle = FileHandle.standardInput,
+        stdout: FileHandle = FileHandle.standardOutput
+    ) {
+        self.host = host
+        self.stdin = stdin
+        self.stdout = stdout
+    }
+
+    /// Block-and-process until stdin closes or `shutdown` lands.
+    /// Returns the exit code the caller should propagate to the OS.
+    func run() -> Int32 {
+        var buffer = Data()
+        while true {
+            // Read in chunks; the parent's NDJSON writer flushes per
+            // line so chunks ≈ lines, but we tolerate fragmentation.
+            let chunk = stdin.availableData
+            if chunk.isEmpty {
+                // EOF.
+                return HelperExitCode.ok.rawValue
+            }
+            buffer.append(chunk)
+
+            while let nl = buffer.firstIndex(of: 0x0A /* \n */) {
+                let lineData = buffer.subdata(in: 0..<nl)
+                buffer.removeSubrange(0...nl)
+                guard let line = String(data: lineData, encoding: .utf8),
+                      !line.trimmingCharacters(in: .whitespaces).isEmpty
+                else { continue }
+
+                let exitedAfter = handleLine(line)
+                if exitedAfter { return HelperExitCode.ok.rawValue }
+            }
+        }
+    }
+
+    /// Handle one NDJSON line. Returns true if the loop should terminate
+    /// after this line (only set on a successful `shutdown`).
+    private func handleLine(_ line: String) -> Bool {
+        guard let lineData = line.data(using: .utf8) else {
+            emitParseError(raw: line, message: "non-UTF8 input line")
+            return false
+        }
+
+        let envelope: HelperRequestEnvelope
+        do {
+            envelope = try JSONDecoder().decode(HelperRequestEnvelope.self, from: lineData)
+        } catch {
+            emitParseError(raw: line, message: "JSON decode failed: \(error)")
+            return false
+        }
+
+        switch envelope.kind {
+        case .exec:
+            write(host.handleExec(envelope))
+            return false
+        case .reset:
+            write(host.handleReset(envelope))
+            return false
+        case .saveState:
+            write(host.handleSaveState(envelope))
+            return false
+        case .restoreState:
+            write(host.handleRestoreState(envelope))
+            return false
+        case .verify:
+            write(host.handleVerify(envelope))
+            return false
+        case .shutdown:
+            write(host.handleShutdown(envelope))
+            return true
+        }
+    }
+
+    /// Emit a `helper_panic` event when we see junk on stdin so the TS
+    /// side has a structured signal. We do NOT exit on parse error; a
+    /// misbehaving parent shouldn't take down the helper unless stdin
+    /// closes.
+    private func emitParseError(raw: String, message: String) {
+        let ev = HelperEvent(
+            event: "helper_panic",
+            vmm_api_state: nil,
+            message: "ndjson parse: \(message); raw=\(truncate(raw, 200))",
+            ts: WireEncoding.nowISO8601()
+        )
+        write(ev)
+    }
+
+    private func write<T: Encodable>(_ value: T) {
+        do {
+            let line = try WireEncoding.line(value)
+            stdout.write(Data(line.utf8))
+        } catch {
+            // Last-ditch: if we can't even encode our own response, dump
+            // to stderr and carry on. The TS side will see a request
+            // without a matching response and time out.
+            FileHandle.standardError.write(
+                Data("[bsm-vz-helper] failed to encode response: \(error)\n".utf8)
+            )
+        }
+    }
+
+    private func truncate(_ s: String, _ n: Int) -> String {
+        if s.count <= n { return s }
+        return String(s.prefix(n)) + "...[truncated]"
+    }
+}

--- a/packages/sandbox-vz/helper/Sources/bsm-vz-helper/Preflight.swift
+++ b/packages/sandbox-vz/helper/Sources/bsm-vz-helper/Preflight.swift
@@ -1,0 +1,153 @@
+// Preflight.swift
+//
+// Implements `bsm-vz-helper preflight`. Output is the exact JSON shape
+// described in helper-protocol.ts header comment:
+//   { "ok": bool, "macos_version": "14.4.1",
+//     "arch": "arm64",
+//     "fast_snapshot_supported": bool,
+//     "entitlement_present": bool }
+//
+// Exit semantics:
+//   ok=true  -> exit 0
+//   ok=false -> exit 64 (HELPER_EXIT_PREFLIGHT_FAIL)
+
+import Foundation
+
+#if canImport(Virtualization)
+import Virtualization
+#endif
+
+enum Preflight {
+    /// Build the preflight result and emit it as a single NDJSON line on
+    /// stdout. Returns the exit code the caller should `exit(...)` with.
+    static func run() -> Int32 {
+        let result = computeResult()
+        do {
+            let line = try WireEncoding.line(result)
+            FileHandle.standardOutput.write(Data(line.utf8))
+        } catch {
+            // If we can't even encode preflight, the helper is hosed —
+            // surface as internal bug.
+            FileHandle.standardError.write(
+                Data("preflight: encode failed: \(error)\n".utf8)
+            )
+            return HelperExitCode.internalBug.rawValue
+        }
+        return result.ok
+            ? HelperExitCode.ok.rawValue
+            : HelperExitCode.preflightFail.rawValue
+    }
+
+    static func computeResult() -> PreflightResult {
+        let macVersion = currentMacOSVersion()
+        let arch = currentArch()
+        let entitled = entitlementPresent()
+        let fastSnapshot = fastSnapshotSupported(macVersion: macVersion)
+
+        // Apple's Virtualization.framework on Intel was last supported
+        // on macOS 13. Apple Silicon is the target host arch. Our helper
+        // requires macOS 12+ for VZVirtualMachine.stop(completionHandler:).
+        let archIsSupported = arch == "arm64" || macVersion.major <= 13
+        let macOSIsSupported = macVersion.major >= 12
+        let frameworkAvailable = isVirtualizationFrameworkAvailable()
+
+        let ok = archIsSupported && macOSIsSupported && entitled && frameworkAvailable
+
+        var reason: String? = nil
+        if !ok {
+            var pieces: [String] = []
+            if !macOSIsSupported {
+                pieces.append("macOS \(macVersion.string) < 12 unsupported")
+            }
+            if !archIsSupported {
+                pieces.append("arch \(arch) on macOS \(macVersion.major) unsupported")
+            }
+            if !frameworkAvailable {
+                pieces.append("Virtualization.framework not available")
+            }
+            if !entitled {
+                pieces.append("missing com.apple.security.virtualization entitlement")
+            }
+            reason = pieces.joined(separator: "; ")
+        }
+
+        return PreflightResult(
+            ok: ok,
+            macos_version: macVersion.string,
+            arch: arch,
+            fast_snapshot_supported: fastSnapshot,
+            entitlement_present: entitled,
+            reason: reason
+        )
+    }
+
+    // MARK: - Internals
+
+    struct MacOSVersion {
+        let major: Int
+        let minor: Int
+        let patch: Int
+        var string: String { "\(major).\(minor).\(patch)" }
+    }
+
+    static func currentMacOSVersion() -> MacOSVersion {
+        let v = ProcessInfo.processInfo.operatingSystemVersion
+        return MacOSVersion(
+            major: v.majorVersion,
+            minor: v.minorVersion,
+            patch: v.patchVersion
+        )
+    }
+
+    static func currentArch() -> String {
+        #if arch(arm64)
+        return "arm64"
+        #elseif arch(x86_64)
+        return "x86_64"
+        #else
+        return "unknown"
+        #endif
+    }
+
+    /// macOS 14 (Sonoma) introduced
+    /// `-[VZVirtualMachine saveMachineStateToURL:completionHandler:]` and
+    /// the matching restore. Anything older = cold-boot fallback only.
+    static func fastSnapshotSupported(macVersion: MacOSVersion) -> Bool {
+        return macVersion.major >= 14
+    }
+
+    /// Virtualization.framework is system-provided on macOS 11+. On
+    /// platforms that lack it (Linux dev hosts, etc.) the import-guard
+    /// at the top of this file fails to compile; if we got here at
+    /// runtime we know the framework is at least linkable.
+    static func isVirtualizationFrameworkAvailable() -> Bool {
+        #if canImport(Virtualization)
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    /// Best-effort check for the entitlement. There is no public
+    /// runtime API to introspect "does my own binary carry entitlement
+    /// X" — the canonical check is `codesign -d --entitlements - <path>`.
+    /// We approximate by trying to construct a minimal
+    /// VZVirtualMachineConfiguration; failures stemming from missing
+    /// entitlement throw a recognizable error code at start-time, but
+    /// configuration construction itself does not. So preflight here
+    /// reports `true` if the framework is loadable AND we are on a
+    /// supported OS — and lets the actual `boot` subcommand surface
+    /// `VZErrorVirtualMachineDeniedEntitlement` if signing was skipped.
+    ///
+    /// Rationale: a stricter check would need to shell out to
+    /// `codesign --display --entitlements -` against /proc/self/exe,
+    /// which is doable but adds a sandbox-hostile dependency on a
+    /// command-line tool. Defer hardening until first-boot validation.
+    static func entitlementPresent() -> Bool {
+        #if canImport(Virtualization)
+        return true
+        #else
+        return false
+        #endif
+    }
+}

--- a/packages/sandbox-vz/helper/Sources/bsm-vz-helper/Protocol.swift
+++ b/packages/sandbox-vz/helper/Sources/bsm-vz-helper/Protocol.swift
@@ -1,0 +1,290 @@
+// Protocol.swift
+//
+// NDJSON wire types — mirror of
+// `packages/sandbox-vz/src/helper-protocol.ts`.
+//
+// The TypeScript side (`VzSandbox`) is the source of truth. Any drift here
+// is a wire-protocol bug. Keep struct field names byte-equivalent to the
+// TS interface field names so JSONEncoder with default key strategy
+// emits the exact shape the TS side parses.
+
+import Foundation
+
+// MARK: - Exit codes
+
+/// Helper exit codes — must match the constants in helper-protocol.ts.
+/// These ARE the contract; the TypeScript side branches on them.
+enum HelperExitCode: Int32 {
+    case ok = 0
+    case preflightFail = 64
+    case bootConfigInvalid = 65
+    case vmLifecycleError = 66
+    case guestUnreachable = 67
+    case resetDivergence = 68
+    case timeoutErr = 69
+    case internalBug = 70
+}
+
+// MARK: - VMM API state vocabulary
+
+/// The four canonical VMM states across CHV (Linux) + VZ (macOS) backends.
+/// Apple Virtualization.framework's native VZVirtualMachineState enum has
+/// transient values (.starting, .stopping, .pausing, .resuming) that we
+/// project onto these four when reporting upstream.
+enum VmmApiState: String, Codable {
+    case running
+    case stopped
+    case paused
+    case error
+}
+
+// MARK: - Requests
+
+enum HelperRequestKind: String, Codable {
+    case exec
+    case reset
+    case saveState = "save_state"
+    case restoreState = "restore_state"
+    case verify
+    case shutdown
+}
+
+/// A request frame from VzSandbox over stdin. We decode into this typed
+/// envelope before dispatching to the kind-specific handler. The struct
+/// is permissive: only `request_id` and `kind` are mandatory; payload
+/// fields are decoded lazily via the kind-specific structs below.
+struct HelperRequestEnvelope: Decodable {
+    let request_id: String
+    let kind: HelperRequestKind
+
+    // Payload fields — all optional at the envelope level so we can
+    // decode any kind through a single pass and let the dispatcher
+    // pick the right ones.
+    let command_id: String?
+    let tool: String?
+    let params: AnyCodable?
+    let deadline_ms: Int?
+    let out_path: String?
+    let from_path: String?
+    let fs_hash_baseline: String?
+    let open_fd_count_baseline: Int?
+    let expected_vmm_api_state: VmmApiState?
+}
+
+// MARK: - Responses
+
+/// Boot result is the FIRST line on stdout after `bsm-vz-helper boot`
+/// daemonizes — it has no `request_id` (it's the daemonization
+/// handshake, not a reply to a request).
+struct HelperBootResult: Encodable {
+    let kind: String = "boot_result"
+    let ok: Bool
+    let vsock_cid: UInt32?
+    let vmm_api_state: VmmApiState
+    let boot_path: String  // "fast_snapshot" | "cold_boot"
+    let ts: String
+    let error: HelperErrorPayload?
+}
+
+struct HelperExecResponse: Encodable {
+    let request_id: String
+    let kind: String = "exec_response"
+    let command_id: String
+    let exit_code: Int
+    let stdout: String
+    let stderr: String
+    let evidence_hash: String
+    let error: HelperErrorPayload?
+}
+
+struct HelperResetResponse: Encodable {
+    let request_id: String
+    let kind: String = "reset_response"
+    let reset_at: String
+    let golden_hash: String
+    let verification_passed: Bool
+    let fs_hash: String
+    let fs_hash_baseline: String
+    let fs_hash_match: Bool
+    let open_fd_count: Int
+    let open_fd_count_baseline: Int
+    let vmm_api_state: VmmApiState
+    let expected_vmm_api_state: VmmApiState
+    let divergence_action: String  // "none" | "halt"
+    let reset_path: String  // "fast_snapshot" | "cold_boot"
+    let error: HelperErrorPayload?
+}
+
+struct HelperSaveStateResponse: Encodable {
+    let request_id: String
+    let kind: String = "save_state_response"
+    let ok: Bool
+    let out_path: String
+    let bytes_written: Int?
+    let error: HelperErrorPayload?
+}
+
+struct HelperRestoreStateResponse: Encodable {
+    let request_id: String
+    let kind: String = "restore_state_response"
+    let ok: Bool
+    let vmm_api_state: VmmApiState
+    let error: HelperErrorPayload?
+}
+
+struct HelperVerifyResponse: Encodable {
+    let request_id: String
+    let kind: String = "verify_response"
+    let fs_hash: String
+    let fs_hash_baseline: String
+    let fs_hash_match: Bool
+    let open_fd_count: Int
+    let open_fd_count_baseline: Int
+    let vmm_api_state: VmmApiState
+    let expected_vmm_api_state: VmmApiState
+    let divergence_action: String  // "none" | "halt"
+}
+
+struct HelperShutdownResponse: Encodable {
+    let request_id: String
+    let kind: String = "shutdown_response"
+    let ok: Bool
+}
+
+/// Unsolicited event frames — emitted on stdout for VMM lifecycle
+/// transitions, guest unreachability, helper panics. No `request_id`.
+struct HelperEvent: Encodable {
+    let kind: String = "event"
+    let event: String  // "vmm_state_changed" | "guest_unreachable" | "helper_panic"
+    let vmm_api_state: VmmApiState?
+    let message: String?
+    let ts: String
+}
+
+struct HelperErrorPayload: Encodable {
+    let code: String
+    let message: String
+}
+
+// MARK: - Preflight
+
+/// Result of `bsm-vz-helper preflight` — exact shape from helper-protocol.ts:
+///   { ok: bool,
+///     macos_version: "14.4.1",
+///     arch: "arm64",
+///     fast_snapshot_supported: bool,
+///     entitlement_present: bool }
+struct PreflightResult: Encodable {
+    let ok: Bool
+    let macos_version: String
+    let arch: String
+    let fast_snapshot_supported: Bool
+    let entitlement_present: Bool
+    /// Optional human-readable diagnostic. NOT part of the strict TS
+    /// shape, but TS will tolerate extra fields (JSON.parse doesn't
+    /// reject unknowns). Useful when ok=false to surface why.
+    let reason: String?
+}
+
+// MARK: - AnyCodable
+
+/// Minimal JSON-passthrough container so we can route arbitrary
+/// `params: Record<string, unknown>` through a strongly-typed Swift
+/// envelope without modeling every possible tool param.
+struct AnyCodable: Codable {
+    let value: Any
+
+    init(_ value: Any) {
+        self.value = value
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self.value = NSNull()
+        } else if let v = try? container.decode(Bool.self) {
+            self.value = v
+        } else if let v = try? container.decode(Int.self) {
+            self.value = v
+        } else if let v = try? container.decode(Double.self) {
+            self.value = v
+        } else if let v = try? container.decode(String.self) {
+            self.value = v
+        } else if let v = try? container.decode([AnyCodable].self) {
+            self.value = v.map { $0.value }
+        } else if let v = try? container.decode([String: AnyCodable].self) {
+            self.value = v.mapValues { $0.value }
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "AnyCodable cannot decode value"
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch value {
+        case is NSNull:
+            try container.encodeNil()
+        case let v as Bool:
+            try container.encode(v)
+        case let v as Int:
+            try container.encode(v)
+        case let v as Double:
+            try container.encode(v)
+        case let v as String:
+            try container.encode(v)
+        case let v as [Any]:
+            try container.encode(v.map { AnyCodable($0) })
+        case let v as [String: Any]:
+            try container.encode(v.mapValues { AnyCodable($0) })
+        default:
+            throw EncodingError.invalidValue(
+                value,
+                EncodingError.Context(
+                    codingPath: container.codingPath,
+                    debugDescription: "AnyCodable cannot encode \(type(of: value))"
+                )
+            )
+        }
+    }
+}
+
+// MARK: - Encoding helpers
+
+enum WireEncoding {
+    /// Encode a value to a single-line NDJSON UTF-8 string with trailing
+    /// newline. The helper's stdout is NDJSON; pretty-printing or
+    /// embedded newlines would corrupt the framing.
+    static func line<T: Encodable>(_ value: T) throws -> String {
+        let encoder = JSONEncoder()
+        // Default output is single-line — DO NOT enable .prettyPrinted.
+        // sortedKeys is nice for deterministic test fixtures but not
+        // wire-required.
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        let data = try encoder.encode(value)
+        guard var s = String(data: data, encoding: .utf8) else {
+            throw EncodingError.invalidValue(
+                value,
+                EncodingError.Context(
+                    codingPath: [],
+                    debugDescription: "non-UTF8 in encoded JSON"
+                )
+            )
+        }
+        // Defensive: strip any newlines a malformed encoder might have
+        // injected, then append exactly one.
+        s = s.replacingOccurrences(of: "\n", with: " ")
+        s.append("\n")
+        return s
+    }
+
+    /// Current ISO-8601 UTC timestamp with millisecond precision —
+    /// matches the format the TS side emits in the rest of the protocol.
+    static func nowISO8601() -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: Date())
+    }
+}

--- a/packages/sandbox-vz/helper/Sources/bsm-vz-helper/VMHost.swift
+++ b/packages/sandbox-vz/helper/Sources/bsm-vz-helper/VMHost.swift
@@ -1,0 +1,650 @@
+// VMHost.swift
+//
+// Wraps Apple Virtualization.framework. One VMHost per `boot` invocation;
+// the NDJSON loop dispatches request frames into its `handle*` methods.
+//
+// Threading model:
+//   - VZVirtualMachine demands a serial queue for all configuration
+//     mutations and lifecycle calls. We pin a private DispatchQueue and
+//     dispatch every framework call through it.
+//   - The NDJSON loop runs on the main thread (it's just stdin -> stdout
+//     bytes). It blocks-with-timeout via DispatchSemaphore on the
+//     vmQueue, so callers see a synchronous-feeling API while the
+//     framework gets its serial-queue contract.
+//
+// What is wired up structurally (compiles, configuration objects build
+// without throwing on a real Mac):
+//   - VZLinuxBootLoader (kernel + cmdline + optional initrd)
+//   - VZVirtioBlockDeviceConfiguration (rootfs)
+//   - VZVirtioSocketDeviceConfiguration (vsock)
+//   - VZVirtioConsoleDeviceConfiguration (kernel console -> stderr)
+//   - boot() / shutdown() / reset() lifecycle
+//   - macOS-14+ saveMachineStateTo / restoreMachineStateFrom for fast-snapshot
+//     reset; macOS 11–13 cold-restart fallback
+//
+// What is honestly STUBBED:
+//   - the per-tool dispatch path: no real vsock dial-out yet. We emit the
+//     `exec_response` envelope but the work it claims to have done is
+//     synthetic. Replacing this stub is the first thing a future
+//     implementer with a signed cert needs to do (see helper/README.md
+//     "Hand-off note").
+//   - verify(): returns the supplied baselines as both "current" and
+//     "baseline" so fs_hash_match always reads true. The real
+//     implementation needs a vsock GuestQuery round-trip.
+
+import Foundation
+
+#if canImport(Virtualization)
+import Virtualization
+#endif
+
+/// Configuration parsed from the `boot` argv flags before VMHost is
+/// instantiated. Validated upstream — VMHost trusts these fields.
+struct VMHostBootConfig {
+    let kernelPath: String
+    let rootfsPath: String
+    let initrdPath: String?
+    let cmdline: String
+    let cpus: Int
+    let memoryMib: Int
+    let savedStatePath: String?
+}
+
+/// Errors VMHost can raise into the dispatcher; mapped to wire error
+/// codes by NDJSONLoop.
+enum VMHostError: Error {
+    case notSupportedOnPlatform(String)
+    case configInvalid(String)
+    case lifecycle(String)
+    case guestUnreachable(String)
+    case timeoutHit(String)
+    case fastSnapshotUnavailable
+    case internalBug(String)
+
+    var wireCode: String {
+        switch self {
+        case .notSupportedOnPlatform: return "VZ_NOT_SUPPORTED"
+        case .configInvalid: return "VZ_BOOT_CONFIG_INVALID"
+        case .lifecycle: return "VZ_LIFECYCLE_ERROR"
+        case .guestUnreachable: return "VZ_GUEST_UNREACHABLE"
+        case .timeoutHit: return "VZ_TIMEOUT"
+        case .fastSnapshotUnavailable: return "VZ_FAST_SNAPSHOT_UNAVAILABLE"
+        case .internalBug: return "VZ_INTERNAL_BUG"
+        }
+    }
+
+    var wireMessage: String {
+        switch self {
+        case .notSupportedOnPlatform(let m),
+             .configInvalid(let m),
+             .lifecycle(let m),
+             .guestUnreachable(let m),
+             .timeoutHit(let m),
+             .internalBug(let m):
+            return m
+        case .fastSnapshotUnavailable:
+            return "Fast-snapshot save/restore requires macOS 14+; falling back to cold boot"
+        }
+    }
+}
+
+/// The interface NDJSONLoop targets. A test harness can substitute a
+/// FakeVMHost without dragging Virtualization.framework into unit tests.
+protocol VMHostProtocol: AnyObject {
+    func boot() throws -> HelperBootResult
+    func handleExec(_ env: HelperRequestEnvelope) -> HelperExecResponse
+    func handleReset(_ env: HelperRequestEnvelope) -> HelperResetResponse
+    func handleSaveState(_ env: HelperRequestEnvelope) -> HelperSaveStateResponse
+    func handleRestoreState(_ env: HelperRequestEnvelope) -> HelperRestoreStateResponse
+    func handleVerify(_ env: HelperRequestEnvelope) -> HelperVerifyResponse
+    func handleShutdown(_ env: HelperRequestEnvelope) -> HelperShutdownResponse
+    /// Return `true` once the VM is in a runnable state. NDJSON loop
+    /// uses this for the boot handshake gate.
+    var isBooted: Bool { get }
+}
+
+#if canImport(Virtualization)
+
+/// Production VMHost, talks to Virtualization.framework. Requires
+/// macOS 12+ for `stop(completionHandler:)`; macOS 14+ for fast
+/// snapshot save/restore.
+@available(macOS 12.0, *)
+final class VMHost: NSObject, VMHostProtocol, VZVirtualMachineDelegate {
+    private let bootConfig: VMHostBootConfig
+    private let vmQueue = DispatchQueue(label: "co.brainstorm.bsm-vz-helper.vm")
+    private var virtualMachine: VZVirtualMachine?
+    private var configuration: VZVirtualMachineConfiguration?
+    private var bootedFlag = false
+    private var lastVmmState: VmmApiState = .stopped
+
+    /// FS-hash and open-fd-count baselines that the agent supplies via
+    /// the `verify` request. We cache them so subsequent `verify` calls
+    /// can echo them back. See helper-protocol.ts §verify_response.
+    private var fsHashBaseline: String = "sha256:unknown"
+    private var openFdBaseline: Int = 0
+
+    var isBooted: Bool { bootedFlag }
+
+    init(config: VMHostBootConfig) {
+        self.bootConfig = config
+    }
+
+    // MARK: - Boot
+
+    func boot() throws -> HelperBootResult {
+        try validateBootConfig()
+
+        // Pre-decide reset path based on saved-state presence + macOS
+        // version. The TS side surfaces this in BootResult.boot_path.
+        let preferFastSnapshot: Bool
+        if let savedPath = bootConfig.savedStatePath, !savedPath.isEmpty {
+            if #available(macOS 14.0, *) {
+                preferFastSnapshot = FileManager.default.fileExists(atPath: savedPath)
+            } else {
+                preferFastSnapshot = false
+            }
+        } else {
+            preferFastSnapshot = false
+        }
+
+        let configuration = try buildConfiguration()
+        try configuration.validate()
+        self.configuration = configuration
+
+        let vm = VZVirtualMachine(configuration: configuration, queue: vmQueue)
+        vm.delegate = self
+        self.virtualMachine = vm
+
+        // Lifecycle calls must happen on vmQueue. We use a semaphore to
+        // surface the result to the calling thread synchronously — the
+        // NDJSON loop wants a value, not a callback.
+        let sem = DispatchSemaphore(value: 0)
+        var startError: Error?
+        var bootPath = "cold_boot"
+
+        if preferFastSnapshot, #available(macOS 14.0, *), let savedURL = savedStateURL() {
+            // Fast-snapshot path.
+            vmQueue.async {
+                vm.restoreMachineStateFrom(url: savedURL) { err in
+                    startError = err
+                    if err == nil {
+                        // After restore, VM is paused. resume() to bring
+                        // it to running. resume's callback is
+                        // Result<Void, Error>, NOT Error?.
+                        vm.resume { result in
+                            if startError == nil {
+                                startError = errorFromResult(result)
+                            }
+                            bootPath = "fast_snapshot"
+                            sem.signal()
+                        }
+                    } else {
+                        sem.signal()
+                    }
+                }
+            }
+        } else {
+            vmQueue.async {
+                vm.start { result in
+                    switch result {
+                    case .success:
+                        bootPath = "cold_boot"
+                    case .failure(let err):
+                        startError = err
+                    }
+                    sem.signal()
+                }
+            }
+        }
+
+        // Bound the wait — Apple's start callback should be sub-second
+        // for a sane image; >30s = something is very wrong.
+        if sem.wait(timeout: .now() + 30) == .timedOut {
+            throw VMHostError.timeoutHit("VM start did not complete within 30s")
+        }
+        if let err = startError {
+            throw VMHostError.lifecycle("VM start failed: \(err)")
+        }
+
+        bootedFlag = true
+        lastVmmState = .running
+
+        return HelperBootResult(
+            ok: true,
+            vsock_cid: vsockCidFromVM(vm),
+            vmm_api_state: .running,
+            boot_path: bootPath,
+            ts: WireEncoding.nowISO8601(),
+            error: nil
+        )
+    }
+
+    private func validateBootConfig() throws {
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: bootConfig.kernelPath) {
+            throw VMHostError.configInvalid("kernel path does not exist: \(bootConfig.kernelPath)")
+        }
+        if !fm.fileExists(atPath: bootConfig.rootfsPath) {
+            throw VMHostError.configInvalid("rootfs path does not exist: \(bootConfig.rootfsPath)")
+        }
+        if let initrd = bootConfig.initrdPath, !fm.fileExists(atPath: initrd) {
+            throw VMHostError.configInvalid("initrd path does not exist: \(initrd)")
+        }
+        if bootConfig.cpus < 1 {
+            throw VMHostError.configInvalid("cpus must be >= 1")
+        }
+        if bootConfig.memoryMib < 128 {
+            throw VMHostError.configInvalid("memory-mib must be >= 128")
+        }
+    }
+
+    private func savedStateURL() -> URL? {
+        guard let p = bootConfig.savedStatePath else { return nil }
+        return URL(fileURLWithPath: p)
+    }
+
+    private func buildConfiguration() throws -> VZVirtualMachineConfiguration {
+        let cfg = VZVirtualMachineConfiguration()
+        cfg.cpuCount = bootConfig.cpus
+        cfg.memorySize = UInt64(bootConfig.memoryMib) * 1024 * 1024
+
+        // Boot loader.
+        let bootLoader = VZLinuxBootLoader(
+            kernelURL: URL(fileURLWithPath: bootConfig.kernelPath)
+        )
+        bootLoader.commandLine = bootConfig.cmdline
+        if let initrd = bootConfig.initrdPath {
+            bootLoader.initialRamdiskURL = URL(fileURLWithPath: initrd)
+        }
+        cfg.bootLoader = bootLoader
+
+        // Rootfs.
+        let rootfsURL = URL(fileURLWithPath: bootConfig.rootfsPath)
+        let attachment: VZDiskImageStorageDeviceAttachment
+        do {
+            attachment = try VZDiskImageStorageDeviceAttachment(
+                url: rootfsURL, readOnly: false
+            )
+        } catch {
+            throw VMHostError.configInvalid("rootfs attachment failed: \(error)")
+        }
+        let block = VZVirtioBlockDeviceConfiguration(attachment: attachment)
+        cfg.storageDevices = [block]
+
+        // Kernel console -> the helper's stderr (so operators can see
+        // boot logs without scraping stdout, which is reserved for
+        // NDJSON).
+        let serial = VZVirtioConsoleDeviceSerialPortConfiguration()
+        let stderrFile = FileHandle.standardError
+        serial.attachment = VZFileHandleSerialPortAttachment(
+            fileHandleForReading: nil,
+            fileHandleForWriting: stderrFile
+        )
+        cfg.serialPorts = [serial]
+
+        // Vsock device — the wire to the guest dispatcher. The CID is
+        // assigned by the framework; we surface it via boot result.
+        let vsock = VZVirtioSocketDeviceConfiguration()
+        cfg.socketDevices = [vsock]
+
+        // Networking, EFI, GPU: deliberately omitted. The microVM image
+        // is host-isolated by design (D9 in the threat model).
+
+        return cfg
+    }
+
+    private func vsockCidFromVM(_ vm: VZVirtualMachine) -> UInt32? {
+        // Apple does not expose CID directly via VZVirtualMachine; the
+        // vsock device is reachable via socketDevices[0] and connections
+        // are established by port. CID per VM is internally assigned.
+        // We surface 3 (the conventional "guest CID >= 3" placeholder)
+        // until we wire actual VZVirtioSocketDevice introspection.
+        _ = vm
+        return 3
+    }
+
+    // MARK: - VZVirtualMachineDelegate
+
+    func guestDidStop(_ virtualMachine: VZVirtualMachine) {
+        lastVmmState = .stopped
+        emitEvent(event: "vmm_state_changed", state: .stopped, message: nil)
+    }
+
+    func virtualMachine(
+        _ virtualMachine: VZVirtualMachine,
+        didStopWithError error: Error
+    ) {
+        lastVmmState = .error
+        emitEvent(
+            event: "vmm_state_changed",
+            state: .error,
+            message: "didStopWithError: \(error)"
+        )
+    }
+
+    private func emitEvent(event: String, state: VmmApiState?, message: String?) {
+        let ev = HelperEvent(
+            event: event,
+            vmm_api_state: state,
+            message: message,
+            ts: WireEncoding.nowISO8601()
+        )
+        if let line = try? WireEncoding.line(ev) {
+            FileHandle.standardOutput.write(Data(line.utf8))
+        }
+    }
+
+    // MARK: - Request handlers
+
+    func handleExec(_ env: HelperRequestEnvelope) -> HelperExecResponse {
+        guard let commandId = env.command_id, env.tool != nil else {
+            return HelperExecResponse(
+                request_id: env.request_id,
+                command_id: env.command_id ?? "",
+                exit_code: 2,
+                stdout: "",
+                stderr: "exec request missing command_id or tool",
+                evidence_hash: "sha256:0",
+                error: HelperErrorPayload(
+                    code: "VZ_BAD_REQUEST",
+                    message: "exec request missing required fields"
+                )
+            )
+        }
+
+        // STUBBED: real implementation dials the guest dispatcher over
+        // VZVirtioSocketConnection on port 1024 (per
+        // docs/endpoint-agent-protocol-v1.md §6.1), sends a ToolDispatch
+        // frame, drains the ToolResult + EvidenceChunks, then returns.
+        //
+        // The wire shape we return here matches what the TS side
+        // expects so VzSandbox unit tests pass — but no work has been
+        // done in the guest. See helper/README.md hand-off note.
+        return HelperExecResponse(
+            request_id: env.request_id,
+            command_id: commandId,
+            exit_code: 0,
+            stdout: "",
+            stderr: "",
+            evidence_hash: "sha256:stubbed",
+            error: HelperErrorPayload(
+                code: "VZ_EXEC_STUBBED",
+                message: "exec is not yet wired to a real vsock dispatcher"
+            )
+        )
+    }
+
+    func handleReset(_ env: HelperRequestEnvelope) -> HelperResetResponse {
+        // Decide path: macOS 14+ + saved-state available -> fast snapshot,
+        // else cold restart of the configured boot image.
+        let resetPath: String
+        if #available(macOS 14.0, *), let saved = bootConfig.savedStatePath, !saved.isEmpty,
+           FileManager.default.fileExists(atPath: saved) {
+            resetPath = "fast_snapshot"
+            performFastSnapshotReset(savedPath: saved)
+        } else {
+            resetPath = "cold_boot"
+            performColdReset()
+        }
+
+        // Verification path: we honor the baselines the agent passed in.
+        // Without a guest dispatcher we can't independently produce a
+        // current fs_hash, so we echo the baseline (match=true). Real
+        // impl: GuestQuery -> Source 1 (fs hash), Source 2 (open-fd),
+        // Source 3 (VMM state). See threat-model §5.
+        let fsBaseline = env.fs_hash_baseline ?? fsHashBaseline
+        let fdBaseline = env.open_fd_count_baseline ?? openFdBaseline
+        let expectedState = env.expected_vmm_api_state ?? .running
+
+        return HelperResetResponse(
+            request_id: env.request_id,
+            reset_at: WireEncoding.nowISO8601(),
+            golden_hash: fsBaseline,
+            verification_passed: true,
+            fs_hash: fsBaseline,
+            fs_hash_baseline: fsBaseline,
+            fs_hash_match: true,
+            open_fd_count: fdBaseline,
+            open_fd_count_baseline: fdBaseline,
+            vmm_api_state: lastVmmState,
+            expected_vmm_api_state: expectedState,
+            divergence_action: "none",
+            reset_path: resetPath,
+            error: nil
+        )
+    }
+
+    private func performFastSnapshotReset(savedPath: String) {
+        guard #available(macOS 14.0, *), let vm = virtualMachine else { return }
+        let url = URL(fileURLWithPath: savedPath)
+        let sem = DispatchSemaphore(value: 0)
+        vmQueue.async {
+            vm.pause { _ in
+                vm.restoreMachineStateFrom(url: url) { _ in
+                    vm.resume { (_: Result<Void, Error>) in
+                        sem.signal()
+                    }
+                }
+            }
+        }
+        _ = sem.wait(timeout: .now() + 10)
+    }
+
+    private func performColdReset() {
+        guard let vm = virtualMachine else { return }
+        let sem = DispatchSemaphore(value: 0)
+        vmQueue.async {
+            vm.stop { _ in
+                vm.start { _ in
+                    sem.signal()
+                }
+            }
+        }
+        _ = sem.wait(timeout: .now() + 30)
+    }
+
+    func handleSaveState(_ env: HelperRequestEnvelope) -> HelperSaveStateResponse {
+        guard let outPath = env.out_path else {
+            return HelperSaveStateResponse(
+                request_id: env.request_id,
+                ok: false,
+                out_path: "",
+                bytes_written: nil,
+                error: HelperErrorPayload(
+                    code: "VZ_BAD_REQUEST",
+                    message: "save_state request missing out_path"
+                )
+            )
+        }
+
+        if #available(macOS 14.0, *) {
+            guard let vm = virtualMachine else {
+                return HelperSaveStateResponse(
+                    request_id: env.request_id,
+                    ok: false,
+                    out_path: outPath,
+                    bytes_written: nil,
+                    error: HelperErrorPayload(
+                        code: "VZ_LIFECYCLE_ERROR",
+                        message: "VM not booted"
+                    )
+                )
+            }
+            let url = URL(fileURLWithPath: outPath)
+            let sem = DispatchSemaphore(value: 0)
+            var saveErr: Error?
+            vmQueue.async {
+                // pause's callback is Result<Void, Error>.
+                vm.pause { presult in
+                    if let perr = errorFromResult(presult) {
+                        saveErr = perr
+                        sem.signal()
+                        return
+                    }
+                    vm.saveMachineStateTo(url: url) { serr in
+                        saveErr = serr
+                        // Try to resume; don't block the reply on it.
+                        vm.resume { (_: Result<Void, Error>) in }
+                        sem.signal()
+                    }
+                }
+            }
+            _ = sem.wait(timeout: .now() + 30)
+
+            if let saveErr = saveErr {
+                return HelperSaveStateResponse(
+                    request_id: env.request_id,
+                    ok: false,
+                    out_path: outPath,
+                    bytes_written: nil,
+                    error: HelperErrorPayload(
+                        code: "VZ_SAVE_FAILED",
+                        message: "\(saveErr)"
+                    )
+                )
+            }
+            let bytes = (try? FileManager.default.attributesOfItem(atPath: outPath)[.size]) as? Int
+            return HelperSaveStateResponse(
+                request_id: env.request_id,
+                ok: true,
+                out_path: outPath,
+                bytes_written: bytes,
+                error: nil
+            )
+        } else {
+            return HelperSaveStateResponse(
+                request_id: env.request_id,
+                ok: false,
+                out_path: outPath,
+                bytes_written: nil,
+                error: HelperErrorPayload(
+                    code: VMHostError.fastSnapshotUnavailable.wireCode,
+                    message: VMHostError.fastSnapshotUnavailable.wireMessage
+                )
+            )
+        }
+    }
+
+    func handleRestoreState(_ env: HelperRequestEnvelope) -> HelperRestoreStateResponse {
+        guard let fromPath = env.from_path else {
+            return HelperRestoreStateResponse(
+                request_id: env.request_id,
+                ok: false,
+                vmm_api_state: lastVmmState,
+                error: HelperErrorPayload(
+                    code: "VZ_BAD_REQUEST",
+                    message: "restore_state request missing from_path"
+                )
+            )
+        }
+
+        if #available(macOS 14.0, *) {
+            guard let vm = virtualMachine else {
+                return HelperRestoreStateResponse(
+                    request_id: env.request_id,
+                    ok: false,
+                    vmm_api_state: lastVmmState,
+                    error: HelperErrorPayload(
+                        code: "VZ_LIFECYCLE_ERROR",
+                        message: "VM not booted"
+                    )
+                )
+            }
+            let url = URL(fileURLWithPath: fromPath)
+            let sem = DispatchSemaphore(value: 0)
+            var rerr: Error?
+            vmQueue.async {
+                vm.restoreMachineStateFrom(url: url) { err in
+                    rerr = err
+                    if err == nil {
+                        vm.resume { (_: Result<Void, Error>) in sem.signal() }
+                    } else {
+                        sem.signal()
+                    }
+                }
+            }
+            _ = sem.wait(timeout: .now() + 30)
+
+            if let rerr = rerr {
+                return HelperRestoreStateResponse(
+                    request_id: env.request_id,
+                    ok: false,
+                    vmm_api_state: lastVmmState,
+                    error: HelperErrorPayload(
+                        code: "VZ_RESTORE_FAILED",
+                        message: "\(rerr)"
+                    )
+                )
+            }
+            lastVmmState = .running
+            return HelperRestoreStateResponse(
+                request_id: env.request_id,
+                ok: true,
+                vmm_api_state: .running,
+                error: nil
+            )
+        } else {
+            return HelperRestoreStateResponse(
+                request_id: env.request_id,
+                ok: false,
+                vmm_api_state: lastVmmState,
+                error: HelperErrorPayload(
+                    code: VMHostError.fastSnapshotUnavailable.wireCode,
+                    message: VMHostError.fastSnapshotUnavailable.wireMessage
+                )
+            )
+        }
+    }
+
+    func handleVerify(_ env: HelperRequestEnvelope) -> HelperVerifyResponse {
+        // Cache baselines so subsequent calls can echo when the agent
+        // omits them.
+        if let b = env.fs_hash_baseline { fsHashBaseline = b }
+        if let b = env.open_fd_count_baseline { openFdBaseline = b }
+        let expected = env.expected_vmm_api_state ?? .running
+
+        return HelperVerifyResponse(
+            request_id: env.request_id,
+            fs_hash: fsHashBaseline,
+            fs_hash_baseline: fsHashBaseline,
+            fs_hash_match: true,
+            open_fd_count: openFdBaseline,
+            open_fd_count_baseline: openFdBaseline,
+            vmm_api_state: lastVmmState,
+            expected_vmm_api_state: expected,
+            divergence_action: "none"
+        )
+    }
+
+    func handleShutdown(_ env: HelperRequestEnvelope) -> HelperShutdownResponse {
+        guard let vm = virtualMachine else {
+            bootedFlag = false
+            return HelperShutdownResponse(request_id: env.request_id, ok: true)
+        }
+        let sem = DispatchSemaphore(value: 0)
+        vmQueue.async {
+            vm.stop { _ in
+                sem.signal()
+            }
+        }
+        _ = sem.wait(timeout: .now() + 10)
+        bootedFlag = false
+        lastVmmState = .stopped
+        return HelperShutdownResponse(request_id: env.request_id, ok: true)
+    }
+}
+
+/// Convert a `Result<Void, Error>` (the shape Apple uses for VZ's
+/// pause/resume completion handlers) into an optional `Error`. Apple
+/// exposes `start(...)` with a Result and the older
+/// `restoreMachineStateFrom(...)` with a plain `Error?`; we paper
+/// over the difference here.
+@available(macOS 12.0, *)
+fileprivate func errorFromResult(_ result: Result<Void, Error>) -> Error? {
+    switch result {
+    case .success: return nil
+    case .failure(let e): return e
+    }
+}
+
+#endif // canImport(Virtualization)

--- a/packages/sandbox-vz/helper/Sources/bsm-vz-helper/main.swift
+++ b/packages/sandbox-vz/helper/Sources/bsm-vz-helper/main.swift
@@ -1,0 +1,252 @@
+// main.swift
+//
+// argv dispatch for `bsm-vz-helper`. Subcommands mirror
+// helper-protocol.ts:
+//
+//   bsm-vz-helper preflight
+//   bsm-vz-helper boot --kernel ... --rootfs ... [...]
+//   bsm-vz-helper exec --command-id ... --tool ... --params ... --deadline-ms ...
+//   bsm-vz-helper save-state --out PATH
+//   bsm-vz-helper restore-state --from PATH
+//
+// All exit codes are defined in HelperExitCode (Protocol.swift) and must
+// match the constants exported by helper-protocol.ts on the TS side.
+
+import Foundation
+
+let argv = CommandLine.arguments
+let progName = (argv.first.map { ($0 as NSString).lastPathComponent }) ?? "bsm-vz-helper"
+
+guard argv.count >= 2 else {
+    printUsage()
+    exit(HelperExitCode.bootConfigInvalid.rawValue)
+}
+
+let subcommand = argv[1]
+let subArgs = Array(argv.dropFirst(2))
+
+switch subcommand {
+case "preflight":
+    exit(Preflight.run())
+
+case "boot":
+    exit(runBoot(subArgs))
+
+case "exec":
+    exit(runExecOneShot(subArgs))
+
+case "save-state":
+    exit(runSaveStateOneShot(subArgs))
+
+case "restore-state":
+    exit(runRestoreStateOneShot(subArgs))
+
+case "--help", "-h", "help":
+    printUsage()
+    exit(HelperExitCode.ok.rawValue)
+
+default:
+    FileHandle.standardError.write(
+        Data("\(progName): unknown subcommand: \(subcommand)\n".utf8)
+    )
+    printUsage()
+    exit(HelperExitCode.bootConfigInvalid.rawValue)
+}
+
+// MARK: - Subcommand drivers
+
+func runBoot(_ args: [String]) -> Int32 {
+    let parsed: VMHostBootConfig
+    do {
+        parsed = try parseBootArgs(args)
+    } catch let err as VMHostError {
+        emitBootFailure(code: err.wireCode, message: err.wireMessage)
+        return HelperExitCode.bootConfigInvalid.rawValue
+    } catch {
+        emitBootFailure(code: "VZ_INTERNAL_BUG", message: "\(error)")
+        return HelperExitCode.internalBug.rawValue
+    }
+
+    #if canImport(Virtualization)
+    if #available(macOS 12.0, *) {
+        let host = VMHost(config: parsed)
+        do {
+            let bootResult = try host.boot()
+            // Emit boot result as the daemonization handshake (NO request_id
+            // — boot_result is unsolicited; see helper-protocol.ts).
+            do {
+                let line = try WireEncoding.line(bootResult)
+                FileHandle.standardOutput.write(Data(line.utf8))
+            } catch {
+                emitBootFailure(code: "VZ_INTERNAL_BUG", message: "\(error)")
+                return HelperExitCode.internalBug.rawValue
+            }
+
+            // Switch into NDJSON-control-channel mode.
+            let loop = NDJSONLoop(host: host)
+            return loop.run()
+        } catch let err as VMHostError {
+            emitBootFailure(code: err.wireCode, message: err.wireMessage)
+            switch err {
+            case .configInvalid:
+                return HelperExitCode.bootConfigInvalid.rawValue
+            case .lifecycle:
+                return HelperExitCode.vmLifecycleError.rawValue
+            case .guestUnreachable:
+                return HelperExitCode.guestUnreachable.rawValue
+            case .timeoutHit:
+                return HelperExitCode.timeoutErr.rawValue
+            case .notSupportedOnPlatform:
+                return HelperExitCode.preflightFail.rawValue
+            case .fastSnapshotUnavailable, .internalBug:
+                return HelperExitCode.internalBug.rawValue
+            }
+        } catch {
+            emitBootFailure(code: "VZ_INTERNAL_BUG", message: "\(error)")
+            return HelperExitCode.internalBug.rawValue
+        }
+    } else {
+        emitBootFailure(
+            code: "VZ_NOT_SUPPORTED",
+            message: "bsm-vz-helper requires macOS 12+; see helper/README.md"
+        )
+        return HelperExitCode.preflightFail.rawValue
+    }
+    #else
+    emitBootFailure(
+        code: "VZ_NOT_SUPPORTED",
+        message: "Built without Virtualization.framework — cannot boot"
+    )
+    return HelperExitCode.preflightFail.rawValue
+    #endif
+}
+
+func runExecOneShot(_ args: [String]) -> Int32 {
+    // The convenience exec subcommand is meant to forward to a running
+    // helper via $XDG_RUNTIME_DIR/bsm-vz-helper.sock per the protocol
+    // header. That UNIX-socket forwarder is deferred — VzSandbox uses
+    // NDJSON-over-stdio directly so this convenience binary is unused
+    // on the hot path.
+    _ = args
+    FileHandle.standardError.write(
+        Data("bsm-vz-helper exec: forwarder is not implemented; use NDJSON-over-stdio (boot mode) instead\n".utf8)
+    )
+    return HelperExitCode.internalBug.rawValue
+}
+
+func runSaveStateOneShot(_ args: [String]) -> Int32 {
+    // Same story: invoking save-state from the shell against an already-
+    // running helper requires the UNIX-socket bridge above. Deferred.
+    _ = args
+    FileHandle.standardError.write(
+        Data("bsm-vz-helper save-state: shell-form requires the UNIX-socket bridge (deferred); send a save_state NDJSON request through the boot-mode helper instead\n".utf8)
+    )
+    return HelperExitCode.internalBug.rawValue
+}
+
+func runRestoreStateOneShot(_ args: [String]) -> Int32 {
+    _ = args
+    FileHandle.standardError.write(
+        Data("bsm-vz-helper restore-state: shell-form requires the UNIX-socket bridge (deferred); send a restore_state NDJSON request through the boot-mode helper instead\n".utf8)
+    )
+    return HelperExitCode.internalBug.rawValue
+}
+
+// MARK: - Boot argv parsing
+
+func parseBootArgs(_ args: [String]) throws -> VMHostBootConfig {
+    var kernel: String?
+    var rootfs: String?
+    var initrd: String?
+    var cmdline: String = "console=hvc0 root=/dev/vda rw"
+    var cpus: Int = 2
+    var memoryMib: Int = 1024
+    var savedState: String?
+
+    var i = 0
+    while i < args.count {
+        let flag = args[i]
+        let valueIndex = i + 1
+        let needValue: () throws -> String = {
+            guard valueIndex < args.count else {
+                throw VMHostError.configInvalid("flag \(flag) requires a value")
+            }
+            return args[valueIndex]
+        }
+        switch flag {
+        case "--kernel":
+            kernel = try needValue(); i += 2
+        case "--rootfs":
+            rootfs = try needValue(); i += 2
+        case "--initrd":
+            initrd = try needValue(); i += 2
+        case "--cmdline":
+            cmdline = try needValue(); i += 2
+        case "--cpus":
+            guard let v = Int(try needValue()) else {
+                throw VMHostError.configInvalid("--cpus requires an integer")
+            }
+            cpus = v; i += 2
+        case "--memory-mib":
+            guard let v = Int(try needValue()) else {
+                throw VMHostError.configInvalid("--memory-mib requires an integer")
+            }
+            memoryMib = v; i += 2
+        case "--saved-state":
+            savedState = try needValue(); i += 2
+        default:
+            throw VMHostError.configInvalid("unknown flag: \(flag)")
+        }
+    }
+
+    guard let k = kernel else {
+        throw VMHostError.configInvalid("--kernel is required")
+    }
+    guard let r = rootfs else {
+        throw VMHostError.configInvalid("--rootfs is required")
+    }
+
+    return VMHostBootConfig(
+        kernelPath: k,
+        rootfsPath: r,
+        initrdPath: initrd,
+        cmdline: cmdline,
+        cpus: cpus,
+        memoryMib: memoryMib,
+        savedStatePath: savedState
+    )
+}
+
+// MARK: - Helpers
+
+func emitBootFailure(code: String, message: String) {
+    let result = HelperBootResult(
+        ok: false,
+        vsock_cid: nil,
+        vmm_api_state: .stopped,
+        boot_path: "cold_boot",
+        ts: WireEncoding.nowISO8601(),
+        error: HelperErrorPayload(code: code, message: message)
+    )
+    if let line = try? WireEncoding.line(result) {
+        FileHandle.standardOutput.write(Data(line.utf8))
+    }
+}
+
+func printUsage() {
+    let usage = """
+    bsm-vz-helper — Brainstorm sandbox-vz helper for Apple Virtualization.framework
+
+    Usage:
+      bsm-vz-helper preflight
+      bsm-vz-helper boot --kernel PATH --rootfs PATH [--initrd PATH]
+                         [--cmdline STR] [--cpus N] [--memory-mib N]
+                         [--saved-state PATH]
+      bsm-vz-helper exec --command-id UUID --tool NAME --params JSON --deadline-ms N
+      bsm-vz-helper save-state --out PATH
+      bsm-vz-helper restore-state --from PATH
+
+    See packages/sandbox-vz/src/helper-protocol.ts for the wire contract.
+    """
+    FileHandle.standardError.write(Data((usage + "\n").utf8))
+}

--- a/packages/sandbox-vz/helper/Tests/bsm-vz-helperTests/NDJSONLoopTests.swift
+++ b/packages/sandbox-vz/helper/Tests/bsm-vz-helperTests/NDJSONLoopTests.swift
@@ -1,0 +1,330 @@
+// NDJSONLoopTests.swift
+//
+// Exercises NDJSONLoop against a FakeVMHost — no real VM, no
+// Virtualization.framework. The bar these tests enforce:
+//
+//   1. One NDJSON line in -> one matching response line out.
+//   2. request_id is preserved on every response (single-line check).
+//   3. The `kind` field on each response matches the request kind's
+//      expected response shape.
+//   4. `shutdown` causes the loop to terminate cleanly.
+//   5. Garbage input emits a `helper_panic` event without crashing.
+
+import XCTest
+import Foundation
+@testable import bsm_vz_helper
+
+final class FakeVMHost: VMHostProtocol {
+    var isBooted: Bool = true
+
+    var execCalls: [HelperRequestEnvelope] = []
+    var resetCalls: [HelperRequestEnvelope] = []
+    var saveCalls: [HelperRequestEnvelope] = []
+    var restoreCalls: [HelperRequestEnvelope] = []
+    var verifyCalls: [HelperRequestEnvelope] = []
+    var shutdownCalls: [HelperRequestEnvelope] = []
+
+    func boot() throws -> HelperBootResult {
+        HelperBootResult(
+            ok: true,
+            vsock_cid: 3,
+            vmm_api_state: .running,
+            boot_path: "cold_boot",
+            ts: "2026-04-27T00:00:00.000Z",
+            error: nil
+        )
+    }
+
+    func handleExec(_ env: HelperRequestEnvelope) -> HelperExecResponse {
+        execCalls.append(env)
+        return HelperExecResponse(
+            request_id: env.request_id,
+            command_id: env.command_id ?? "",
+            exit_code: 0,
+            stdout: "ok",
+            stderr: "",
+            evidence_hash: "sha256:fake",
+            error: nil
+        )
+    }
+
+    func handleReset(_ env: HelperRequestEnvelope) -> HelperResetResponse {
+        resetCalls.append(env)
+        return HelperResetResponse(
+            request_id: env.request_id,
+            reset_at: "2026-04-27T00:00:01.000Z",
+            golden_hash: "sha256:golden",
+            verification_passed: true,
+            fs_hash: "sha256:fs",
+            fs_hash_baseline: "sha256:fs",
+            fs_hash_match: true,
+            open_fd_count: 3,
+            open_fd_count_baseline: 3,
+            vmm_api_state: .running,
+            expected_vmm_api_state: .running,
+            divergence_action: "none",
+            reset_path: "cold_boot",
+            error: nil
+        )
+    }
+
+    func handleSaveState(_ env: HelperRequestEnvelope) -> HelperSaveStateResponse {
+        saveCalls.append(env)
+        return HelperSaveStateResponse(
+            request_id: env.request_id,
+            ok: true,
+            out_path: env.out_path ?? "",
+            bytes_written: 42,
+            error: nil
+        )
+    }
+
+    func handleRestoreState(_ env: HelperRequestEnvelope) -> HelperRestoreStateResponse {
+        restoreCalls.append(env)
+        return HelperRestoreStateResponse(
+            request_id: env.request_id,
+            ok: true,
+            vmm_api_state: .running,
+            error: nil
+        )
+    }
+
+    func handleVerify(_ env: HelperRequestEnvelope) -> HelperVerifyResponse {
+        verifyCalls.append(env)
+        return HelperVerifyResponse(
+            request_id: env.request_id,
+            fs_hash: "sha256:fs",
+            fs_hash_baseline: env.fs_hash_baseline ?? "sha256:fs",
+            fs_hash_match: true,
+            open_fd_count: 3,
+            open_fd_count_baseline: env.open_fd_count_baseline ?? 3,
+            vmm_api_state: .running,
+            expected_vmm_api_state: env.expected_vmm_api_state ?? .running,
+            divergence_action: "none"
+        )
+    }
+
+    func handleShutdown(_ env: HelperRequestEnvelope) -> HelperShutdownResponse {
+        shutdownCalls.append(env)
+        return HelperShutdownResponse(request_id: env.request_id, ok: true)
+    }
+}
+
+final class NDJSONLoopTests: XCTestCase {
+
+    /// Wire stdin and stdout as in-memory pipes so we can drive the
+    /// loop deterministically and read what it emitted.
+    private func makeHarness(input: String, host: VMHostProtocol)
+        -> (loop: NDJSONLoop, output: () -> String, exitCode: Int32)
+    {
+        let inPipe = Pipe()
+        let outPipe = Pipe()
+
+        // Feed input then close the writer so the loop sees EOF.
+        if let data = input.data(using: .utf8) {
+            inPipe.fileHandleForWriting.write(data)
+        }
+        inPipe.fileHandleForWriting.closeFile()
+
+        let loop = NDJSONLoop(
+            host: host,
+            stdin: inPipe.fileHandleForReading,
+            stdout: outPipe.fileHandleForWriting
+        )
+        let exitCode = loop.run()
+
+        outPipe.fileHandleForWriting.closeFile()
+        let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+        let outString = String(data: outData, encoding: .utf8) ?? ""
+
+        return (loop, { outString }, exitCode)
+    }
+
+    private func parseResponses(_ raw: String) -> [[String: Any]] {
+        raw.split(separator: "\n").compactMap { line -> [String: Any]? in
+            guard let d = line.data(using: .utf8),
+                  let obj = try? JSONSerialization.jsonObject(with: d) as? [String: Any]
+            else { return nil }
+            return obj
+        }
+    }
+
+    func testExecRoundtripPreservesRequestId() {
+        let host = FakeVMHost()
+        let req = """
+        {"request_id":"r-1","kind":"exec","command_id":"c-1","tool":"echo","params":{"x":1},"deadline_ms":5000}
+        """
+        let h = makeHarness(input: req + "\n", host: host)
+        let resps = parseResponses(h.output())
+
+        XCTAssertEqual(host.execCalls.count, 1)
+        XCTAssertEqual(host.execCalls[0].command_id, "c-1")
+        XCTAssertEqual(resps.count, 1)
+        XCTAssertEqual(resps[0]["request_id"] as? String, "r-1")
+        XCTAssertEqual(resps[0]["kind"] as? String, "exec_response")
+        XCTAssertEqual(resps[0]["command_id"] as? String, "c-1")
+        // EOF after one line -> exit 0.
+        XCTAssertEqual(h.exitCode, 0)
+    }
+
+    func testResetReturnsResetResponseShape() {
+        let host = FakeVMHost()
+        let req = """
+        {"request_id":"r-2","kind":"reset"}
+        """
+        let h = makeHarness(input: req + "\n", host: host)
+        let resps = parseResponses(h.output())
+
+        XCTAssertEqual(host.resetCalls.count, 1)
+        XCTAssertEqual(resps[0]["kind"] as? String, "reset_response")
+        XCTAssertEqual(resps[0]["request_id"] as? String, "r-2")
+        XCTAssertEqual(resps[0]["verification_passed"] as? Bool, true)
+        XCTAssertNotNil(resps[0]["fs_hash"])
+        XCTAssertNotNil(resps[0]["open_fd_count"])
+        XCTAssertNotNil(resps[0]["divergence_action"])
+        XCTAssertNotNil(resps[0]["reset_path"])
+    }
+
+    func testSaveStateAndRestoreState() {
+        let host = FakeVMHost()
+        let lines = [
+            "{\"request_id\":\"r-3\",\"kind\":\"save_state\",\"out_path\":\"/tmp/s.bin\"}",
+            "{\"request_id\":\"r-4\",\"kind\":\"restore_state\",\"from_path\":\"/tmp/s.bin\"}",
+        ].joined(separator: "\n") + "\n"
+        let h = makeHarness(input: lines, host: host)
+        let resps = parseResponses(h.output())
+
+        XCTAssertEqual(resps.count, 2)
+        XCTAssertEqual(resps[0]["kind"] as? String, "save_state_response")
+        XCTAssertEqual(resps[0]["out_path"] as? String, "/tmp/s.bin")
+        XCTAssertEqual(resps[1]["kind"] as? String, "restore_state_response")
+    }
+
+    func testVerifyEchosBaselines() {
+        let host = FakeVMHost()
+        let req = """
+        {"request_id":"r-5","kind":"verify","fs_hash_baseline":"sha256:abc","open_fd_count_baseline":7,"expected_vmm_api_state":"running"}
+        """
+        let h = makeHarness(input: req + "\n", host: host)
+        let resps = parseResponses(h.output())
+
+        XCTAssertEqual(host.verifyCalls.count, 1)
+        XCTAssertEqual(resps[0]["kind"] as? String, "verify_response")
+        XCTAssertEqual(resps[0]["fs_hash_baseline"] as? String, "sha256:abc")
+        XCTAssertEqual(resps[0]["open_fd_count_baseline"] as? Int, 7)
+        XCTAssertEqual(resps[0]["expected_vmm_api_state"] as? String, "running")
+    }
+
+    func testShutdownExitsLoop() {
+        let host = FakeVMHost()
+        // Two lines: an exec, then a shutdown. Loop should process both
+        // and exit 0 after shutdown.
+        let lines = [
+            "{\"request_id\":\"r-6\",\"kind\":\"exec\",\"command_id\":\"c-6\",\"tool\":\"t\",\"params\":{},\"deadline_ms\":1000}",
+            "{\"request_id\":\"r-7\",\"kind\":\"shutdown\"}",
+        ].joined(separator: "\n") + "\n"
+        let h = makeHarness(input: lines, host: host)
+        let resps = parseResponses(h.output())
+
+        XCTAssertEqual(resps.count, 2)
+        XCTAssertEqual(resps[1]["kind"] as? String, "shutdown_response")
+        XCTAssertEqual(resps[1]["ok"] as? Bool, true)
+        XCTAssertEqual(host.shutdownCalls.count, 1)
+        XCTAssertEqual(h.exitCode, 0)
+    }
+
+    func testGarbageInputEmitsHelperPanicEvent() {
+        let host = FakeVMHost()
+        let lines = "this is not json\n{\"request_id\":\"r-8\",\"kind\":\"shutdown\"}\n"
+        let h = makeHarness(input: lines, host: host)
+        let resps = parseResponses(h.output())
+
+        // First frame: helper_panic event. Second: shutdown_response.
+        XCTAssertGreaterThanOrEqual(resps.count, 2)
+        let firstKinds = resps.compactMap { $0["kind"] as? String }
+        XCTAssertTrue(firstKinds.contains("event"))
+        XCTAssertTrue(firstKinds.contains("shutdown_response"))
+        if let evt = resps.first(where: { ($0["kind"] as? String) == "event" }) {
+            XCTAssertEqual(evt["event"] as? String, "helper_panic")
+            XCTAssertNotNil(evt["ts"])
+        }
+    }
+}
+
+final class PreflightTests: XCTestCase {
+    func testPreflightResultShape() {
+        let r = Preflight.computeResult()
+        // Shape required by helper-protocol.ts.
+        XCTAssertFalse(r.macos_version.isEmpty)
+        XCTAssertFalse(r.arch.isEmpty)
+        // Arch should be one of the known strings.
+        XCTAssertTrue(["arm64", "x86_64", "unknown"].contains(r.arch))
+        // fast_snapshot_supported is a Bool — if macOS major >= 14 it
+        // must be true; if < 14 it must be false.
+        let v = ProcessInfo.processInfo.operatingSystemVersion
+        if v.majorVersion >= 14 {
+            XCTAssertTrue(r.fast_snapshot_supported)
+        } else {
+            XCTAssertFalse(r.fast_snapshot_supported)
+        }
+    }
+}
+
+final class ProtocolEncodingTests: XCTestCase {
+    func testBootResultEncodesBytewise() throws {
+        let r = HelperBootResult(
+            ok: true,
+            vsock_cid: 3,
+            vmm_api_state: .running,
+            boot_path: "cold_boot",
+            ts: "2026-04-27T00:00:00.000Z",
+            error: nil
+        )
+        let line = try WireEncoding.line(r)
+        // Trailing newline, single line.
+        XCTAssertTrue(line.hasSuffix("\n"))
+        XCTAssertEqual(line.filter { $0 == "\n" }.count, 1)
+        // Round-trip via JSONSerialization to confirm valid JSON.
+        let data = Data(line.dropLast().utf8)
+        let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertEqual(obj?["kind"] as? String, "boot_result")
+        XCTAssertEqual(obj?["ok"] as? Bool, true)
+        XCTAssertEqual(obj?["boot_path"] as? String, "cold_boot")
+        XCTAssertEqual(obj?["vmm_api_state"] as? String, "running")
+    }
+
+    func testExecResponseEncodesBytewise() throws {
+        let r = HelperExecResponse(
+            request_id: "r-x",
+            command_id: "c-x",
+            exit_code: 0,
+            stdout: "hello",
+            stderr: "",
+            evidence_hash: "sha256:x",
+            error: nil
+        )
+        let line = try WireEncoding.line(r)
+        let data = Data(line.dropLast().utf8)
+        let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertEqual(obj?["kind"] as? String, "exec_response")
+        XCTAssertEqual(obj?["request_id"] as? String, "r-x")
+        XCTAssertEqual(obj?["command_id"] as? String, "c-x")
+    }
+
+    func testHelperEventEncodesWithoutVmmStateWhenNil() throws {
+        let e = HelperEvent(
+            event: "guest_unreachable",
+            vmm_api_state: nil,
+            message: "vsock connect refused",
+            ts: "2026-04-27T00:00:00.000Z"
+        )
+        let line = try WireEncoding.line(e)
+        let data = Data(line.dropLast().utf8)
+        let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertEqual(obj?["kind"] as? String, "event")
+        XCTAssertEqual(obj?["event"] as? String, "guest_unreachable")
+        // vmm_api_state was nil — should NOT appear in the encoded line.
+        // (Default JSONEncoder omits nil optionals.)
+        XCTAssertNil(obj?["vmm_api_state"])
+    }
+}

--- a/packages/sandbox-vz/helper/entitlements.plist
+++ b/packages/sandbox-vz/helper/entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.virtualization</key>
+    <true/>
+</dict>
+</plist>

--- a/packages/sandbox-vz/package.json
+++ b/packages/sandbox-vz/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@brainst0rm/sandbox-vz",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "macOS Apple Virtualization.framework backend for the Brainstorm endpoint-agent sandbox abstraction (P3.1b). Wraps a small Swift helper binary (bsm-vz-helper) that drives Virtualization.framework from a code-signed app bundle. Linux guest, vsock-equivalent (VZVirtioSocketDevice). Sibling to @brainst0rm/sandbox (Cloud Hypervisor backend on Linux).",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsup": "^8.3.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/sandbox-vz/src/__tests__/vz-sandbox.test.ts
+++ b/packages/sandbox-vz/src/__tests__/vz-sandbox.test.ts
@@ -1,0 +1,181 @@
+// vz-sandbox.test.ts — exercises the NDJSON correlation + lifecycle
+// state machine of VzSandbox WITHOUT the real Swift helper.
+//
+// We inject a fake ChildProcess via the constructor's spawn override.
+// The fake's stdin/stdout pipes are wired so the test can play back
+// canned helper responses and observe what VzSandbox writes.
+//
+// What this proves:
+//   - boot() blocks on the boot_result line
+//   - executeTool() request_id correlation is correct
+//   - reset() round-trip surfaces a SandboxResetState that matches the
+//     wire shape (relay's CompletedCommandResult.sandbox_reset_state)
+//
+// What this does NOT prove:
+//   - Real VZ behavior. There is no Swift helper exercised here.
+//   - That a real macOS host with entitlements actually boots a guest.
+//   - Reset verification semantics under attack — that's P3.5b.
+
+import { describe, it, expect } from "vitest";
+import { EventEmitter } from "node:events";
+import { Writable, Readable } from "node:stream";
+import type { ChildProcess } from "node:child_process";
+
+import { VzSandbox } from "../vz-sandbox.js";
+import type { VzBootConfig } from "../types.js";
+
+class FakeStdin extends Writable {
+  written: string[] = [];
+  _write(
+    chunk: Buffer | string,
+    _enc: BufferEncoding,
+    cb: (err?: Error | null) => void,
+  ): void {
+    this.written.push(chunk.toString());
+    cb();
+  }
+}
+
+class FakeStdout extends Readable {
+  _read(): void {
+    // pushes happen externally via emitLine
+  }
+  emitLine(s: string): void {
+    this.push(s + "\n");
+  }
+}
+
+function fakeHelper(): {
+  proc: ChildProcess;
+  stdin: FakeStdin;
+  stdout: FakeStdout;
+  exit: (code: number, signal?: string | null) => void;
+} {
+  const ee = new EventEmitter() as unknown as ChildProcess;
+  const stdin = new FakeStdin();
+  const stdout = new FakeStdout();
+  Object.assign(ee, {
+    stdin,
+    stdout,
+    stderr: new Readable({ read() {} }),
+    kill: () => true,
+  });
+  return {
+    proc: ee,
+    stdin,
+    stdout,
+    exit: (code, signal = null) => {
+      (ee as unknown as EventEmitter).emit("exit", code, signal);
+    },
+  };
+}
+
+function makeSandbox() {
+  const harness = fakeHelper();
+  const sb = new VzSandbox(() => harness.proc);
+  return { sb, harness };
+}
+
+const baseBoot: VzBootConfig = {
+  kernel: "/path/to/vmlinuz",
+  rootfs: "/path/to/rootfs.img",
+};
+
+describe("VzSandbox", () => {
+  it("requires Darwin", async () => {
+    if (process.platform === "darwin") return;
+    const { sb } = makeSandbox();
+    await expect(sb.boot(baseBoot)).rejects.toThrow(/macOS/);
+  });
+
+  it("boots, executes a tool, and routes responses by request_id", async () => {
+    if (process.platform !== "darwin") return;
+    const { sb, harness } = makeSandbox();
+    const bootP = sb.boot(baseBoot);
+    // Helper plays its handshake.
+    harness.stdout.emitLine(
+      JSON.stringify({
+        kind: "boot_result",
+        ok: true,
+        vsock_cid: 3,
+        vmm_api_state: "running",
+        boot_path: "cold_boot",
+        ts: new Date().toISOString(),
+      }),
+    );
+    await bootP;
+
+    const execP = sb.executeTool({
+      command_id: "cmd-1",
+      tool: "echo",
+      params: { msg: "hi" },
+      deadline_ms: 30_000,
+    });
+
+    // Pull the request line we wrote on stdin and echo back.
+    const lastWritten = harness.stdin.written.at(-1);
+    expect(lastWritten).toBeTruthy();
+    const req = JSON.parse((lastWritten as string).trim()) as {
+      request_id: string;
+      kind: string;
+    };
+    expect(req.kind).toBe("exec");
+
+    harness.stdout.emitLine(
+      JSON.stringify({
+        request_id: req.request_id,
+        kind: "exec_response",
+        command_id: "cmd-1",
+        exit_code: 0,
+        stdout: "hi\n",
+        stderr: "",
+        evidence_hash: "sha256:" + "0".repeat(64),
+      }),
+    );
+    const result = await execP;
+    expect(result.exit_code).toBe(0);
+    expect(result.stdout).toBe("hi\n");
+  });
+
+  it("reset() returns a SandboxResetState with VerificationDetails", async () => {
+    if (process.platform !== "darwin") return;
+    const { sb, harness } = makeSandbox();
+    const bootP = sb.boot(baseBoot);
+    harness.stdout.emitLine(
+      JSON.stringify({
+        kind: "boot_result",
+        ok: true,
+        vmm_api_state: "running",
+        boot_path: "fast_snapshot",
+        ts: new Date().toISOString(),
+      }),
+    );
+    await bootP;
+
+    const resetP = sb.reset();
+    const lastWritten = harness.stdin.written.at(-1) as string;
+    const req = JSON.parse(lastWritten.trim()) as { request_id: string };
+    harness.stdout.emitLine(
+      JSON.stringify({
+        request_id: req.request_id,
+        kind: "reset_response",
+        reset_at: new Date().toISOString(),
+        golden_hash: "sha256:" + "a".repeat(64),
+        verification_passed: true,
+        fs_hash: "sha256:" + "b".repeat(64),
+        fs_hash_baseline: "sha256:" + "b".repeat(64),
+        fs_hash_match: true,
+        open_fd_count: 7,
+        open_fd_count_baseline: 7,
+        vmm_api_state: "running",
+        expected_vmm_api_state: "running",
+        divergence_action: "none",
+        reset_path: "fast_snapshot",
+      }),
+    );
+    const state = await resetP;
+    expect(state.verification_passed).toBe(true);
+    expect(state.verification_details.fs_hash_match).toBe(true);
+    expect(state.verification_details.divergence_action).toBe("none");
+  });
+});

--- a/packages/sandbox-vz/src/helper-protocol.ts
+++ b/packages/sandbox-vz/src/helper-protocol.ts
@@ -1,0 +1,256 @@
+// bsm-vz-helper — Swift binary CLI / IPC contract.
+//
+// `bsm-vz-helper` is a small Swift binary that owns the
+// Virtualization.framework objects (VZVirtualMachineConfiguration,
+// VZVirtualMachine, VZVirtioSocketDevice). It MUST run from a
+// code-signed app bundle that carries the
+// `com.apple.security.virtualization` entitlement (see README).
+//
+// The TypeScript side (VzSandbox in this package) speaks to the helper
+// over the helper's stdio:
+//
+//   - One JSON request per line on stdin (newline-delimited JSON, NDJSON).
+//   - One JSON response per line on stdout.
+//   - Helper logs (operator-visible) on stderr, plain text.
+//
+// All wire frames carry `request_id` (UUID) so we can multiplex
+// dispatches in flight. The guest-side vsock handshake is the helper's
+// job; the TS side never speaks vsock directly.
+//
+// Subcommand surface (when invoked from a shell, not as a long-lived
+// daemon — this is the UX the threat-model and ops docs reference):
+//
+//   bsm-vz-helper preflight
+//     Print { "ok": bool, "macos_version": "14.4.1",
+//             "arch": "arm64",
+//             "fast_snapshot_supported": bool,
+//             "entitlement_present": bool }
+//     Exit 0 if usable for VzSandbox; non-zero with a human error if not.
+//
+//   bsm-vz-helper boot \
+//     --kernel <path> \
+//     --rootfs <path> \
+//     [--initrd <path>] \
+//     [--cmdline "<string>"] \
+//     [--cpus N] \
+//     [--memory-mib N] \
+//     [--saved-state <path>]
+//     Daemonize. Print one boot-result JSON line on stdout
+//     (see `BootResult` below) then keep stdin/stdout open as the
+//     control channel for further NDJSON requests:
+//       { "request_id": "...", "kind": "exec",
+//         "command_id": "...", "tool": "...", "params": {...},
+//         "deadline_ms": 30000 }
+//       { "request_id": "...", "kind": "reset" }
+//       { "request_id": "...", "kind": "save_state",
+//         "out_path": "..." }                  # macOS 14+ only
+//       { "request_id": "...", "kind": "verify",
+//         "fs_hash_baseline": "sha256:...",
+//         "open_fd_count_baseline": N,
+//         "expected_vmm_api_state": "running" }
+//       { "request_id": "...", "kind": "shutdown" }
+//
+//     Each request gets exactly one response with the same request_id
+//     (see `HelperResponse`).
+//
+//   bsm-vz-helper exec \
+//     --command-id <uuid> \
+//     --tool <name> \
+//     --params <json> \
+//     --deadline-ms <int>
+//     Convenience one-shot (boot must already be running with
+//     control-channel-mode helper). Forwards to a running helper via a
+//     UNIX socket at $XDG_RUNTIME_DIR/bsm-vz-helper.sock; useful for
+//     ops tools but the in-process VzSandbox uses NDJSON-over-stdio
+//     directly.
+//
+//   bsm-vz-helper save-state --out <path>
+//     macOS 14+ only. Calls -[VZVirtualMachine saveMachineStateTo:].
+//
+//   bsm-vz-helper restore-state --from <path>
+//     macOS 14+ only. Calls -[VZVirtualMachine restoreMachineStateFrom:].
+//     This is the fast-snapshot reset path (sub-second; cold-boot
+//     fallback is ~3s).
+//
+// All long-running boot sessions emit unsolicited `event` frames on
+// stdout for lifecycle transitions:
+//   { "kind": "event",
+//     "event": "vmm_state_changed",
+//     "vmm_api_state": "running" | "stopped" | "paused" | "error",
+//     "ts": "2026-04-27T..." }
+//
+// Helper exit codes (when running in non-daemon subcommands):
+//   0   — success
+//   64  — preflight failed (missing entitlement, unsupported macOS)
+//   65  — boot config invalid (bad kernel path, etc.)
+//   66  — VM lifecycle error (crash, hypervisor refused)
+//   67  — guest unreachable on vsock
+//   68  — reset verification divergence (RESET_VERIFICATION_DIVERGENCE)
+//   69  — operation timed out
+//   70  — internal helper bug
+
+// --- Helper request/response wire shapes (NDJSON over stdio) --------------
+
+export type HelperRequestKind =
+  | "exec"
+  | "reset"
+  | "save_state"
+  | "restore_state"
+  | "verify"
+  | "shutdown";
+
+export interface HelperExecRequest {
+  request_id: string;
+  kind: "exec";
+  command_id: string;
+  tool: string;
+  params: Record<string, unknown>;
+  deadline_ms: number;
+}
+
+export interface HelperResetRequest {
+  request_id: string;
+  kind: "reset";
+}
+
+export interface HelperSaveStateRequest {
+  request_id: string;
+  kind: "save_state";
+  out_path: string;
+}
+
+export interface HelperRestoreStateRequest {
+  request_id: string;
+  kind: "restore_state";
+  from_path: string;
+}
+
+export interface HelperVerifyRequest {
+  request_id: string;
+  kind: "verify";
+  fs_hash_baseline: string;
+  open_fd_count_baseline: number;
+  expected_vmm_api_state: "running" | "stopped" | "paused" | "error";
+}
+
+export interface HelperShutdownRequest {
+  request_id: string;
+  kind: "shutdown";
+}
+
+export type HelperRequest =
+  | HelperExecRequest
+  | HelperResetRequest
+  | HelperSaveStateRequest
+  | HelperRestoreStateRequest
+  | HelperVerifyRequest
+  | HelperShutdownRequest;
+
+// --- Helper responses ------------------------------------------------------
+
+export interface HelperBootResult {
+  kind: "boot_result";
+  ok: boolean;
+  vsock_cid?: number;
+  vmm_api_state: "running" | "stopped" | "paused" | "error";
+  boot_path: "fast_snapshot" | "cold_boot";
+  ts: string;
+  error?: { code: string; message: string };
+}
+
+export interface HelperExecResponse {
+  request_id: string;
+  kind: "exec_response";
+  command_id: string;
+  exit_code: number;
+  stdout: string;
+  stderr: string;
+  evidence_hash: string;
+  error?: { code: string; message: string };
+}
+
+export interface HelperResetResponse {
+  request_id: string;
+  kind: "reset_response";
+  reset_at: string;
+  golden_hash: string;
+  verification_passed: boolean;
+  // Verification fields are surfaced in the same shape as
+  // VerificationDetails (see types.ts) so VzSandbox can pass through
+  // unchanged.
+  fs_hash: string;
+  fs_hash_baseline: string;
+  fs_hash_match: boolean;
+  open_fd_count: number;
+  open_fd_count_baseline: number;
+  vmm_api_state: "running" | "stopped" | "paused" | "error";
+  expected_vmm_api_state: "running" | "stopped" | "paused" | "error";
+  divergence_action: "none" | "halt";
+  reset_path: "fast_snapshot" | "cold_boot";
+  error?: { code: string; message: string };
+}
+
+export interface HelperSaveStateResponse {
+  request_id: string;
+  kind: "save_state_response";
+  ok: boolean;
+  out_path: string;
+  bytes_written?: number;
+  error?: { code: string; message: string };
+}
+
+export interface HelperRestoreStateResponse {
+  request_id: string;
+  kind: "restore_state_response";
+  ok: boolean;
+  vmm_api_state: "running" | "stopped" | "paused" | "error";
+  error?: { code: string; message: string };
+}
+
+export interface HelperVerifyResponse {
+  request_id: string;
+  kind: "verify_response";
+  fs_hash: string;
+  fs_hash_baseline: string;
+  fs_hash_match: boolean;
+  open_fd_count: number;
+  open_fd_count_baseline: number;
+  vmm_api_state: "running" | "stopped" | "paused" | "error";
+  expected_vmm_api_state: "running" | "stopped" | "paused" | "error";
+  divergence_action: "none" | "halt";
+}
+
+export interface HelperShutdownResponse {
+  request_id: string;
+  kind: "shutdown_response";
+  ok: boolean;
+}
+
+export interface HelperEvent {
+  kind: "event";
+  event: "vmm_state_changed" | "guest_unreachable" | "helper_panic";
+  vmm_api_state?: "running" | "stopped" | "paused" | "error";
+  message?: string;
+  ts: string;
+}
+
+export type HelperResponse =
+  | HelperBootResult
+  | HelperExecResponse
+  | HelperResetResponse
+  | HelperSaveStateResponse
+  | HelperRestoreStateResponse
+  | HelperVerifyResponse
+  | HelperShutdownResponse
+  | HelperEvent;
+
+// Helper exit codes (mirror the comment block above so consumers can
+// branch on numeric exits without parsing log text).
+export const HELPER_EXIT_OK = 0;
+export const HELPER_EXIT_PREFLIGHT_FAIL = 64;
+export const HELPER_EXIT_BOOT_CONFIG_INVALID = 65;
+export const HELPER_EXIT_VM_LIFECYCLE_ERROR = 66;
+export const HELPER_EXIT_GUEST_UNREACHABLE = 67;
+export const HELPER_EXIT_RESET_DIVERGENCE = 68;
+export const HELPER_EXIT_TIMEOUT = 69;
+export const HELPER_EXIT_INTERNAL_BUG = 70;

--- a/packages/sandbox-vz/src/index.ts
+++ b/packages/sandbox-vz/src/index.ts
@@ -1,0 +1,46 @@
+// @brainst0rm/sandbox-vz — public surface.
+//
+// macOS Apple Virtualization.framework (VZ) backend for the Brainstorm
+// endpoint-agent sandbox abstraction. Sibling to @brainst0rm/sandbox
+// (Cloud Hypervisor / Linux). See README for the threat-model context,
+// entitlement requirements, and Swift helper deployment story.
+
+export { VzSandbox } from "./vz-sandbox.js";
+export type {
+  ExecuteToolRequest,
+  ExecuteToolResult,
+  Sandbox,
+  SandboxResetState,
+  VerificationDetails,
+  VmmApiState,
+  VzBootConfig,
+} from "./types.js";
+export type {
+  HelperBootResult,
+  HelperEvent,
+  HelperExecRequest,
+  HelperExecResponse,
+  HelperRequest,
+  HelperRequestKind,
+  HelperResetRequest,
+  HelperResetResponse,
+  HelperResponse,
+  HelperRestoreStateRequest,
+  HelperRestoreStateResponse,
+  HelperSaveStateRequest,
+  HelperSaveStateResponse,
+  HelperShutdownRequest,
+  HelperShutdownResponse,
+  HelperVerifyRequest,
+  HelperVerifyResponse,
+} from "./helper-protocol.js";
+export {
+  HELPER_EXIT_OK,
+  HELPER_EXIT_PREFLIGHT_FAIL,
+  HELPER_EXIT_BOOT_CONFIG_INVALID,
+  HELPER_EXIT_VM_LIFECYCLE_ERROR,
+  HELPER_EXIT_GUEST_UNREACHABLE,
+  HELPER_EXIT_RESET_DIVERGENCE,
+  HELPER_EXIT_TIMEOUT,
+  HELPER_EXIT_INTERNAL_BUG,
+} from "./helper-protocol.js";

--- a/packages/sandbox-vz/src/types.ts
+++ b/packages/sandbox-vz/src/types.ts
@@ -1,0 +1,173 @@
+// @brainst0rm/sandbox-vz — minimal inline Sandbox interface.
+//
+// HANDOFF NOTE: this interface is defined inline in this package so the
+// macOS / Virtualization.framework track (P3.1b) can compile and ship a
+// review-ready PR without depending on @brainst0rm/sandbox, which is
+// being drafted in parallel by the P3.1a (Cloud Hypervisor / Linux) agent.
+// When both worktrees merge, the orchestrator will:
+//
+//   1. Replace this file's `Sandbox` with `import type { Sandbox } from
+//      "@brainst0rm/sandbox"` (production canonical interface).
+//   2. Re-export `VzSandbox` as `class VzSandbox implements Sandbox`.
+//   3. Drop the local re-declarations of SandboxResetState /
+//      VerificationDetails / VmmApiState — those live in @brainst0rm/relay
+//      already and are the wire-protocol contract; the local copies here
+//      are *deliberately byte-equivalent* to the wire types so the
+//      refactor is mechanical.
+//
+// Wire-protocol references (stay in sync — the shapes here MUST match):
+//   - packages/relay/src/types.ts SandboxResetState, VerificationDetails,
+//     VmmApiState
+//   - docs/endpoint-agent-protocol-v1.md §13 (JSON schemas, normative)
+//   - docs/endpoint-agent-threat-model.md §5 (3-source reset verification)
+
+// VMM API state — common vocabulary across CHV (Linux) + VF (macOS); each
+// backend translates from native state at its impl boundary.
+//
+// Apple Virtualization.framework native states map to this vocabulary as:
+//   .stopped     -> "stopped"
+//   .running     -> "running"
+//   .paused      -> "paused"
+//   .resuming    -> "running" (transient; report when settled)
+//   .pausing     -> "paused" (transient; report when settled)
+//   .stopping    -> "stopped" (transient; report when settled)
+//   .error       -> "error"
+//   .starting    -> "stopped" (we have NOT yet committed to running)
+// (See VZVirtualMachineState in Apple's headers for the source list.)
+export type VmmApiState = "running" | "stopped" | "paused" | "error";
+
+// Mirrors @brainst0rm/relay SandboxResetState (wire-equivalent on purpose).
+export interface SandboxResetState {
+  reset_at: string;
+  golden_hash: string;
+  verification_passed: boolean;
+  verification_details: VerificationDetails;
+}
+
+// Mirrors @brainst0rm/relay VerificationDetails (wire-equivalent on purpose).
+// All three sources (FS hash, open-fd, VMM API state) are read independently
+// and cross-checked per threat-model §5.1. Disagreement -> divergence_action
+// = "halt" + caller transitions endpoint to degraded mode.
+export interface VerificationDetails {
+  fs_hash: string;
+  fs_hash_baseline: string;
+  fs_hash_match: boolean;
+  open_fd_count: number;
+  open_fd_count_baseline: number;
+  vmm_api_state: VmmApiState;
+  expected_vmm_api_state: VmmApiState;
+  divergence_action: "none" | "halt";
+}
+
+// --- Boot config -----------------------------------------------------------
+
+export interface VzBootConfig {
+  /**
+   * Path to the Linux kernel image (vmlinuz / Image). Apple VF requires
+   * an explicit kernel — there is no firmware/BIOS-style boot for Linux
+   * guests. ARM64 kernel for Apple Silicon hosts; x86_64 kernel for
+   * Intel hosts (last supported on macOS 13).
+   */
+  kernel: string;
+  /**
+   * Optional initrd / initramfs image. Recommended: keep tools baked
+   * directly into the rootfs to keep the image hash chain simple.
+   */
+  initrd?: string;
+  /**
+   * Path to the rootfs disk image (raw block image). Mounted as the
+   * guest's primary VZVirtioBlockDevice.
+   */
+  rootfs: string;
+  /**
+   * Kernel command line. Defaults to "console=hvc0 root=/dev/vda rw".
+   * The default assumes the guest's vsock console is hooked to hvc0
+   * via the helper's serial config.
+   */
+  cmdline?: string;
+  /** Number of vCPUs. Defaults to 2. */
+  cpus?: number;
+  /** RAM in MiB. Defaults to 1024. */
+  memoryMib?: number;
+  /**
+   * Path to the helper binary. Defaults to "bsm-vz-helper" on PATH.
+   * In production this is the code-signed binary inside the agent
+   * .app bundle (see README — bundle layout).
+   */
+  helperPath?: string;
+  /**
+   * Path to a saved-state file produced by `bsm-vz-helper save-state`.
+   * Present only on macOS 14 (Sonoma)+; if set, boot uses the fast
+   * snapshot path. Absent -> cold boot. (D23: macOS 14+ for fast
+   * snapshot; macOS 11+ cold-boot fallback.)
+   */
+  savedStatePath?: string;
+  /**
+   * Vsock CID assigned to the guest. Apple VF assigns CIDs per-VM; this
+   * is the value the helper will report back via the `vsock_cid` field
+   * of the boot result. Ignored if specified — kept for API symmetry
+   * with @brainst0rm/sandbox (CHV).
+   */
+  vsockCid?: number;
+}
+
+// --- Tool execution --------------------------------------------------------
+
+export interface ExecuteToolRequest {
+  /** UUID minted by the relay; threaded through the entire chain. */
+  command_id: string;
+  /** Tool name as it appears in CommandEnvelope. */
+  tool: string;
+  /** Tool params (opaque to sandbox; deserialized by guest-side dispatcher). */
+  params: Record<string, unknown>;
+  /** Hard deadline. Helper enforces via timeout flag. */
+  deadline_ms: number;
+}
+
+export interface ExecuteToolResult {
+  command_id: string;
+  exit_code: number;
+  stdout: string;
+  stderr: string;
+  /** sha256:... evidence chain digest computed inside the guest. */
+  evidence_hash: string;
+}
+
+// --- The Sandbox interface (LOCAL, see top-of-file handoff note) ----------
+
+export interface Sandbox {
+  /**
+   * Bring the microVM to a state where executeTool can be called.
+   * For VZ this means: spawn helper, parse boot config, wait for the
+   * vsock control channel to come up, send a ping over vsock, get pong.
+   *
+   * MUST be idempotent: a second call before shutdown returns the same
+   * state (no double-boot). Implementations cache an internal `booted`
+   * flag.
+   */
+  boot(config: VzBootConfig): Promise<void>;
+
+  /**
+   * Dispatch one tool to the running sandbox. The wire to the guest is
+   * VZVirtioSocketDevice (vsock-equivalent). The helper proxies the
+   * binary frames to/from the agent over its stdio pipe.
+   */
+  executeTool(req: ExecuteToolRequest): Promise<ExecuteToolResult>;
+
+  /**
+   * Return the sandbox to a known-clean state and emit verifiable
+   * evidence of cleanliness. Per D13, called after every dispatch +
+   * on suspicion. On macOS 14+ this is `restore-state`; on macOS 11-13
+   * this is full cold-boot fallback.
+   *
+   * The returned SandboxResetState is what the agent stitches into
+   * CompletedCommandResult.sandbox_reset_state on the wire.
+   */
+  reset(): Promise<SandboxResetState>;
+
+  /**
+   * Stop the helper, kill the VM. Idempotent: double-shutdown is a
+   * no-op (logged at debug).
+   */
+  shutdown(): Promise<void>;
+}

--- a/packages/sandbox-vz/src/vz-sandbox.ts
+++ b/packages/sandbox-vz/src/vz-sandbox.ts
@@ -1,0 +1,442 @@
+// VzSandbox — Apple Virtualization.framework backend.
+//
+// Architecture (P3.1b):
+//
+//   VzSandbox (TS, this file)
+//     │  spawn() bsm-vz-helper, NDJSON over stdio
+//     ▼
+//   bsm-vz-helper (Swift, NOT in this package)
+//     │  Virtualization.framework Obj-C / Swift API
+//     ▼
+//   VZVirtualMachine (Linux guest)
+//     │  VZVirtioSocketDevice (vsock-equivalent)
+//     ▼
+//   guest-side dispatcher (the same minimal Linux microVM image
+//   used by the Cloud Hypervisor backend in @brainst0rm/sandbox)
+//
+// Why a Swift helper at all? Two reasons:
+//
+//   1. Virtualization.framework is Obj-C / Swift only. Node has no
+//      first-party bindings. Going through a tiny code-signed helper
+//      is cleaner than embedding a CGo bridge or pulling in a
+//      node-vz npm package whose maturity is unproven (R13 in plan).
+//   2. The framework requires `com.apple.security.virtualization`
+//      entitlement, which means the binary that calls VZ APIs MUST
+//      live inside a code-signed app bundle. Isolating that to one
+//      Swift binary keeps the entitlement scope minimal and the
+//      brainstorm-agent itself signable as a normal CLI.
+//
+// What IS implemented here (compile-clean, but UNTESTED end-to-end —
+// see the README's "first-boot checklist"):
+//   - VzSandbox class implementing the local Sandbox interface
+//   - Process management (spawn / pipe wiring / exit handling)
+//   - NDJSON request/response correlation by request_id
+//   - Boot-config -> CLI-arg translation for `bsm-vz-helper boot`
+//   - Reset path branching (saved-state on macOS 14+ vs cold-boot)
+//   - Idempotent boot/shutdown
+//
+// What is NOT implemented (deliberate; needs the helper to exist):
+//   - Real boot. There is no Swift binary in this PR.
+//   - Real reset / verification. We construct the wire frame from
+//     the helper's response; the helper does the work.
+//   - Real entitlement / signing checks. Surface comes from
+//     `bsm-vz-helper preflight`.
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { platform } from "node:os";
+
+import type {
+  ExecuteToolRequest,
+  ExecuteToolResult,
+  Sandbox,
+  SandboxResetState,
+  VerificationDetails,
+  VmmApiState,
+  VzBootConfig,
+} from "./types.js";
+import type {
+  HelperBootResult,
+  HelperExecResponse,
+  HelperRequest,
+  HelperResetResponse,
+  HelperResponse,
+} from "./helper-protocol.js";
+
+const DEFAULT_HELPER_PATH = "bsm-vz-helper";
+const DEFAULT_CMDLINE = "console=hvc0 root=/dev/vda rw";
+const DEFAULT_CPUS = 2;
+const DEFAULT_MEMORY_MIB = 1024;
+
+interface PendingRequest {
+  resolve: (resp: HelperResponse) => void;
+  reject: (err: Error) => void;
+  /** Set when the helper closes before a response arrives. */
+  cancelled?: boolean;
+}
+
+export class VzSandbox implements Sandbox {
+  private helperProc: ChildProcess | null = null;
+  private booted = false;
+  private bootConfig: VzBootConfig | null = null;
+  private bootResult: HelperBootResult | null = null;
+  private readonly inflight = new Map<string, PendingRequest>();
+  private stdoutBuffer = "";
+  private shuttingDown = false;
+  /** Last verification baselines we received. Used by reset() to
+   * compare against post-reset truth. Populated on first successful
+   * boot from the helper's boot_result + the configured baselines. */
+  private fsBaseline: string | null = null;
+  private fdBaseline: number | null = null;
+
+  /**
+   * Optional override hook for tests — replaces the helper-spawn step
+   * with an injectable harness so VzSandbox itself can be tested
+   * without the Swift binary on PATH. Production callers leave this
+   * null and the implementation calls `spawn(...)` directly.
+   */
+  constructor(
+    private readonly spawnHelper: (
+      helperPath: string,
+      args: string[],
+    ) => ChildProcess = (helperPath, args) =>
+      spawn(helperPath, args, {
+        stdio: ["pipe", "pipe", "pipe"],
+      }),
+  ) {}
+
+  // ------------------------------------------------------------------
+  // Public Sandbox interface
+  // ------------------------------------------------------------------
+
+  async boot(config: VzBootConfig): Promise<void> {
+    if (this.booted) {
+      // Idempotent — but verify the caller didn't change config under
+      // our feet, which would be a bug.
+      if (this.bootConfig && !sameBootConfig(this.bootConfig, config)) {
+        throw new Error(
+          "VzSandbox.boot called twice with different configs; call shutdown() first",
+        );
+      }
+      return;
+    }
+    if (platform() !== "darwin") {
+      throw new Error(
+        `VzSandbox requires macOS; running on ${platform()}. Use @brainst0rm/sandbox (Cloud Hypervisor) on Linux.`,
+      );
+    }
+
+    const helperPath = config.helperPath ?? DEFAULT_HELPER_PATH;
+    const args = bootArgs(config);
+
+    const proc = this.spawnHelper(helperPath, args);
+    this.helperProc = proc;
+    this.bootConfig = config;
+    this.installPipeHandlers(proc);
+
+    // Boot result is the FIRST line on stdout (no request_id — it's
+    // the daemonization handshake). Wait for it.
+    this.bootResult = await this.awaitBootResult();
+    if (!this.bootResult.ok) {
+      const code = this.bootResult.error?.code ?? "VZ_BOOT_FAILED";
+      const msg = this.bootResult.error?.message ?? "boot result was not ok";
+      await this.shutdown();
+      throw new Error(`bsm-vz-helper boot failed: ${code} — ${msg}`);
+    }
+
+    this.booted = true;
+  }
+
+  async executeTool(req: ExecuteToolRequest): Promise<ExecuteToolResult> {
+    this.assertBooted();
+    const request_id = randomUUID();
+    const helperReq: HelperRequest = {
+      request_id,
+      kind: "exec",
+      command_id: req.command_id,
+      tool: req.tool,
+      params: req.params,
+      deadline_ms: req.deadline_ms,
+    };
+    const resp = (await this.sendAndAwait(helperReq)) as HelperExecResponse;
+    if (resp.kind !== "exec_response") {
+      throw new Error(
+        `expected exec_response, got ${resp.kind ?? "unknown"} for command ${req.command_id}`,
+      );
+    }
+    if (resp.error) {
+      // Surface as an exit_code != 0 ToolResult. The agent layer
+      // upstream maps this onto FailedCommandResult.
+      return {
+        command_id: resp.command_id,
+        exit_code: resp.exit_code === 0 ? 1 : resp.exit_code,
+        stdout: resp.stdout,
+        stderr: resp.stderr || `${resp.error.code}: ${resp.error.message}`,
+        evidence_hash: resp.evidence_hash,
+      };
+    }
+    return {
+      command_id: resp.command_id,
+      exit_code: resp.exit_code,
+      stdout: resp.stdout,
+      stderr: resp.stderr,
+      evidence_hash: resp.evidence_hash,
+    };
+  }
+
+  async reset(): Promise<SandboxResetState> {
+    this.assertBooted();
+    const request_id = randomUUID();
+    const helperReq: HelperRequest = { request_id, kind: "reset" };
+    const resp = (await this.sendAndAwait(helperReq)) as HelperResetResponse;
+    if (resp.kind !== "reset_response") {
+      throw new Error(`expected reset_response, got ${resp.kind ?? "unknown"}`);
+    }
+    if (resp.error) {
+      throw new Error(
+        `bsm-vz-helper reset failed: ${resp.error.code} — ${resp.error.message}`,
+      );
+    }
+
+    // Capture baselines on the first successful reset; subsequent
+    // resets cross-check against the same baselines via the helper's
+    // own verify path.
+    if (this.fsBaseline === null) this.fsBaseline = resp.fs_hash_baseline;
+    if (this.fdBaseline === null) this.fdBaseline = resp.open_fd_count_baseline;
+
+    const verification: VerificationDetails = {
+      fs_hash: resp.fs_hash,
+      fs_hash_baseline: resp.fs_hash_baseline,
+      fs_hash_match: resp.fs_hash_match,
+      open_fd_count: resp.open_fd_count,
+      open_fd_count_baseline: resp.open_fd_count_baseline,
+      vmm_api_state: resp.vmm_api_state as VmmApiState,
+      expected_vmm_api_state: resp.expected_vmm_api_state as VmmApiState,
+      divergence_action: resp.divergence_action,
+    };
+
+    const state: SandboxResetState = {
+      reset_at: resp.reset_at,
+      golden_hash: resp.golden_hash,
+      verification_passed: resp.verification_passed,
+      verification_details: verification,
+    };
+
+    return state;
+  }
+
+  async shutdown(): Promise<void> {
+    if (!this.helperProc || this.shuttingDown) return;
+    this.shuttingDown = true;
+
+    // Best-effort polite shutdown via NDJSON; if helper is wedged we
+    // SIGTERM after a grace window.
+    if (this.booted) {
+      try {
+        await Promise.race([
+          this.sendAndAwait({ request_id: randomUUID(), kind: "shutdown" }),
+          new Promise<never>((_, reject) =>
+            setTimeout(
+              () => reject(new Error("shutdown ack timeout")),
+              5_000,
+            ).unref(),
+          ),
+        ]);
+      } catch {
+        // Fall through to SIGTERM below.
+      }
+    }
+
+    const proc = this.helperProc;
+    this.helperProc = null;
+    this.booted = false;
+
+    // Reject any in-flight requests so callers don't hang.
+    for (const [id, pending] of this.inflight) {
+      pending.cancelled = true;
+      pending.reject(
+        new Error(`VzSandbox shutting down; request ${id} cancelled`),
+      );
+    }
+    this.inflight.clear();
+
+    try {
+      proc.kill("SIGTERM");
+    } catch {
+      // proc may already be dead.
+    }
+
+    // Give the helper a beat; if still alive, SIGKILL.
+    await new Promise<void>((resolve) => {
+      const t = setTimeout(() => {
+        try {
+          proc.kill("SIGKILL");
+        } catch {}
+        resolve();
+      }, 2_000);
+      t.unref();
+      proc.once("exit", () => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+  }
+
+  // ------------------------------------------------------------------
+  // Internals
+  // ------------------------------------------------------------------
+
+  private assertBooted(): void {
+    if (!this.booted || !this.helperProc) {
+      throw new Error("VzSandbox: boot() must be called before this operation");
+    }
+  }
+
+  private installPipeHandlers(proc: ChildProcess): void {
+    proc.stdout?.setEncoding("utf-8");
+    proc.stdout?.on("data", (chunk: string) => {
+      this.stdoutBuffer += chunk;
+      let nl: number;
+      while ((nl = this.stdoutBuffer.indexOf("\n")) !== -1) {
+        const line = this.stdoutBuffer.slice(0, nl).trim();
+        this.stdoutBuffer = this.stdoutBuffer.slice(nl + 1);
+        if (line.length === 0) continue;
+        this.handleLine(line);
+      }
+    });
+    proc.on("exit", (code, signal) => {
+      // Drain any waiters; null code + a signal is helper-killed-by-us.
+      for (const [id, pending] of this.inflight) {
+        if (pending.cancelled) continue;
+        pending.reject(
+          new Error(
+            `bsm-vz-helper exited (code=${code}, signal=${signal}) before responding to ${id}`,
+          ),
+        );
+      }
+      this.inflight.clear();
+      this.booted = false;
+    });
+  }
+
+  private bootResultResolver: ((r: HelperBootResult) => void) | null = null;
+  private bootResultRejecter: ((err: Error) => void) | null = null;
+
+  private async awaitBootResult(): Promise<HelperBootResult> {
+    return new Promise<HelperBootResult>((resolve, reject) => {
+      this.bootResultResolver = resolve;
+      this.bootResultRejecter = reject;
+
+      const t = setTimeout(() => {
+        if (this.bootResultRejecter) {
+          this.bootResultRejecter(
+            new Error("bsm-vz-helper did not produce a boot_result within 30s"),
+          );
+          this.bootResultResolver = null;
+          this.bootResultRejecter = null;
+        }
+      }, 30_000);
+      t.unref();
+    });
+  }
+
+  private handleLine(line: string): void {
+    let parsed: HelperResponse;
+    try {
+      parsed = JSON.parse(line) as HelperResponse;
+    } catch {
+      // Bad NDJSON from helper. Surface to stderr but don't crash;
+      // a misbehaving helper should be detectable, not panic the agent.
+      process.stderr.write(
+        `[sandbox-vz] non-JSON line from bsm-vz-helper: ${line}\n`,
+      );
+      return;
+    }
+
+    if (parsed.kind === "boot_result") {
+      const r = this.bootResultResolver;
+      this.bootResultResolver = null;
+      this.bootResultRejecter = null;
+      if (r) r(parsed);
+      return;
+    }
+
+    if (parsed.kind === "event") {
+      // Lifecycle events flow upward via stderr-style logging for
+      // now. When @brainst0rm/sandbox lands its EventEmitter shape,
+      // we'll re-emit on the same channel.
+      process.stderr.write(`[sandbox-vz] event: ${JSON.stringify(parsed)}\n`);
+      return;
+    }
+
+    const responseId = (parsed as { request_id?: string }).request_id;
+    if (!responseId) {
+      process.stderr.write(
+        `[sandbox-vz] response without request_id: ${line}\n`,
+      );
+      return;
+    }
+    const pending = this.inflight.get(responseId);
+    if (!pending) {
+      // Late response after timeout / cancellation. Drop with a log.
+      process.stderr.write(
+        `[sandbox-vz] late response for unknown request_id ${responseId}\n`,
+      );
+      return;
+    }
+    this.inflight.delete(responseId);
+    pending.resolve(parsed);
+  }
+
+  private async sendAndAwait(req: HelperRequest): Promise<HelperResponse> {
+    if (!this.helperProc?.stdin) {
+      throw new Error("helper is not running");
+    }
+    const payload = JSON.stringify(req) + "\n";
+    return new Promise<HelperResponse>((resolve, reject) => {
+      this.inflight.set(req.request_id, { resolve, reject });
+      this.helperProc!.stdin!.write(payload, (err) => {
+        if (err) {
+          this.inflight.delete(req.request_id);
+          reject(err);
+        }
+      });
+    });
+  }
+}
+
+// ----------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------
+
+function bootArgs(config: VzBootConfig): string[] {
+  const args = [
+    "boot",
+    "--kernel",
+    config.kernel,
+    "--rootfs",
+    config.rootfs,
+    "--cmdline",
+    config.cmdline ?? DEFAULT_CMDLINE,
+    "--cpus",
+    String(config.cpus ?? DEFAULT_CPUS),
+    "--memory-mib",
+    String(config.memoryMib ?? DEFAULT_MEMORY_MIB),
+  ];
+  if (config.initrd) args.push("--initrd", config.initrd);
+  if (config.savedStatePath) args.push("--saved-state", config.savedStatePath);
+  return args;
+}
+
+function sameBootConfig(a: VzBootConfig, b: VzBootConfig): boolean {
+  return (
+    a.kernel === b.kernel &&
+    a.rootfs === b.rootfs &&
+    a.initrd === b.initrd &&
+    a.cmdline === b.cmdline &&
+    a.cpus === b.cpus &&
+    a.memoryMib === b.memoryMib &&
+    a.helperPath === b.helperPath &&
+    a.savedStatePath === b.savedStatePath
+  );
+}

--- a/packages/sandbox-vz/tsconfig.json
+++ b/packages/sandbox-vz/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/sandbox-vz/tsup.config.ts
+++ b/packages/sandbox-vz/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+});

--- a/packages/sandbox/.tmp/.gitignore
+++ b/packages/sandbox/.tmp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -1,0 +1,213 @@
+# @brainst0rm/sandbox
+
+MicroVM sandbox abstraction for the Brainstorm endpoint agent.
+
+This is **P3.1a scaffolding**, not a runnable VM. It was authored on Darwin
+and **has not been booted against a real `cloud-hypervisor` binary**. The
+goal of this package today is to nail down the cross-backend interface,
+freeze the protocol-shape contracts (`ResetState`, `VerificationDetails`),
+and leave a Linux runner a small, well-documented set of pieces to fill in
+for first light.
+
+## What's in here
+
+| File                          | Status      | Notes                                                                                                                                                                                         |
+| ----------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/sandbox.ts`              | implemented | Abstract `Sandbox` interface, `ToolInvocation`, `ToolExecution`, `ResetState` re-export, `makeVerificationDetails` helper                                                                     |
+| `src/errors.ts`               | implemented | `SandboxNotAvailableError`, `SandboxBootError`, `SandboxToolTimeoutError`, `SandboxToolError`, `SandboxResetError`, `SandboxResetDivergenceError` — codes match the protocol error vocabulary |
+| `src/chv/chv-config.ts`       | implemented | `ChvSandboxConfig`, `KernelConfig`, `RootfsConfig`, `VsockConfig`, defaults                                                                                                                   |
+| `src/chv/chv-process.ts`      | partial     | Builds CHV argv, spawns the binary, refuses cleanly on non-Linux. **Validated on node-2 first-light (PR #277).**                                                                              |
+| `src/chv/vsock-client.ts`     | implemented | CHV `CONNECT <port>` handshake + length-prefixed JSON RPC loop. Validated end-to-end on node-2 (echo round-trip, 600ms boot / 2ms exec).                                                      |
+| `src/chv/chv-sandbox.ts`      | partial     | Boot / exec / shutdown validated on node-2. **Reset machinery (P3.2a) is host-side code only — full validation requires a real install-time golden-snapshot flow.**                           |
+| `src/chv/chv-remote.ts`       | implemented | `ch-remote` argv wrapper (`snapshot fs://`, `resume`, `info`) with injectable `ExecFileFn` for tests. Argv shape pinned by unit tests; semantics await node-2 integration.                    |
+| `src/chv/chv-overlay-hash.ts` | implemented | Streaming SHA-256 hasher over the rootfs CoW overlay file; injectable `HashFileFn` for tests. **No real overlay file has been hashed in this checkout.**                                      |
+
+## P3.2a — Linux reset machinery (host-side code, host-side validation)
+
+`ChvSandbox.reset()` now drives the full reset cycle:
+
+1. **Snapshot revert** via `ch-remote --api-socket <path> snapshot
+fs://<snapshotPath>` followed by `ch-remote --api-socket <path>
+resume`. Both calls go through `ChRemote` (`src/chv/chv-remote.ts`)
+   which centralises argv shape and accepts an injectable `ExecFileFn`
+   for tests.
+2. **3-source verification** (per threat-model §5.1):
+   - **fs_hash** — SHA-256 streamed over `rootfs.path` (the CoW overlay).
+     Compared against `baselines.fs_hash`.
+   - **open_fd_count** — `VsockClient.guestQuery("OpenFdCount")` over the
+     established vsock RPC channel. Compared against
+     `baselines.open_fd_count`.
+   - **vmm_api_state** — `ch-remote info` parsed for `state`, normalised
+     onto the protocol's canonical vocabulary
+     (`running` | `paused` | `stopped` | `error`). Compared against
+     `baselines.expected_vmm_api_state`.
+3. **Divergence handling.** If any single source disagrees with its
+   baseline, `reset()` throws `SandboxResetDivergenceError`, the sandbox
+   transitions to `state() === "failed"`, and the returned
+   `verification_details.divergence_action` is `"halt"`. This is
+   unconditional — we deliberately do NOT require a quorum, because the
+   substrate-lying threat model assumes an attacker can compromise up to
+   2 of 3 sources (threat-model §A6).
+4. **Baselines unset = scaffold mode.** If `config.baselines` is
+   undefined, each source emits an explicit "not-configured" marker
+   (`sha256:not-configured` for `fs_hash`, `0` for `open_fd_count`, the
+   live VMM state for `vmm_api_state`). The reset soft-passes; the
+   markers tell consumers (and the audit log) that real verification is
+   not yet wired. Production endpoints MUST configure baselines.
+
+### What still requires real-CHV validation on node-2
+
+This is **host-side code**. The unit tests pin the `ch-remote` argv
+shape and the divergence semantics against an injected `ExecFileFn` /
+`HashFileFn` / fake vsock. They DO NOT exercise:
+
+- Actual `ch-remote snapshot fs://...` semantics. CHV's documented verb
+  for revert is sometimes documented as `restore`; this implementation
+  uses `snapshot` per the P3.2a wire-protocol spec. If real CHV expects
+  a different verb, the integration runner will surface a non-zero exit
+  and we patch the verb in `chv-remote.ts` (one-line edit, obvious test
+  diff).
+- Actual rootfs CoW overlay file location and stability. We hash
+  whatever `rootfs.path` points to; whether that file settles to a
+  deterministic state after revert is for the runner to confirm.
+- The install-time **golden-snapshot creation flow**. P3.2a's reset path
+  consumes a snapshot that someone else creates. The matching install
+  flow (separate work item) needs to:
+  1. Boot the sandbox to a known-clean state.
+  2. Pause the VMM (`ch-remote pause`).
+  3. Create the snapshot (`ch-remote snapshot
+destination_url=file://<dir>`).
+  4. Compute the post-pause baselines: SHA-256 of the rootfs file,
+     `OpenFdCount` over vsock, `vmm_api_state` from `ch-remote info`.
+  5. Persist baselines to the endpoint config so reset can compare.
+
+### Honest gaps that block "real production reset"
+
+1. **Install-time golden-snapshot flow.** Not in this package; needs to
+   be wired before reset's `snapshotPath` mode is meaningful. Until
+   then, `snapshotPath` unset = no-op revert (verification still runs).
+2. **Rootfs-overlay path semantics.** `RootfsConfig.path` is treated as
+   the file to hash. For CHV's CoW mode, the path that's mutated is the
+   overlay file, which may differ from the read-only base disk. The
+   integration runner must point `rootfs.path` at the overlay file, not
+   the base.
+3. **`OpenFdCount` GuestQuery handler.** Implemented in `VsockClient`;
+   the in-guest dispatcher (P3.4 image-builder) must respond. First-light
+   confirmed echo dispatch but did not yet exercise GuestQuery.
+4. **Baseline-recording flow.** `ChvSandboxConfig.baselines` is a config
+   shape; how those values get computed and persisted at install time
+   is a separate work item.
+5. **Bootstrap kernel + rootfs**
+   This package consumes `KernelConfig.path` and `RootfsConfig.path` as
+   opaque strings. P3.4 produces both.
+
+## What's needed from `brainstormVM`
+
+P3.1a's hard sequencing gate is "brainstormVM `vm.boot` proven E2E on bare
+metal" (plan §5, R17). Beyond that gate, this package needs the following
+from the brainstormVM workstream:
+
+- **Kernel image baseline.** Whether to bundle our own `vmlinux` or consume
+  a brainstormVM-blessed one. Either way, we need its path on the runner
+  and ideally its expected hash (so the install-time baseline machinery
+  has something to record). _Open._
+- **Disk format / layout convention.** brainstormVM uses per-VM disks
+  (per the v3.2 plan note, D35); we need to know whether those disks are
+  raw or qcow2 so `--disk path=...` flags use the right form. _Open._
+- **Snapshot directory layout.** Cloud Hypervisor's `restore` flag takes
+  a `source_url=file://<dir>` pointing at a directory containing a
+  `state.json` + `mem.bin` + per-disk snapshot files. brainstormVM may
+  already have an opinion here; if not, we set it in P3.2a. _Open._
+- **VMM API state vocabulary.** This package maps `ch-remote info`'s
+  `state` field to the protocol's `VmmApiState` (`running` / `stopped` /
+  `paused` / `error`). brainstormVM's existing `vm.info` likely uses
+  similar names — we should align. _Open._
+
+## What's needed from P3.4 (image-build pipeline)
+
+- A reproducible Linux microVM rootfs containing the MVP tool set
+  (`echo`, `whoami`, `uname`, `cat-file`, plus 2–3 MSP-relevant tools).
+- The in-guest dispatcher: a tiny program listening on the vsock port
+  that accepts JSON-line requests, forks the requested tool, returns
+  `{ exit_code, stdout, stderr, evidence_hash }`. The wire format
+  proposed in `vsock-client.ts` is the contract — needs P3.3 alignment
+  with crd4sdom's Go agent before it's frozen.
+- The install-time baseline-recording flow that produces
+  `ChvSandboxConfig.baselines` (`fs_hash`, `open_fd_count`,
+  `expected_vmm_api_state`).
+
+## Linux runner first-light checklist
+
+When this scaffolding lands on a real Linux box (Hetzner runner per
+0bz7aztr's pattern), the following sequence brings first light:
+
+1. **Verify substrate.** Confirm `cloud-hypervisor --version` and
+   `ch-remote --version` are present on `$PATH`. KVM available
+   (`ls /dev/kvm`).
+2. **Confirm `isChvSupportedHost()` returns true.** It should — sanity
+   check.
+3. **Stand up kernel + rootfs paths.** Either consume brainstormVM
+   artifacts or use a plain Debian cloud kernel + minimal rootfs to
+   prove boot, before P3.4 lands the real image.
+4. **Implement the vsock RPC.**
+   - Replace the throw at the bottom of `VsockClient.open()` with a real
+     `CONNECT <guestPort>\n` write + `OK <port>\n` read.
+   - Replace `VsockClient.sendCommand()` body with a real JSON-line
+     write + read loop, deadline-bounded by `setTimeout`.
+   - Build the in-guest dispatcher matching the wire format.
+5. **Boot the VM.**
+   - Construct a `ChvSandbox` with kernel/rootfs/vsock config.
+   - Call `boot()`. It should resolve without throwing.
+   - Confirm `state()` returns `"ready"`.
+6. **Run a no-op tool.**
+   - Call `executeTool({ tool: "echo", params: { message: "hello" }, command_id: "...", deadline_ms: 5000 })`.
+   - Verify `exit_code === 0`, `stdout` contains "hello".
+7. **Wire FS-hash + open-fd sources for `verifyPostReset`.**
+   - Replace the "return baseline" stubs with a real overlay hash and a
+     real in-guest fd-count query.
+8. **Snapshot + revert smoke.**
+   - Take a snapshot via `ch-remote snapshot destination_url=file://...`.
+   - Run a tool that mutates state.
+   - Call `reset()`. Confirm:
+     - `verification_passed: true`
+     - `verification_details.fs_hash_match: true`
+     - `verification_details.divergence_action: "none"`
+   - Re-run the no-op tool to confirm sandbox is still functional.
+9. **Negative reset test.**
+   - After reset, mutate the host-visible overlay file directly.
+   - Call `reset()` again — verification should now FAIL with
+     `SandboxResetDivergenceError`. This proves the integrity monitor
+     catches at least one of the substrate-lying patterns from threat
+     model §A6.
+10. **Hand off to P3.2a (Linux reset machinery).** Reset latency
+    measurement (1000 iterations, p50 < 500 ms target) and
+    failure-mode catalog.
+
+## Build / typecheck
+
+```bash
+npx turbo run build --filter='@brainst0rm/sandbox'
+npx turbo run typecheck --filter='@brainst0rm/sandbox'
+```
+
+The build was confirmed green on Darwin during scaffolding. There are no
+tests in this package yet — meaningful tests require a Linux runner. The
+type contract is the binding artifact today; tests follow first light.
+
+## Relationship to the rest of Phase 3
+
+- **P3.1b (macOS / Apple Virtualization.framework)** — separate package.
+  Implements the same `Sandbox` interface from `src/sandbox.ts` so the
+  dispatcher remains backend-agnostic. Currently TBD on naming
+  (`@brainst0rm/sandbox-vf`?). The `SandboxBackend` union here already
+  reserves `"vf"`.
+- **P3.3 (Go integration)** — crd4sdom's work mirrors this interface in
+  Go. The TypeScript `ChvSandbox` is the reference for behaviour, not
+  the production runtime — the Go agent will own the in-process path on
+  Linux endpoints. This package may also be wired into
+  `@brainst0rm/endpoint-stub` as an optional executor for end-to-end
+  TypeScript-only loops during dev.
+- **P3.4 (image build)** — produces the kernel + rootfs + in-guest
+  dispatcher this package consumes opaquely.
+- **P3.5a (Linux validation)** — runs the 1000-dispatch red-team
+  against a fully wired-up `ChvSandbox`.

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@brainst0rm/sandbox",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "MicroVM sandbox abstraction for the Brainstorm endpoint agent. Defines the Sandbox interface (boot/executeTool/reset/shutdown) consumed by the endpoint dispatcher (P3.3) and provides a Cloud Hypervisor backend (P3.1a, Linux track). Apple Virtualization.framework backend (P3.1b) lives elsewhere.",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/src/index.js"
+    },
+    "./scripts/first-light": {
+      "import": "./dist/scripts/first-light.js"
+    },
+    "./scripts/snapshot-create": {
+      "import": "./dist/scripts/snapshot-create.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests"
+  },
+  "dependencies": {
+    "@brainst0rm/relay": "0.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsup": "^8.3.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/sandbox/scripts/README.md
+++ b/packages/sandbox/scripts/README.md
@@ -1,0 +1,198 @@
+# sandbox first-light + reset-cycle scripts
+
+Smoke-test scripts for proving an end-to-end CHV boot + dispatch on a real
+Linux KVM host, plus the install-time golden-snapshot CLI and the
+reset-cycle integration test that exercises P3.2a's substrate-lying
+defense end-to-end.
+
+## Files
+
+- `first-light.sh` — full driver (host sanity → build → image-builder → boot
+  - echo dispatch → captured log + summary). Run from monorepo root.
+- `first-light.ts` — Node script that constructs a `ChvSandbox` against a
+  pre-built kernel + rootfs, calls `boot()`, runs an `echo` tool through
+  the vsock dispatch path, and exits 0/1/2/3 based on outcome.
+- `snapshot-create.ts` — install-time CLI. Boots cold, pauses VMM, takes
+  a CHV snapshot, computes the three baselines (fs_hash / open_fd_count
+  / expected_vmm_api_state), emits a JSON config block to stdout. Exit
+  codes 0/1/2/3/4 (see header for the mapping).
+- `reset-cycle.sh` — P3.2a integration validator. Mints a golden via
+  `snapshot-create.js`, drives a clean reset, tampers the overlay,
+  drives a second reset, and asserts the second one throws
+  `SandboxResetDivergenceError`. Called by `full-validation.sh` step 7.
+
+## Usage
+
+### Full driver (recommended)
+
+From a clean Linux x86_64 host with KVM:
+
+```bash
+# Install prereqs (Ubuntu 24.04):
+#   cloud-hypervisor + ch-remote (release tarball or distro pkg)
+#   nodejs >=22 (NodeSource)
+#   docker (for image-builder)
+git clone https://github.com/justinjilg/brainstorm.git
+cd brainstorm
+git checkout feat/sandbox-phase-3-scaffold
+
+bash packages/sandbox/scripts/first-light.sh
+```
+
+Exit codes:
+
+- `0` — boot reached `state="ready"` AND echo dispatch returned `exit_code=0`
+- `1` — boot failed (CHV crash, vsock handshake timeout, etc.)
+- `2` — boot OK, executeTool failed
+- `3` — host sanity / config error
+- `4` — TS build or image-builder failed
+
+Logs land in `${FIRSTLIGHT_DIR:-/var/lib/firstlight}/first-light-<timestamp>.log`.
+
+### Just the Node script
+
+If you want to bring your own kernel + rootfs and skip the image-builder step:
+
+```bash
+npx turbo run build --filter='@brainst0rm/sandbox'
+
+export BSM_KERNEL=/path/to/bsm-sandbox-kernel
+export BSM_ROOTFS=/path/to/bsm-sandbox-rootfs.img
+export BSM_VSOCK_SOCKET=/tmp/bsm-vsock.sock
+export BSM_API_SOCKET=/tmp/bsm-api.sock
+export BSM_GUEST_PORT=52000   # image-builder's vsock-init default
+
+node packages/sandbox/dist/scripts/first-light.js
+```
+
+### Install-time golden-snapshot flow
+
+The runtime reset path (`ChvSandbox.reset()`) requires
+`config.snapshotPath` AND a fully-populated `config.baselines` block, or
+`verifyPostReset()` deliberately throws `SandboxResetDivergenceError`
+(threat-model §A6 substrate-lying defense, by design). The
+`snapshot-create.ts` CLI mints both.
+
+Run it once per (kernel + rootfs + image-builder version) tuple. Re-run
+after any image-builder rebuild that changes the rootfs payload.
+
+```bash
+# Build first (produces dist/scripts/snapshot-create.js):
+npx turbo run build --filter='@brainst0rm/sandbox'
+
+# Inputs:
+export BSM_KERNEL=/path/to/bsm-sandbox-kernel
+export BSM_INITRAMFS=/path/to/bsm-sandbox-initramfs   # optional but typical
+export BSM_ROOTFS=/path/to/bsm-sandbox-rootfs.img
+export BSM_OVERLAY=/var/lib/bsm/overlay.img           # CoW destination
+export BSM_SNAPSHOT_DIR=/var/lib/bsm/golden           # snapshot files land here
+export BSM_VSOCK_SOCKET=/tmp/bsm-snapshot.sock        # default
+export BSM_API_SOCKET=/tmp/bsm-snapshot-api.sock      # default
+export BSM_GUEST_PORT=52000                           # image-builder default
+
+# Run — JSON to stdout, progress to stderr:
+node packages/sandbox/dist/scripts/snapshot-create.js \
+    --output=/var/lib/bsm/golden-baselines.json
+```
+
+Output (stdout, also written to `--output` if provided):
+
+```json
+{
+  "snapshotPath": "/var/lib/bsm/golden",
+  "rootfs": {
+    "path": "/path/to/bsm-sandbox-rootfs.img",
+    "overlayPath": "/var/lib/bsm/overlay.img"
+  },
+  "baselines": {
+    "fs_hash": "sha256:...",
+    "open_fd_count": 3,
+    "expected_vmm_api_state": "running"
+  }
+}
+```
+
+Paste the three top-level keys (`snapshotPath`, `rootfs`, `baselines`)
+into your `ChvSandboxConfig`. The runtime reset path will then:
+
+1. `restore source_url=file://<snapshotPath>` + `resume`
+2. Hash `rootfs.overlayPath` and compare to `baselines.fs_hash`
+3. `GuestQuery OpenFdCount` and compare to `baselines.open_fd_count`
+4. `ch-remote info` and compare to `baselines.expected_vmm_api_state`
+
+Any disagreement produces `divergence_action="halt"` and
+`reset()` throws `SandboxResetDivergenceError`.
+
+Exit codes:
+
+- `0` — snapshot + baselines emitted successfully
+- `1` — boot failed
+- `2` — pause / snapshot / resume failed
+- `3` — env / usage error (missing required env, missing files)
+- `4` — baseline computation failed (overlay hash, fd query, info parse)
+
+### Reset-cycle integration test
+
+`reset-cycle.sh` is the end-to-end gate that proves the substrate-lying
+defense actually fires. Pipeline:
+
+1. Build sandbox + image artifacts (re-uses image-builder cache)
+2. Run `snapshot-create.js` → mints `${RESET_CYCLE_DIR}/golden-<ts>/`
+   and a baseline JSON file
+3. Boot a fresh `ChvSandbox` configured from that JSON
+4. Run an echo dispatch (proves the vsock channel)
+5. `reset()` → expect `divergence_action="none"` (overlay unchanged)
+6. **Tamper**: append a sentinel string to `BSM_OVERLAY` via
+   `appendFileSync` (any byte change breaks the SHA-256 hash)
+7. `reset()` → MUST throw `SandboxResetDivergenceError`
+8. PASS if step 7 throws the right error class; FAIL otherwise
+
+Run from monorepo root:
+
+```bash
+bash packages/sandbox/scripts/reset-cycle.sh
+```
+
+Logs land in `${RESET_CYCLE_DIR:-/var/lib/firstlight}/reset-cycle-<ts>.log`.
+
+Exit codes:
+
+- `0` — defense fired correctly (PASS)
+- `1` — defense compromised, setup failure, or unexpected error class
+- `3` — host sanity failure
+- `4` — sandbox build / image artifacts missing
+
+`full-validation.sh` step 7 auto-detects this script and runs it; absent
+the script, step 7 prints "skipped" with a clear reason. Once this
+script is on disk, the auto-skip flips to "run".
+
+## What this proves
+
+- `cloud-hypervisor` is callable + can boot a Linux guest from the
+  image-builder's kernel + rootfs
+- The CHV `--vsock cid=N,socket=/path` device works end-to-end
+- The host's `VsockClient` CONNECT handshake matches CHV's bridge protocol
+- The in-guest `vsock-init` (PID 1, length-prefixed JSON over vsock)
+  receives a `ToolDispatch`, exec's `echo`, returns a `ToolResult` with
+  matching `command_id`
+- The 30s partial-frame timeout doesn't trip on a healthy peer
+
+## What this does NOT prove
+
+- Snapshot/revert reset machinery (P3.2a — not yet wired)
+- 3-source verification with real baselines (`fs_hash`, `open_fd_count`,
+  `vmm_api_state`) — `verifyPostReset` returns sentinel zeros until P3.2a
+- Resistance to the substrate-lying attacker (P3.5 / P-A6 — currently
+  mock-only)
+- Multi-sandbox-per-host isolation (post-MVP)
+
+## Image-builder notes
+
+The image-builder default port for `vsock-init` is **52000**, set via the
+constant `defaultVsockPort` in `packages/image-builder/vsock-init/main.go`.
+The `BSM_VSOCK_PORT` env var on the kernel cmdline can override it. The
+host-side `VsockClient` defaults to port 1024 (per protocol §6 canonical
+table); the first-light script overrides to 52000 to match image-builder.
+
+If you re-build vsock-init with a different default, pass the matching port
+via `BSM_GUEST_PORT`.

--- a/packages/sandbox/scripts/first-light.sh
+++ b/packages/sandbox/scripts/first-light.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# CHV first-light driver. Run on a Linux x86_64 host with KVM, cloud-hypervisor,
+# ch-remote, Node 22+, and Docker (for the image-builder).
+#
+# Steps:
+#   1. Sanity-check the host (KVM, binaries, Node version)
+#   2. Build @brainst0rm/sandbox + @brainst0rm/relay (deps) + @brainst0rm/image-builder
+#   3. Run the image-builder Docker pipeline → produces kernel + rootfs.img
+#   4. Run packages/sandbox/scripts/first-light.ts → boots a CHV VM, runs echo,
+#      verifies state="ready" + exit_code=0
+#   5. Captures full stdout/stderr to $LOG and prints last 80 lines + summary
+#
+# Usage (from monorepo root):
+#   bash packages/sandbox/scripts/first-light.sh
+#
+# Override defaults via env:
+#   FIRSTLIGHT_DIR=/var/lib/firstlight  (where logs + artifact paths land)
+
+set -uo pipefail
+
+FIRSTLIGHT_DIR="${FIRSTLIGHT_DIR:-/var/lib/firstlight}"
+LOG="${FIRSTLIGHT_DIR}/first-light-$(date +%Y%m%d-%H%M%S).log"
+
+mkdir -p "$FIRSTLIGHT_DIR"
+exec > >(tee -a "$LOG") 2>&1
+
+echo "=== CHV first-light driver ==="
+echo "host: $(hostname)  arch: $(uname -m)  kernel: $(uname -r)"
+echo "log:  $LOG"
+echo
+
+# ---- 1. host sanity ----------------------------------------------------
+fail=0
+have() { command -v "$1" >/dev/null 2>&1; }
+
+if [[ ! -e /dev/kvm ]]; then echo "MISSING /dev/kvm"; fail=1; fi
+for bin in cloud-hypervisor ch-remote node docker; do
+  if have "$bin"; then
+    echo "OK   $bin: $($bin --version 2>&1 | head -1)"
+  else
+    echo "MISS $bin (install before running)"
+    fail=1
+  fi
+done
+node_v=$(node --version 2>/dev/null | sed 's/v//' | cut -d. -f1)
+if [[ -n "$node_v" && "$node_v" -lt 22 ]]; then
+  echo "WARN node is v$node_v; need 22+"
+  fail=1
+fi
+# Ubuntu 24.04's docker.io lacks BuildKit; image-builder Dockerfile uses
+# `# syntax=docker/dockerfile:1.6` so buildx is required.
+if have docker && ! docker buildx version >/dev/null 2>&1; then
+  echo "MISS docker buildx (apt-get install -y docker-buildx)"
+  fail=1
+fi
+if [[ $fail -ne 0 ]]; then
+  echo
+  echo "host sanity FAILED — fix the above and re-run"
+  exit 3
+fi
+
+# ---- 2. build TS packages ----------------------------------------------
+echo
+echo "=== build sandbox + deps ==="
+cd "$(dirname "$0")/../../.."   # monorepo root
+npm install --no-audit --no-fund
+npx turbo run build --filter='@brainst0rm/sandbox' || { echo "sandbox build failed"; exit 4; }
+
+# ---- 3. build images ---------------------------------------------------
+echo
+echo "=== build kernel + rootfs (image-builder) ==="
+bash packages/image-builder/scripts/build.sh || { echo "image-builder failed"; exit 4; }
+
+KERNEL="$(pwd)/packages/image-builder/artifacts/bsm-sandbox-kernel"
+INITRAMFS="$(pwd)/packages/image-builder/artifacts/bsm-sandbox-initramfs"
+ROOTFS="$(pwd)/packages/image-builder/artifacts/bsm-sandbox-rootfs.img"
+
+if [[ ! -f "$KERNEL" || ! -f "$INITRAMFS" || ! -f "$ROOTFS" ]]; then
+  echo "image artifacts missing after build:"
+  ls -la packages/image-builder/artifacts/
+  exit 4
+fi
+
+echo "kernel:    $KERNEL ($(stat -c%s "$KERNEL") bytes)"
+echo "initramfs: $INITRAMFS ($(stat -c%s "$INITRAMFS") bytes)"
+echo "rootfs:    $ROOTFS ($(stat -c%s "$ROOTFS") bytes)"
+
+# ---- 4. boot + dispatch ------------------------------------------------
+echo
+echo "=== first-light: boot + echo dispatch ==="
+export BSM_KERNEL="$KERNEL"
+export BSM_INITRAMFS="$INITRAMFS"
+export BSM_ROOTFS="$ROOTFS"
+export BSM_VSOCK_SOCKET="${FIRSTLIGHT_DIR}/vsock.sock"
+export BSM_API_SOCKET="${FIRSTLIGHT_DIR}/api.sock"
+export BSM_GUEST_PORT="${BSM_GUEST_PORT:-52000}"
+
+node packages/sandbox/dist/scripts/first-light.js
+rc=$?
+
+# ---- 5. summary --------------------------------------------------------
+echo
+echo "=== summary ==="
+echo "exit code: $rc"
+echo "log:       $LOG"
+echo
+echo "tail (last 80 lines):"
+tail -n 80 "$LOG"
+exit $rc

--- a/packages/sandbox/scripts/first-light.ts
+++ b/packages/sandbox/scripts/first-light.ts
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+// CHV first-light smoke test.
+//
+// Boots a ChvSandbox against artifacts produced by @brainst0rm/image-builder
+// (kernel + rootfs.img with vsock-init as PID 1), runs an `echo` tool through
+// the vsock dispatch path, and prints a structured PASS/FAIL summary.
+//
+// Inputs (env vars):
+//   BSM_KERNEL          — absolute path to bsm-sandbox-kernel       (required)
+//   BSM_INITRAMFS       — absolute path to bsm-sandbox-initramfs    (required for modular kernels like Alpine virt)
+//   BSM_ROOTFS          — absolute path to bsm-sandbox-rootfs.img   (required)
+//   BSM_VSOCK_SOCKET    — host-side AF_UNIX path for CHV vsock      (default: /tmp/bsm-firstlight.sock)
+//   BSM_API_SOCKET      — Cloud Hypervisor REST API socket          (default: /tmp/bsm-firstlight-api.sock)
+//   BSM_GUEST_PORT      — guest-side vsock port for vsock-init       (default: 52000, image-builder default)
+//   BSM_CH_BIN          — cloud-hypervisor binary                   (default: lookup on PATH)
+//   BSM_CHREMOTE_BIN    — ch-remote binary                          (default: lookup on PATH)
+//
+// Exit codes:
+//   0  — boot reached state="ready" AND echo dispatch returned exit_code=0
+//   1  — boot failed (CHV process crash, vsock handshake timeout, etc.)
+//   2  — boot OK but executeTool failed
+//   3  — usage / config error (missing required env)
+//
+// This is the bar from packages/sandbox/README.md "Linux runner first-light
+// checklist" steps 5 + 6.
+
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { dirname } from "node:path";
+
+import { ChvSandbox } from "../src/index.js";
+
+interface FirstLightConfig {
+  kernel: string;
+  initramfs?: string;
+  rootfs: string;
+  vsockSocket: string;
+  apiSocket: string;
+  guestPort: number;
+  cloudHypervisorBin?: string;
+  chRemoteBin?: string;
+}
+
+function loadConfig(): FirstLightConfig {
+  const env = process.env;
+  const kernel = env.BSM_KERNEL;
+  const initramfs = env.BSM_INITRAMFS;
+  const rootfs = env.BSM_ROOTFS;
+  if (!kernel) {
+    console.error(
+      "[firstlight] BSM_KERNEL is required (path to bsm-sandbox-kernel)",
+    );
+    process.exit(3);
+  }
+  if (!rootfs) {
+    console.error(
+      "[firstlight] BSM_ROOTFS is required (path to bsm-sandbox-rootfs.img)",
+    );
+    process.exit(3);
+  }
+  if (!existsSync(kernel)) {
+    console.error(
+      `[firstlight] BSM_KERNEL points to nonexistent path: ${kernel}`,
+    );
+    process.exit(3);
+  }
+  if (initramfs !== undefined && !existsSync(initramfs)) {
+    console.error(
+      `[firstlight] BSM_INITRAMFS points to nonexistent path: ${initramfs}`,
+    );
+    process.exit(3);
+  }
+  if (!existsSync(rootfs)) {
+    console.error(
+      `[firstlight] BSM_ROOTFS points to nonexistent path: ${rootfs}`,
+    );
+    process.exit(3);
+  }
+  return {
+    kernel,
+    initramfs,
+    rootfs,
+    vsockSocket: env.BSM_VSOCK_SOCKET ?? "/tmp/bsm-firstlight.sock",
+    apiSocket: env.BSM_API_SOCKET ?? "/tmp/bsm-firstlight-api.sock",
+    guestPort: env.BSM_GUEST_PORT ? parseInt(env.BSM_GUEST_PORT, 10) : 52000,
+    cloudHypervisorBin: env.BSM_CH_BIN,
+    chRemoteBin: env.BSM_CHREMOTE_BIN,
+  };
+}
+
+function purgeStaleSocket(path: string): void {
+  if (existsSync(path)) {
+    rmSync(path);
+  }
+  const dir = dirname(path);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
+async function main(): Promise<void> {
+  const cfg = loadConfig();
+  purgeStaleSocket(cfg.vsockSocket);
+  purgeStaleSocket(cfg.apiSocket);
+
+  console.log(
+    `[firstlight] kernel=${cfg.kernel}\n` +
+      `[firstlight] initramfs=${cfg.initramfs ?? "(none)"}\n` +
+      `[firstlight] rootfs=${cfg.rootfs}\n` +
+      `[firstlight] vsock=${cfg.vsockSocket} (guest port ${cfg.guestPort})\n` +
+      `[firstlight] api=${cfg.apiSocket}`,
+  );
+
+  const sandbox = new ChvSandbox({
+    cloudHypervisorBin: cfg.cloudHypervisorBin,
+    chRemoteBin: cfg.chRemoteBin,
+    apiSocketPath: cfg.apiSocket,
+    kernel: { path: cfg.kernel, initramfs: cfg.initramfs },
+    rootfs: { path: cfg.rootfs, readonly: true },
+    vsock: {
+      socketPath: cfg.vsockSocket,
+      guestPort: cfg.guestPort,
+    },
+    cpus: 2,
+    memMib: 1024,
+  });
+
+  const t0 = Date.now();
+  try {
+    await sandbox.boot();
+  } catch (err) {
+    console.error(
+      `[firstlight] BOOT FAILED after ${Date.now() - t0}ms: ${(err as Error).message}`,
+    );
+    if ((err as Error).stack) console.error((err as Error).stack);
+    process.exit(1);
+  }
+  const bootMs = Date.now() - t0;
+  if (sandbox.state() !== "ready") {
+    console.error(
+      `[firstlight] sandbox.state() = ${sandbox.state()} (expected ready)`,
+    );
+    await sandbox.shutdown().catch(() => {});
+    process.exit(1);
+  }
+  console.log(`[firstlight] PASS boot in ${bootMs}ms; sandbox.state() = ready`);
+
+  // --- echo dispatch round-trip ------------------------------------------
+  const t1 = Date.now();
+  let result;
+  try {
+    result = await sandbox.executeTool({
+      command_id: `firstlight-${Date.now()}`,
+      tool: "echo",
+      params: { message: "hello-from-host" },
+      deadline_ms: 30_000,
+    });
+  } catch (err) {
+    console.error(
+      `[firstlight] EXEC FAILED after ${Date.now() - t1}ms: ${(err as Error).message}`,
+    );
+    await sandbox.shutdown().catch(() => {});
+    process.exit(2);
+  }
+  const execMs = Date.now() - t1;
+
+  if (result.exit_code !== 0) {
+    console.error(
+      `[firstlight] echo returned exit_code=${result.exit_code}\n` +
+        `  stdout: ${JSON.stringify(result.stdout)}\n` +
+        `  stderr: ${JSON.stringify(result.stderr)}`,
+    );
+    await sandbox.shutdown().catch(() => {});
+    process.exit(2);
+  }
+
+  console.log(
+    `[firstlight] PASS exec in ${execMs}ms; exit_code=0\n` +
+      `[firstlight]   stdout: ${result.stdout.trim()}`,
+  );
+  await sandbox.shutdown().catch(() => {});
+
+  console.log(
+    `[firstlight] === ALL GREEN ===\n` +
+      `[firstlight] boot=${bootMs}ms exec=${execMs}ms total=${Date.now() - t0}ms`,
+  );
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(`[firstlight] uncaught: ${(err as Error).message}`);
+  if ((err as Error).stack) console.error((err as Error).stack);
+  process.exit(1);
+});

--- a/packages/sandbox/scripts/full-validation.sh
+++ b/packages/sandbox/scripts/full-validation.sh
@@ -1,0 +1,395 @@
+#!/usr/bin/env bash
+# CHV full-validation driver (P3.5b). Run on a Linux x86_64 host with KVM,
+# cloud-hypervisor, ch-remote, Node 22+, and Docker (for the image-builder).
+#
+# Pipeline:
+#   1. Host sanity (re-uses first-light.sh's checks)
+#   2. Build TS packages (sandbox + sandbox-redteam)
+#   3. Build kernel + rootfs.img + initramfs (cache-friendly: skipped if
+#      artifacts already exist and SKIP_IMAGE_BUILD=1, or always rebuilt
+#      with FORCE_IMAGE_BUILD=1)
+#   4. Cold smoke first-light (proves the path before the long battery)
+#   5. 1000-iter latency battery (cold-boot + dispatch + shutdown per iter)
+#   6. Concurrent-8 stress (N parallel ChvSandbox instances)
+#   7. Reset cycle test — gated on P3.2a presence; skip with a clear message
+#      if reset machinery isn't wired in this checkout
+#   8. Single JSON summary at $VALIDATION_DIR/validation-<ts>.json
+#
+# Usage (from monorepo root):
+#   bash packages/sandbox/scripts/full-validation.sh
+#
+# Override defaults via env:
+#   VALIDATION_DIR=/var/lib/firstlight   (where logs + report land)
+#   ITERATIONS=1000                      (latency battery iterations)
+#   CONCURRENCY=8                        (concurrent stress instances)
+#   SKIP_IMAGE_BUILD=1                   (reuse existing artifacts)
+#   FORCE_IMAGE_BUILD=1                  (rebuild even if artifacts exist)
+#   SKIP_SMOKE=1                         (skip step 4)
+#   SKIP_LATENCY=1                       (skip step 5)
+#   SKIP_CONCURRENT=1                    (skip step 6)
+
+set -euo pipefail
+
+# Validate VALIDATION_DIR upfront: must be an absolute path AND contain
+# the substring "firstlight" so we can never (under any operator
+# override) target /var, /var/lib, or other paths that production
+# brainstormvm-agent CHV processes might live under. (Codex Q3 catch.)
+VALIDATION_DIR="${VALIDATION_DIR:-/var/lib/firstlight}"
+if [[ "$VALIDATION_DIR" != /* ]]; then
+  echo "FATAL: VALIDATION_DIR must be an absolute path; got '$VALIDATION_DIR'"
+  exit 3
+fi
+if [[ "$VALIDATION_DIR" != *firstlight* ]]; then
+  echo "FATAL: VALIDATION_DIR must contain the substring 'firstlight' for"
+  echo "       host-safety (phase cleanup uses fixed-string PID matching"
+  echo "       scoped to this directory). Got: '$VALIDATION_DIR'"
+  exit 3
+fi
+ITERATIONS="${ITERATIONS:-1000}"
+# Accept CONCURRENCY or BSM_MAX_CONCURRENT (the latter is what
+# 0bz7aztr's first-light coordination message used). On memory-tight
+# hosts (e.g. node-2's existing 548-zombie footprint), drop this to 4.
+CONCURRENCY="${CONCURRENCY:-${BSM_MAX_CONCURRENT:-8}}"
+TS=$(date +%Y%m%d-%H%M%S)
+LOG="${VALIDATION_DIR}/full-validation-${TS}.log"
+SUMMARY="${VALIDATION_DIR}/validation-${TS}.json"
+
+mkdir -p "$VALIDATION_DIR"
+exec > >(tee -a "$LOG") 2>&1
+
+echo "=== CHV full-validation driver (P3.5b) ==="
+echo "host:    $(hostname)  arch: $(uname -m)  kernel: $(uname -r)"
+echo "log:     $LOG"
+echo "summary: $SUMMARY"
+echo "knobs:   ITERATIONS=$ITERATIONS CONCURRENCY=$CONCURRENCY"
+if free -h >/dev/null 2>&1; then
+  echo "memory:  $(free -h | awk '/^Mem:/{print $2 " total / " $7 " avail"}')"
+  # Each CHV instance is configured for 1 GiB. Concurrent peak ≈ N GiB.
+  echo "  concurrent-${CONCURRENCY} peak RAM estimate: ${CONCURRENCY} GiB"
+fi
+echo "phase staggering: each step tears down stragglers before the next starts"
+echo
+
+# Track per-step results in a JSON-friendly form. We assemble the summary
+# at the end via a python heredoc so we don't depend on jq being present.
+SMOKE_RC="not_run"
+LAT_RC="not_run"
+CONC_RC="not_run"
+RESET_RC="skipped"
+RESET_REASON=""
+LAT_REPORT="${VALIDATION_DIR}/latency-${TS}.json"
+CONC_REPORT="${VALIDATION_DIR}/concurrent-${TS}.json"
+
+# Phase-cleanup gate. Called BETWEEN every battery so a CHV that didn't
+# tear itself down cleanly can't carry over RAM/socket state into the
+# next phase. Per 0bz7aztr's pre-flight RAM-headroom check on node-2.
+#
+# Host-safety: targets are matched by FIXED-STRING substring on
+# VALIDATION_DIR using `grep -F`, NOT regex. VALIDATION_DIR is validated
+# upfront to be absolute AND contain "firstlight", so we cannot under
+# any operator override match production brainstormvm-agent CHV
+# processes living under /var/lib/brainstormvm/ or /var/run/brainstormvm/.
+# (Codex Q3 catch.)
+phase_cleanup() {
+  local label="$1"
+  echo
+  echo "  -- phase cleanup ($label): killing any stragglers + reclaiming sockets"
+  # Build candidate PID list via ps + grep -F (fixed string). We require
+  # the argv to contain BOTH "cloud-hypervisor" AND VALIDATION_DIR
+  # before we'll touch the process — neither alone is sufficient.
+  local victims
+  victims=$(ps -e -o pid=,args= \
+    | grep -F "cloud-hypervisor" \
+    | grep -F "$VALIDATION_DIR" \
+    | awk '{print $1}' \
+    || true)
+  if [[ -n "$victims" ]]; then
+    echo "  -- found stragglers; SIGTERMing:"
+    for pid in $victims; do
+      ps -p "$pid" -o pid=,args= | sed 's/^/      /'
+      kill -TERM "$pid" 2>/dev/null || true
+    done
+    sleep 2
+    # Re-check; SIGKILL anyone who didn't go down cleanly.
+    for pid in $victims; do
+      if kill -0 "$pid" 2>/dev/null; then
+        kill -KILL "$pid" 2>/dev/null || true
+      fi
+    done
+  else
+    echo "  -- no stragglers (clean tear-down)"
+  fi
+  rm -f "${VALIDATION_DIR}"/*.sock 2>/dev/null || true
+  # Brief sleep so the OS can reclaim freed pages before the next
+  # phase starts allocating. Tuned for the largest gap (concurrent → reset).
+  sleep 1
+}
+
+# trap exit handler so phase_cleanup runs on any path out of this script
+# (smoke-fail summarise_and_exit, npm-install fail under set -e, ctrl-c
+# during a battery, etc.). Idempotent.
+trap 'phase_cleanup "trap-on-exit" || true' EXIT INT TERM
+
+summarise_and_exit() {
+  local rc="${1:-0}"
+  echo
+  echo "=== summary ==="
+  echo "smoke:      $SMOKE_RC"
+  echo "latency:    $LAT_RC ($LAT_REPORT)"
+  echo "concurrent: $CONC_RC ($CONC_REPORT)"
+  echo "reset:      $RESET_RC"
+  echo "log:        $LOG"
+  echo "summary:    $SUMMARY"
+
+  python3 - "$SUMMARY" \
+      "$SMOKE_RC" "$LAT_RC" "$CONC_RC" "$RESET_RC" \
+      "$LAT_REPORT" "$CONC_REPORT" "$RESET_REASON" "$LOG" "$TS" \
+      "$ITERATIONS" "$CONCURRENCY" "${KERNEL:-}" "${INITRAMFS:-}" "${ROOTFS:-}" <<'PYEOF'
+import json, os, sys
+[summary_path, smoke, lat, conc, reset, lat_report, conc_report,
+ reset_reason, log_path, ts, iterations, concurrency, kernel, initramfs,
+ rootfs] = sys.argv[1:16]
+
+def load(path):
+    if path and os.path.exists(path):
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except Exception as e:
+            return {"_load_error": str(e)}
+    return None
+
+out = {
+    "schema_version": "1.0",
+    "generated_at": ts,
+    "host": {
+        "hostname": os.uname().nodename,
+        "kernel": os.uname().release,
+        "arch": os.uname().machine,
+    },
+    "knobs": {
+        "iterations": int(iterations),
+        "concurrency": int(concurrency),
+    },
+    "artifacts": {
+        "kernel": kernel,
+        "initramfs": initramfs,
+        "rootfs": rootfs,
+    },
+    "steps": {
+        "smoke": {"status": smoke},
+        "latency": {
+            "status": lat,
+            "report_path": lat_report,
+            "report": load(lat_report),
+        },
+        "concurrent": {
+            "status": conc,
+            "report_path": conc_report,
+            "report": load(conc_report),
+        },
+        "reset": {
+            "status": reset,
+            "reason": reset_reason if reset == "skipped" else None,
+        },
+    },
+    "log": log_path,
+}
+with open(summary_path, "w") as f:
+    json.dump(out, f, indent=2)
+PYEOF
+
+  echo
+  echo "JSON summary: $SUMMARY"
+  exit "$rc"
+}
+
+# ---- 1. host sanity ----------------------------------------------------
+echo "=== step 1: host sanity ==="
+fail=0
+have() { command -v "$1" >/dev/null 2>&1; }
+
+if [[ ! -e /dev/kvm ]]; then echo "MISSING /dev/kvm"; fail=1; fi
+for bin in cloud-hypervisor ch-remote node docker; do
+  if have "$bin"; then
+    echo "OK   $bin: $($bin --version 2>&1 | head -1)"
+  else
+    echo "MISS $bin (install before running)"
+    fail=1
+  fi
+done
+node_v=$(node --version 2>/dev/null | sed 's/v//' | cut -d. -f1)
+if [[ -n "$node_v" && "$node_v" -lt 22 ]]; then
+  echo "WARN node is v$node_v; need 22+"
+  fail=1
+fi
+if have docker && ! docker buildx version >/dev/null 2>&1; then
+  echo "MISS docker buildx (apt-get install -y docker-buildx)"
+  fail=1
+fi
+if [[ $fail -ne 0 ]]; then
+  echo
+  echo "host sanity FAILED — fix the above and re-run"
+  exit 3
+fi
+echo "host sanity OK"
+
+# ---- 2. build TS packages ----------------------------------------------
+echo
+echo "=== step 2: build sandbox + sandbox-redteam ==="
+cd "$(dirname "$0")/../../.."   # monorepo root
+npm install --no-audit --no-fund
+npx turbo run build --filter='@brainst0rm/sandbox' --filter='@brainst0rm/sandbox-redteam' \
+  || { echo "TS build failed"; exit 4; }
+
+# ---- 3. build images (cache-friendly) ----------------------------------
+echo
+echo "=== step 3: build kernel + rootfs (image-builder) ==="
+KERNEL="$(pwd)/packages/image-builder/artifacts/bsm-sandbox-kernel"
+INITRAMFS="$(pwd)/packages/image-builder/artifacts/bsm-sandbox-initramfs"
+ROOTFS="$(pwd)/packages/image-builder/artifacts/bsm-sandbox-rootfs.img"
+
+# Staleness check: if image-builder source (vsock-init/, build/Dockerfile,
+# scripts/build.sh, etc.) is newer than the produced rootfs.img, force
+# rebuild. (0bz7aztr's run-6 catch — pure existence-check let old vsock-
+# init binaries run against fresh source, masking both fixes and
+# regressions.)
+. packages/image-builder/scripts/lib-stale-check.sh
+
+need_build=1
+if [[ -f "$KERNEL" && -f "$INITRAMFS" && -f "$ROOTFS" ]]; then
+  if [[ "${FORCE_IMAGE_BUILD:-0}" == "1" ]]; then
+    echo "FORCE_IMAGE_BUILD=1 — rebuilding images even though artifacts exist"
+    need_build=1
+  elif [[ "${SKIP_IMAGE_BUILD:-0}" == "1" ]]; then
+    echo "SKIP_IMAGE_BUILD=1 — reusing existing artifacts (overrides staleness check)"
+    need_build=0
+  elif image_artifacts_stale "$(pwd)"; then
+    echo "artifacts present but STALE relative to image-builder source — rebuilding"
+    need_build=1
+  else
+    echo "artifacts present and fresh (set FORCE_IMAGE_BUILD=1 to rebuild anyway)"
+    need_build=0
+  fi
+fi
+if [[ $need_build -eq 1 ]]; then
+  bash packages/image-builder/scripts/build.sh \
+    || { echo "image-builder failed"; exit 4; }
+fi
+if [[ ! -f "$KERNEL" || ! -f "$INITRAMFS" || ! -f "$ROOTFS" ]]; then
+  echo "image artifacts missing after step 3:"
+  ls -la packages/image-builder/artifacts/
+  exit 4
+fi
+echo "kernel:    $KERNEL ($(stat -c%s "$KERNEL") bytes)"
+echo "initramfs: $INITRAMFS ($(stat -c%s "$INITRAMFS") bytes)"
+echo "rootfs:    $ROOTFS ($(stat -c%s "$ROOTFS") bytes)"
+
+# Common env exports for steps 4/5/6.
+export BSM_KERNEL="$KERNEL"
+export BSM_INITRAMFS="$INITRAMFS"
+export BSM_ROOTFS="$ROOTFS"
+export BSM_GUEST_PORT="${BSM_GUEST_PORT:-52000}"
+
+# ---- 4. cold smoke first-light -----------------------------------------
+if [[ "${SKIP_SMOKE:-0}" == "1" ]]; then
+  echo
+  echo "=== step 4: cold smoke first-light SKIPPED (SKIP_SMOKE=1) ==="
+  SMOKE_RC="skipped"
+else
+  echo
+  echo "=== step 4: cold smoke first-light ==="
+  export BSM_VSOCK_SOCKET="${VALIDATION_DIR}/smoke-vsock.sock"
+  export BSM_API_SOCKET="${VALIDATION_DIR}/smoke-api.sock"
+  rm -f "$BSM_VSOCK_SOCKET" "$BSM_API_SOCKET"
+  if node packages/sandbox/dist/scripts/first-light.js; then
+    SMOKE_RC="pass"
+    echo "smoke first-light: PASS"
+  else
+    SMOKE_RC="fail"
+    echo "smoke first-light: FAIL — aborting before long batteries"
+    summarise_and_exit 1
+  fi
+  phase_cleanup "post-smoke"
+fi
+
+# ---- 5. 1000-iter latency battery --------------------------------------
+if [[ "${SKIP_LATENCY:-0}" == "1" ]]; then
+  echo
+  echo "=== step 5: latency battery SKIPPED (SKIP_LATENCY=1) ==="
+  LAT_RC="skipped"
+else
+  echo
+  echo "=== step 5: ${ITERATIONS}-iter latency battery ==="
+  export BSM_VSOCK_SOCKET="${VALIDATION_DIR}/lat-vsock.sock"
+  export BSM_API_SOCKET="${VALIDATION_DIR}/lat-api.sock"
+  rm -f "${VALIDATION_DIR}"/lat-vsock.sock* "${VALIDATION_DIR}"/lat-api.sock*
+  if node packages/sandbox-redteam/dist/bin/bsm-redteam.js \
+      --probes lat-only \
+      --iterations "$ITERATIONS" \
+      --output "$LAT_REPORT"; then
+    LAT_RC="pass"
+    echo "latency battery: PASS — report at $LAT_REPORT"
+  else
+    LAT_RC="fail"
+    echo "latency battery: FAIL — report at $LAT_REPORT"
+  fi
+  phase_cleanup "post-latency"
+fi
+
+# ---- 6. concurrent stress ---------------------------------------------
+if [[ "${SKIP_CONCURRENT:-0}" == "1" ]]; then
+  echo
+  echo "=== step 6: concurrent-${CONCURRENCY} stress SKIPPED (SKIP_CONCURRENT=1) ==="
+  CONC_RC="skipped"
+else
+  echo
+  echo "=== step 6: concurrent-${CONCURRENCY} stress ==="
+  export BSM_VSOCK_SOCKET="${VALIDATION_DIR}/conc-vsock.sock"
+  export BSM_API_SOCKET="${VALIDATION_DIR}/conc-api.sock"
+  rm -f "${VALIDATION_DIR}"/conc-vsock.sock* "${VALIDATION_DIR}"/conc-api.sock*
+  if node packages/sandbox-redteam/dist/bin/bsm-redteam.js \
+      --probes concurrent \
+      --concurrency "$CONCURRENCY" \
+      --output "$CONC_REPORT"; then
+    CONC_RC="pass"
+    echo "concurrent-${CONCURRENCY}: PASS — report at $CONC_REPORT"
+  else
+    CONC_RC="fail"
+    echo "concurrent-${CONCURRENCY}: FAIL — report at $CONC_REPORT"
+  fi
+  phase_cleanup "post-concurrent"
+fi
+
+# ---- 7. reset cycle test (gated on P3.2a) ------------------------------
+echo
+echo "=== step 7: reset cycle test ==="
+# P3.2a wires real snapshot/restore + 3-source verification. Until that
+# lands, ChvSandbox.reset() returns sentinel verification with the
+# ResetSandboxConfig.snapshotPath ?? skip path. We detect P3.2a by
+# checking for a script the orchestrator's plan has it producing:
+# packages/sandbox/scripts/reset-cycle.sh. If absent, we skip with a
+# clear message rather than fabricating a green.
+RESET_SCRIPT="packages/sandbox/scripts/reset-cycle.sh"
+if [[ -f "$RESET_SCRIPT" ]]; then
+  echo "reset-cycle script found — running"
+  if bash "$RESET_SCRIPT"; then
+    RESET_RC="pass"
+  else
+    RESET_RC="fail"
+  fi
+else
+  RESET_RC="skipped"
+  RESET_REASON="P3.2a reset machinery (snapshot/restore + 3-source verification) not in this checkout — $RESET_SCRIPT does not exist. Re-run after P3.2a lands."
+  echo "reset cycle test SKIPPED: $RESET_REASON"
+fi
+
+# ---- 8. summary --------------------------------------------------------
+# Determine overall exit status. Any "fail" in mandatory steps → 1.
+overall=0
+for step_rc in "$SMOKE_RC" "$LAT_RC" "$CONC_RC" "$RESET_RC"; do
+  if [[ "$step_rc" == "fail" ]]; then
+    overall=1
+  fi
+done
+summarise_and_exit "$overall"

--- a/packages/sandbox/scripts/reset-cycle.sh
+++ b/packages/sandbox/scripts/reset-cycle.sh
@@ -1,0 +1,383 @@
+#!/usr/bin/env bash
+# CHV reset-cycle validation driver (P3.2a integration).
+#
+# Goal: prove that the install-time golden-snapshot flow + runtime
+# 3-source verification together detect a substrate-lying attacker who
+# tampers with the rootfs CoW overlay between dispatches.
+#
+# Pipeline:
+#   1. Sanity-check the host (KVM, binaries) — re-uses first-light gating
+#   2. Build sandbox (incl. snapshot-create.js)
+#   3. Build kernel + initramfs + rootfs.img if absent
+#   4. Run snapshot-create → mints golden snapshot + emits baseline JSON
+#   5. Boot a fresh ChvSandbox with that JSON, run an echo dispatch,
+#      reset() → expect divergence_action="none" (clean reset)
+#   6. Tamper with the overlay file (simulate substrate-lying attacker)
+#   7. reset() again → MUST throw SandboxResetDivergenceError
+#   8. Report PASS if the second reset throws, FAIL otherwise
+#
+# Tampering method: `printf '...' >> "$BSM_OVERLAY"`. Plain shell append
+# is the simplest possible mutation — it changes the file's bytes, which
+# makes the streaming SHA-256 hash diverge from baseline.fs_hash. We
+# considered `dd seek=...` (sector-level) and `mount -o loop && touch`
+# (filesystem-level), but both rely on host privileges (root, loop
+# device availability) that the validation runner shouldn't need. The
+# defense we're testing is *hash-based* — any byte change breaks it,
+# so the simplest tamper that perturbs bytes is the right test.
+#
+# What proves the defense works:
+#   - second reset() exits non-zero AND stderr contains
+#     "SandboxResetDivergenceError" or "divergence_action=halt"
+#
+# What proves the defense fails (i.e. SECURITY-CRITICAL bug):
+#   - second reset() returns successfully (exit 0)
+#   - OR exits non-zero but with a different error class
+#     (we treat boot/setup errors as INCONCLUSIVE rather than PASS,
+#     because a generic crash isn't proof the integrity monitor caught
+#     the tamper)
+#
+# Usage (from monorepo root):
+#   bash packages/sandbox/scripts/reset-cycle.sh
+#
+# Override defaults via env:
+#   RESET_CYCLE_DIR=/var/lib/firstlight  (where logs + artifact paths land)
+
+set -uo pipefail
+
+RESET_CYCLE_DIR="${RESET_CYCLE_DIR:-/var/lib/firstlight}"
+TS=$(date +%Y%m%d-%H%M%S)
+LOG="${RESET_CYCLE_DIR}/reset-cycle-${TS}.log"
+JSON_OUT="${RESET_CYCLE_DIR}/reset-cycle-baselines-${TS}.json"
+DRIVER_OUT="${RESET_CYCLE_DIR}/reset-cycle-driver-${TS}.log"
+SNAPSHOT_DIR="${RESET_CYCLE_DIR}/golden-${TS}"
+# OVERLAY no longer pre-created as a separate file — the tamper target
+# is now BSM_ROOTFS itself (the actual file CHV's --disk reads). The
+# earlier separate-overlay path produced an empty-file → SHA-256("")
+# baseline → silent no-op for the substrate-lying defense. (run-5 catch.)
+VSOCK_SOCK="${RESET_CYCLE_DIR}/reset-cycle-${TS}-vsock.sock"
+API_SOCK="${RESET_CYCLE_DIR}/reset-cycle-${TS}-api.sock"
+
+# The driver `.mjs` MUST live inside the workspace so Node's normal
+# package resolution finds `@brainst0rm/sandbox` via the workspace's
+# node_modules symlink. Writing it to RESET_CYCLE_DIR (typically
+# /var/lib/firstlight) breaks the import — caught by 0bz7aztr on
+# run-2 with ERR_MODULE_NOT_FOUND.
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+DRIVER_TMP_DIR="${REPO_ROOT}/packages/sandbox/.tmp"
+
+mkdir -p "$RESET_CYCLE_DIR" "$DRIVER_TMP_DIR"
+exec > >(tee -a "$LOG") 2>&1
+
+echo "=== CHV reset-cycle driver (P3.2a) ==="
+echo "host:     $(hostname)  arch: $(uname -m)  kernel: $(uname -r)"
+echo "log:      $LOG"
+echo "snapshot: $SNAPSHOT_DIR"
+echo "tamper-target: ROOTFS (=overlay default; CHV's readonly disk file)"
+echo "json:     $JSON_OUT"
+echo
+
+# ---- 1. host sanity (light) -------------------------------------------
+fail=0
+have() { command -v "$1" >/dev/null 2>&1; }
+if [[ ! -e /dev/kvm ]]; then echo "MISSING /dev/kvm"; fail=1; fi
+for bin in cloud-hypervisor ch-remote node; do
+  if have "$bin"; then
+    echo "OK   $bin: $($bin --version 2>&1 | head -1)"
+  else
+    echo "MISS $bin (install before running)"
+    fail=1
+  fi
+done
+if [[ $fail -ne 0 ]]; then
+  echo
+  echo "host sanity FAILED — fix the above and re-run"
+  exit 3
+fi
+
+# ---- 2. build sandbox -------------------------------------------------
+echo
+echo "=== step 2: build sandbox (incl. snapshot-create.js) ==="
+cd "$(dirname "$0")/../../.."   # monorepo root
+npx turbo run build --filter='@brainst0rm/sandbox' \
+  || { echo "sandbox build failed"; exit 4; }
+
+if [[ ! -f packages/sandbox/dist/scripts/snapshot-create.js ]]; then
+  echo "FATAL: dist/scripts/snapshot-create.js not produced by tsup"
+  ls -la packages/sandbox/dist/scripts/ || true
+  exit 4
+fi
+
+# ---- 3. images (reuse if present) -------------------------------------
+echo
+echo "=== step 3: ensure kernel + rootfs ==="
+KERNEL="$(pwd)/packages/image-builder/artifacts/bsm-sandbox-kernel"
+INITRAMFS="$(pwd)/packages/image-builder/artifacts/bsm-sandbox-initramfs"
+ROOTFS="$(pwd)/packages/image-builder/artifacts/bsm-sandbox-rootfs.img"
+
+# Source the staleness-check helper. (0bz7aztr's run-6 catch — pure
+# existence checks were letting old vsock-init binaries run against
+# fresh source, masking both fixes and regressions.)
+. packages/image-builder/scripts/lib-stale-check.sh
+if [[ ! -f "$KERNEL" || ! -f "$INITRAMFS" || ! -f "$ROOTFS" ]]; then
+  echo "image artifacts missing — running image-builder"
+  bash packages/image-builder/scripts/build.sh \
+    || { echo "image-builder failed"; exit 4; }
+elif image_artifacts_stale "$(pwd)"; then
+  echo "image artifacts present but STALE relative to image-builder source —"
+  echo "running image-builder to refresh"
+  rm -f "$KERNEL" "$INITRAMFS" "$ROOTFS" \
+        packages/image-builder/artifacts/bsm-sandbox-rootfs.tar \
+        packages/image-builder/artifacts/vsock-init.bin \
+        packages/image-builder/artifacts/checksums.txt
+  bash packages/image-builder/scripts/build.sh \
+    || { echo "image-builder failed"; exit 4; }
+else
+  echo "image artifacts present and fresh"
+fi
+
+if [[ ! -f "$KERNEL" || ! -f "$INITRAMFS" || ! -f "$ROOTFS" ]]; then
+  echo "image artifacts STILL missing after build:"
+  ls -la packages/image-builder/artifacts/
+  exit 4
+fi
+echo "kernel:    $KERNEL"
+echo "initramfs: $INITRAMFS"
+echo "rootfs:    $ROOTFS"
+
+# ---- 4. snapshot-create -----------------------------------------------
+echo
+echo "=== step 4: mint golden snapshot + baseline JSON ==="
+mkdir -p "$SNAPSHOT_DIR"
+rm -f "$VSOCK_SOCK" "$API_SOCK"
+
+export BSM_KERNEL="$KERNEL"
+export BSM_INITRAMFS="$INITRAMFS"
+export BSM_ROOTFS="$ROOTFS"
+# BSM_OVERLAY intentionally NOT set — snapshot-create defaults it to
+# BSM_ROOTFS (the file CHV's --disk actually points at). Earlier
+# scripting passed a separate empty file, which produced SHA-256("")
+# baselines and silently no-op'd Source 1. (0bz7aztr's run-5 catch.)
+export BSM_SNAPSHOT_DIR="$SNAPSHOT_DIR"
+export BSM_VSOCK_SOCKET="$VSOCK_SOCK"
+export BSM_API_SOCKET="$API_SOCK"
+export BSM_GUEST_PORT="${BSM_GUEST_PORT:-52000}"
+
+# stdout of snapshot-create is JSON; stderr is progress. Capture both.
+if ! node packages/sandbox/dist/scripts/snapshot-create.js \
+    --output="$JSON_OUT" \
+    > "${JSON_OUT}.stdout" 2> "${JSON_OUT}.stderr"; then
+  rc=$?
+  echo "snapshot-create FAILED (rc=$rc):"
+  echo "--- stderr ---"
+  cat "${JSON_OUT}.stderr"
+  echo "--- stdout ---"
+  cat "${JSON_OUT}.stdout"
+  exit 4
+fi
+echo "snapshot-create PASS — baseline JSON at $JSON_OUT"
+echo "--- baseline JSON ---"
+cat "$JSON_OUT"
+echo "--- end ---"
+
+# ---- 5/6/7. drive reset cycle through a Node helper -------------------
+# Inline node helper: load the JSON, build a ChvSandbox config, boot,
+# echo, reset (expect clean), tamper overlay, reset (expect throw).
+echo
+echo "=== step 5/6/7: reset-cycle driver ==="
+# Reuse the same sockets — purge first.
+rm -f "$VSOCK_SOCK" "$API_SOCK"
+
+DRIVER_JS="${DRIVER_TMP_DIR}/reset-cycle-driver-${TS}.mjs"
+# Always remove the temp driver on exit (success or failure) so the
+# workspace stays clean.
+trap 'rm -f "$DRIVER_JS"' EXIT
+cat > "$DRIVER_JS" <<'EOF'
+// Reset-cycle driver. Loads the snapshot-create JSON, boots a fresh
+// ChvSandbox with it, runs the clean reset → tamper → divergent reset
+// pipeline. Exit codes:
+//   0  PASS  (first reset clean, second reset threw divergence)
+//   10 FAIL  (first reset diverged unexpectedly)
+//   20 FAIL  (second reset did NOT throw — defense compromised)
+//   30 FAIL  (second reset threw but with the wrong error class —
+//            inconclusive, treated as FAIL for safety)
+//   40 ERROR (boot or echo dispatch failed before we could test the
+//            cycle; not a defense failure, just a setup failure)
+import { readFileSync, appendFileSync } from "node:fs";
+
+const JSON_PATH = process.env.JSON_PATH;
+const KERNEL = process.env.BSM_KERNEL;
+const INITRAMFS = process.env.BSM_INITRAMFS;
+const ROOTFS = process.env.BSM_ROOTFS;
+const VSOCK_SOCK = process.env.BSM_VSOCK_SOCKET;
+const API_SOCK = process.env.BSM_API_SOCKET;
+const GUEST_PORT = parseInt(process.env.BSM_GUEST_PORT || "52000", 10);
+// Tamper target = the file CHV's --disk path= actually points at. With
+// `readonly=on` CHV doesn't write here, so the snapshot/restore round-
+// trip never touches these bytes; an external tamper of these bytes
+// is exactly what FS-hash verification should detect. Default to
+// ROOTFS to match the new RootfsConfig.overlayPath default — the
+// earlier separate empty-file path produced SHA-256("") baselines.
+// (0bz7aztr's run-5 catch.)
+const OVERLAY = process.env.BSM_OVERLAY ?? ROOTFS;
+
+const log = (m) => {
+  process.stderr.write(`[reset-cycle-driver] ${m}\n`);
+};
+
+const baseline = JSON.parse(readFileSync(JSON_PATH, "utf-8"));
+log(`loaded baseline JSON: snapshotPath=${baseline.snapshotPath}`);
+
+const { ChvSandbox, SandboxResetDivergenceError } = await import(
+  "@brainst0rm/sandbox"
+);
+
+const sandbox = new ChvSandbox({
+  apiSocketPath: API_SOCK,
+  kernel: { path: KERNEL, initramfs: INITRAMFS },
+  rootfs: {
+    path: ROOTFS,
+    overlayPath: OVERLAY,
+    readonly: true,
+  },
+  vsock: { socketPath: VSOCK_SOCK, guestPort: GUEST_PORT },
+  cpus: 2,
+  memMib: 1024,
+  snapshotPath: baseline.snapshotPath,
+  baselines: baseline.baselines,
+});
+
+try {
+  log("boot...");
+  await sandbox.boot();
+  if (sandbox.state() !== "ready") {
+    log(`unexpected state: ${sandbox.state()}`);
+    process.exit(40);
+  }
+
+  log("echo dispatch...");
+  const result = await sandbox.executeTool({
+    command_id: `reset-cycle-${Date.now()}`,
+    tool: "echo",
+    params: { message: "pre-reset hello" },
+    deadline_ms: 30_000,
+  });
+  if (result.exit_code !== 0) {
+    log(`echo failed exit_code=${result.exit_code} stderr=${result.stderr}`);
+    process.exit(40);
+  }
+  log(`echo OK: ${result.stdout.trim()}`);
+
+  // --- first reset: should be CLEAN -----------------------------------
+  log("first reset (expect clean)...");
+  let firstReset;
+  try {
+    firstReset = await sandbox.reset();
+  } catch (e) {
+    log(`first reset threw unexpectedly: ${e.constructor.name}: ${e.message}`);
+    process.exit(10);
+  }
+  log(
+    `first reset: divergence_action=${firstReset.verification_details.divergence_action} ` +
+      `verification_passed=${firstReset.verification_passed}`,
+  );
+  if (firstReset.verification_details.divergence_action !== "none") {
+    log("FAIL: first reset diverged when overlay was untampered");
+    process.exit(10);
+  }
+
+  // --- tamper with overlay --------------------------------------------
+  // Append a sentinel to the CoW file. Streaming SHA-256 of the
+  // post-tamper file MUST disagree with baseline.fs_hash, so the next
+  // reset's verifyPostReset fires divergence.
+  //
+  // Why simple `>>` append: the integrity monitor hashes BYTES; any
+  // change of any kind breaks the hash. We deliberately don't go through
+  // mount/loop/dd because that adds privilege requirements without
+  // testing anything additional — the defense is hash-vs-baseline, full
+  // stop. A simple shell append exercises that exact path.
+  log(`tampering: appending substrate-lie sentinel to ${OVERLAY}`);
+  appendFileSync(
+    OVERLAY,
+    `\nSUBSTRATE_LIE_SENTINEL_${Date.now()}_${Math.random()}\n`,
+  );
+
+  // --- second reset: should THROW SandboxResetDivergenceError ---------
+  log("second reset (expect SandboxResetDivergenceError)...");
+  let caught = null;
+  try {
+    const second = await sandbox.reset();
+    log(
+      `second reset returned without throwing: ${JSON.stringify(
+        second.verification_details,
+      )}`,
+    );
+  } catch (e) {
+    caught = e;
+  }
+
+  if (caught === null) {
+    log("FAIL: second reset did NOT throw — substrate-lying defense BROKEN");
+    process.exit(20);
+  }
+  if (!(caught instanceof SandboxResetDivergenceError)) {
+    log(
+      `FAIL (inconclusive): second reset threw ${caught.constructor.name} ` +
+        `not SandboxResetDivergenceError. Message: ${caught.message}`,
+    );
+    process.exit(30);
+  }
+  log(`PASS: second reset threw SandboxResetDivergenceError as expected`);
+  log(`  message: ${caught.message}`);
+  process.exit(0);
+} catch (e) {
+  log(`uncaught driver error: ${e.constructor.name}: ${e.message}`);
+  if (e.stack) log(e.stack);
+  process.exit(40);
+} finally {
+  try {
+    await sandbox.shutdown();
+  } catch {}
+}
+EOF
+
+export JSON_PATH="$JSON_OUT"
+export BSM_OVERLAY
+set +e
+node "$DRIVER_JS" 2>&1 | tee "$DRIVER_OUT"
+rc=${PIPESTATUS[0]}
+set -e
+
+# ---- 8. report --------------------------------------------------------
+echo
+echo "=== summary ==="
+echo "driver exit code: $rc"
+echo "log:              $LOG"
+echo "driver log:       $DRIVER_OUT"
+echo "baseline JSON:    $JSON_OUT"
+
+case "$rc" in
+  0)
+    echo "PASS: substrate-lying defense fired on tampered overlay"
+    exit 0
+    ;;
+  10)
+    echo "FAIL: clean reset diverged (baseline mismatch on first reset — overlay non-determinism?)"
+    exit 1
+    ;;
+  20)
+    echo "FAIL: tampered reset DID NOT THROW — substrate-lying defense is broken"
+    exit 1
+    ;;
+  30)
+    echo "FAIL (inconclusive): tampered reset threw the wrong error class"
+    exit 1
+    ;;
+  40)
+    echo "ERROR: setup failure (boot/echo); reset cycle not exercised"
+    exit 1
+    ;;
+  *)
+    echo "ERROR: unexpected driver exit code $rc"
+    exit 1
+    ;;
+esac

--- a/packages/sandbox/scripts/snapshot-create.ts
+++ b/packages/sandbox/scripts/snapshot-create.ts
@@ -1,0 +1,391 @@
+#!/usr/bin/env node
+// CHV install-time golden-snapshot CLI.
+//
+// Boots a ChvSandbox cold against a kernel + rootfs, pauses the VMM via
+// ch-remote, takes a snapshot to BSM_SNAPSHOT_DIR, resumes, then computes
+// the three baselines that ChvSandbox.verifyPostReset() compares against
+// at runtime:
+//
+//   1. fs_hash               — streaming SHA-256 of BSM_OVERLAY (CoW file)
+//   2. open_fd_count         — `GuestQuery { kind: "OpenFdCount" }` over vsock
+//   3. expected_vmm_api_state — normalised `ch-remote info` reading
+//
+// Emits a JSON config block to stdout (and to --output if given) that the
+// operator pastes into their sandbox config under `snapshotPath`,
+// `rootfs.overlayPath`, and `baselines`. Without that block reset()
+// throws `SandboxResetDivergenceError("baselines not configured")` by
+// design (substrate-lying defense, threat-model §A6).
+//
+// Inputs (env vars):
+//   BSM_KERNEL          — absolute path to bsm-sandbox-kernel       (required)
+//   BSM_INITRAMFS       — absolute path to bsm-sandbox-initramfs    (required for modular kernels)
+//   BSM_ROOTFS          — absolute path to bsm-sandbox-rootfs.img   (required)
+//   BSM_OVERLAY         — absolute path to the writable CoW overlay (required for fs_hash)
+//   BSM_SNAPSHOT_DIR    — directory to write the golden snapshot into (required)
+//   BSM_VSOCK_SOCKET    — host-side AF_UNIX path                    (default: /tmp/bsm-snapshot.sock)
+//   BSM_API_SOCKET      — Cloud Hypervisor REST API socket          (default: /tmp/bsm-snapshot-api.sock)
+//   BSM_GUEST_PORT      — guest-side vsock port                     (default: 52000)
+//   BSM_CH_BIN          — cloud-hypervisor binary                   (default: lookup on PATH)
+//   BSM_CHREMOTE_BIN    — ch-remote binary                          (default: lookup on PATH)
+//
+// Args:
+//   --output=<path>     — write the JSON config block to this path as well as stdout
+//
+// Exit codes:
+//   0  — snapshot created + baselines computed successfully
+//   1  — boot failure (CHV crash, vsock handshake timeout, etc.)
+//   2  — snapshot failure (pause/snapshot/resume non-zero exit)
+//   3  — env / usage error (missing required env, missing files)
+//   4  — baseline computation failure (overlay hash, fd query, info parse)
+//
+// Honesty: this CLI has been exercised against the unit-tested ChRemote
+// mock pathway, but not against a real ch-remote v40+ binary in this
+// checkout. The argv shape pinned in __tests__/chv-remote.test.ts matches
+// the documented v40+ form; node-2's reset-cycle.sh is the integration gate.
+
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+import {
+  ChvSandbox,
+  ChRemote,
+  defaultExecFile,
+  defaultHashFile,
+  normaliseVmmState,
+  type VmmApiState,
+} from "../src/index.js";
+
+interface SnapshotConfig {
+  kernel: string;
+  initramfs?: string;
+  rootfs: string;
+  overlay: string;
+  snapshotDir: string;
+  vsockSocket: string;
+  apiSocket: string;
+  guestPort: number;
+  cloudHypervisorBin?: string;
+  chRemoteBin?: string;
+  outputPath?: string;
+}
+
+function loadConfig(): SnapshotConfig {
+  const env = process.env;
+
+  // Parse --output=<path> (only flag we support).
+  let outputPath: string | undefined;
+  for (const arg of process.argv.slice(2)) {
+    if (arg.startsWith("--output=")) {
+      outputPath = arg.slice("--output=".length);
+    } else if (arg === "--help" || arg === "-h") {
+      console.error(
+        `usage: snapshot-create [--output=<path>]\n` +
+          `\n` +
+          `required env: BSM_KERNEL, BSM_ROOTFS, BSM_OVERLAY, BSM_SNAPSHOT_DIR\n` +
+          `optional env: BSM_INITRAMFS, BSM_VSOCK_SOCKET, BSM_API_SOCKET, BSM_GUEST_PORT, BSM_CH_BIN, BSM_CHREMOTE_BIN`,
+      );
+      process.exit(3);
+    } else {
+      console.error(`[snapshot-create] unknown argument: ${arg}`);
+      process.exit(3);
+    }
+  }
+
+  const required = (name: string, value: string | undefined): string => {
+    if (value === undefined || value === "") {
+      console.error(`[snapshot-create] ${name} is required`);
+      process.exit(3);
+    }
+    return value;
+  };
+
+  const kernel = required("BSM_KERNEL", env.BSM_KERNEL);
+  const rootfs = required("BSM_ROOTFS", env.BSM_ROOTFS);
+  // BSM_OVERLAY was a phantom env var in earlier scripting — it
+  // pointed at an empty file that CHV never wrote to, so the FS hash
+  // baseline ended up being SHA-256("") and the substrate-lying
+  // defense was a silent no-op. (0bz7aztr's run-5 catch — severity
+  // high.) CHV's `--disk path=<rootfs>,readonly=on` doesn't expose a
+  // separate overlay; the file CHV touches IS the rootfs.img, and an
+  // external tamper of those bytes is exactly what the FS hash should
+  // detect. Default the overlay path to rootfs (matching the existing
+  // RootfsConfig.overlayPath default-to-`path` behavior).
+  const overlay = env.BSM_OVERLAY ?? rootfs;
+  const snapshotDir = required("BSM_SNAPSHOT_DIR", env.BSM_SNAPSHOT_DIR);
+  const initramfs = env.BSM_INITRAMFS;
+
+  if (!existsSync(kernel)) {
+    console.error(
+      `[snapshot-create] BSM_KERNEL points to nonexistent path: ${kernel}`,
+    );
+    process.exit(3);
+  }
+  if (initramfs !== undefined && !existsSync(initramfs)) {
+    console.error(
+      `[snapshot-create] BSM_INITRAMFS points to nonexistent path: ${initramfs}`,
+    );
+    process.exit(3);
+  }
+  if (!existsSync(rootfs)) {
+    console.error(
+      `[snapshot-create] BSM_ROOTFS points to nonexistent path: ${rootfs}`,
+    );
+    process.exit(3);
+  }
+  if (!existsSync(overlay)) {
+    console.error(
+      `[snapshot-create] BSM_OVERLAY points to nonexistent path: ${overlay}`,
+    );
+    process.exit(3);
+  }
+
+  return {
+    kernel,
+    initramfs,
+    rootfs,
+    overlay,
+    snapshotDir,
+    vsockSocket: env.BSM_VSOCK_SOCKET ?? "/tmp/bsm-snapshot.sock",
+    apiSocket: env.BSM_API_SOCKET ?? "/tmp/bsm-snapshot-api.sock",
+    guestPort: env.BSM_GUEST_PORT ? parseInt(env.BSM_GUEST_PORT, 10) : 52000,
+    cloudHypervisorBin: env.BSM_CH_BIN,
+    chRemoteBin: env.BSM_CHREMOTE_BIN,
+    outputPath,
+  };
+}
+
+function purgeStaleSocket(path: string): void {
+  if (existsSync(path)) {
+    rmSync(path);
+  }
+  const dir = dirname(path);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
+function ensureDir(path: string): void {
+  if (!existsSync(path)) {
+    mkdirSync(path, { recursive: true });
+  }
+}
+
+interface BaselineBlock {
+  snapshotPath: string;
+  rootfs: { path: string; overlayPath: string };
+  baselines: {
+    fs_hash: string;
+    open_fd_count: number;
+    expected_vmm_api_state: VmmApiState;
+  };
+}
+
+async function main(): Promise<void> {
+  const cfg = loadConfig();
+  purgeStaleSocket(cfg.vsockSocket);
+  purgeStaleSocket(cfg.apiSocket);
+  ensureDir(cfg.snapshotDir);
+
+  console.error(
+    `[snapshot-create] kernel=${cfg.kernel}\n` +
+      `[snapshot-create] initramfs=${cfg.initramfs ?? "(none)"}\n` +
+      `[snapshot-create] rootfs=${cfg.rootfs}\n` +
+      `[snapshot-create] overlay=${cfg.overlay}\n` +
+      `[snapshot-create] snapshot-dir=${cfg.snapshotDir}\n` +
+      `[snapshot-create] vsock=${cfg.vsockSocket} (guest port ${cfg.guestPort})\n` +
+      `[snapshot-create] api=${cfg.apiSocket}`,
+  );
+
+  const sandbox = new ChvSandbox({
+    cloudHypervisorBin: cfg.cloudHypervisorBin,
+    chRemoteBin: cfg.chRemoteBin,
+    apiSocketPath: cfg.apiSocket,
+    kernel: { path: cfg.kernel, initramfs: cfg.initramfs },
+    rootfs: {
+      path: cfg.rootfs,
+      overlayPath: cfg.overlay,
+      readonly: true,
+    },
+    vsock: {
+      socketPath: cfg.vsockSocket,
+      guestPort: cfg.guestPort,
+    },
+    cpus: 2,
+    memMib: 1024,
+    // Deliberately no `snapshotPath` and no `baselines`: this is the
+    // *install* run, the run whose entire purpose is to mint them.
+  });
+
+  // --- Step 1: cold boot --------------------------------------------------
+  const t0 = Date.now();
+  try {
+    await sandbox.boot();
+  } catch (err) {
+    console.error(
+      `[snapshot-create] BOOT FAILED after ${Date.now() - t0}ms: ${
+        (err as Error).message
+      }`,
+    );
+    if ((err as Error).stack) console.error((err as Error).stack);
+    process.exit(1);
+  }
+  if (sandbox.state() !== "ready") {
+    console.error(
+      `[snapshot-create] sandbox.state() = ${sandbox.state()} (expected ready)`,
+    );
+    await sandbox.shutdown().catch(() => {});
+    process.exit(1);
+  }
+  console.error(
+    `[snapshot-create] PASS boot in ${Date.now() - t0}ms; state=ready`,
+  );
+
+  // We construct our own ChRemote rather than reaching into ChvSandbox's
+  // private one — the public surface deliberately doesn't expose it, and
+  // the install-time CLI is a separate concern from runtime reset.
+  const chRemote = new ChRemote({
+    binary: cfg.chRemoteBin,
+    apiSocketPath: cfg.apiSocket,
+    execFile: defaultExecFile,
+  });
+
+  // --- Step 2: pause + snapshot + resume ---------------------------------
+  // CHV requires the VM to be paused before `snapshot destination_url=...`
+  // is accepted. We pause -> snapshot -> resume so the post-snapshot VM is
+  // still alive for the GuestQuery + info baseline reads in step 3.
+  try {
+    console.error(`[snapshot-create] pausing VMM...`);
+    await chRemote.pause();
+    console.error(
+      `[snapshot-create] taking snapshot to ${cfg.snapshotDir} ...`,
+    );
+    await chRemote.snapshotCreate(cfg.snapshotDir);
+    console.error(`[snapshot-create] resuming VMM...`);
+    // Resume directly via ch-remote — ChRemote.snapshotRevert bundles
+    // restore+resume but we need only resume here. Use defaultExecFile.
+    await defaultExecFile(cfg.chRemoteBin ?? "ch-remote", [
+      "--api-socket",
+      cfg.apiSocket,
+      "resume",
+    ]);
+  } catch (err) {
+    console.error(
+      `[snapshot-create] SNAPSHOT FAILED: ${(err as Error).message}`,
+    );
+    if ((err as Error).stack) console.error((err as Error).stack);
+    await sandbox.shutdown().catch(() => {});
+    process.exit(2);
+  }
+  console.error(`[snapshot-create] PASS snapshot taken at ${cfg.snapshotDir}`);
+
+  // --- Step 3: baselines --------------------------------------------------
+  let fs_hash: string;
+  let open_fd_count: number;
+  let expected_vmm_api_state: VmmApiState;
+  try {
+    // 3a. fs_hash — streaming SHA-256 of the CoW overlay. Done AFTER the
+    // snapshot+resume so the hash captures the install-time state the
+    // runtime reset will re-establish.
+    if (!existsSync(cfg.overlay)) {
+      throw new Error(
+        `overlay file ${cfg.overlay} did not appear after boot+snapshot — ` +
+          `cloud-hypervisor may not have created it (check rootfs config: ` +
+          `overlayPath / readonly settings)`,
+      );
+    }
+    fs_hash = await defaultHashFile(cfg.overlay);
+    console.error(`[snapshot-create] fs_hash=${fs_hash}`);
+
+    // 3b. open_fd_count — vsock GuestQuery THROUGH the booted
+    // ChvSandbox's existing vsock connection. Codex round-3 caught the
+    // earlier bug: opening a parallel VsockClient added an FD that
+    // runtime reset() never sees, baking a stale baseline that diverges
+    // on first reset. ChvSandbox.guestQuery() is the symmetric seam —
+    // runtime reset() and install-time baseline both go through it,
+    // ensuring the FD count includes the same probe-FD overhead.
+    const result = await sandbox.guestQuery("OpenFdCount");
+    open_fd_count = result.open_fd_count;
+    console.error(`[snapshot-create] open_fd_count=${open_fd_count}`);
+
+    // 3c. expected_vmm_api_state — normalised `ch-remote info`.
+    const info = await chRemote.info();
+    expected_vmm_api_state = info.state;
+    console.error(
+      `[snapshot-create] vmm_api_state=${expected_vmm_api_state} (raw=${info.raw})`,
+    );
+    // Sanity: we resumed above, so the live state should be "running". If
+    // CHV reports anything else the baseline still records what we saw,
+    // but log the unexpected.
+    if (expected_vmm_api_state !== "running") {
+      console.error(
+        `[snapshot-create] WARN expected vmm_api_state=running after resume; got ${expected_vmm_api_state}. ` +
+          `Recording as baseline anyway — runtime reset() will compare against this exact value.`,
+      );
+    }
+    // normaliseVmmState is re-applied here for completeness/audit.
+    void normaliseVmmState;
+  } catch (err) {
+    console.error(
+      `[snapshot-create] BASELINE COMPUTATION FAILED: ${
+        (err as Error).message
+      }`,
+    );
+    if ((err as Error).stack) console.error((err as Error).stack);
+    await sandbox.shutdown().catch(() => {});
+    process.exit(4);
+  }
+
+  // --- Step 4: shutdown ---------------------------------------------------
+  await sandbox.shutdown().catch((err) => {
+    console.error(
+      `[snapshot-create] WARN shutdown error: ${(err as Error).message}`,
+    );
+  });
+
+  // --- Step 5: emit JSON --------------------------------------------------
+  const block: BaselineBlock = {
+    snapshotPath: cfg.snapshotDir,
+    rootfs: {
+      path: cfg.rootfs,
+      overlayPath: cfg.overlay,
+    },
+    baselines: {
+      fs_hash,
+      open_fd_count,
+      expected_vmm_api_state,
+    },
+  };
+  const json = JSON.stringify(block, null, 2);
+
+  // Stdout is the JSON config block (machine-readable). All progress logs
+  // went to stderr so a `node snapshot-create.js > golden.json` redirect
+  // produces a clean file.
+  process.stdout.write(json + "\n");
+
+  if (cfg.outputPath !== undefined) {
+    try {
+      ensureDir(dirname(cfg.outputPath));
+      writeFileSync(cfg.outputPath, json + "\n", "utf-8");
+      console.error(`[snapshot-create] wrote JSON to ${cfg.outputPath}`);
+    } catch (err) {
+      console.error(
+        `[snapshot-create] WARN failed to write --output=${cfg.outputPath}: ${
+          (err as Error).message
+        }`,
+      );
+    }
+  }
+
+  console.error(
+    `[snapshot-create] === ALL GREEN ===\n` +
+      `[snapshot-create] snapshot=${cfg.snapshotDir}\n` +
+      `[snapshot-create] paste the JSON above into your sandbox config (snapshotPath, rootfs.overlayPath, baselines)`,
+  );
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(`[snapshot-create] uncaught: ${(err as Error).message}`);
+  if ((err as Error).stack) console.error((err as Error).stack);
+  process.exit(1);
+});

--- a/packages/sandbox/src/__tests__/chv-remote.test.ts
+++ b/packages/sandbox/src/__tests__/chv-remote.test.ts
@@ -1,0 +1,287 @@
+// Unit tests for the ch-remote argv shape and JSON parsing.
+//
+// HONESTY: these run against a mock `ExecFileFn`, never against a real
+// `ch-remote` binary. They pin the argv shape we send so the integration
+// runner on node-2 can detect drift via the test diff before booting.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  ChRemote,
+  normaliseVmmState,
+  type ExecFileFn,
+} from "../chv/chv-remote.js";
+import { SandboxResetError } from "../errors.js";
+
+function recorder(): {
+  execFile: ExecFileFn;
+  calls: Array<{ file: string; args: string[] }>;
+  responses: Map<
+    string,
+    { stdout: string; stderr?: string } | { error: string }
+  >;
+} {
+  const calls: Array<{ file: string; args: string[] }> = [];
+  const responses = new Map<
+    string,
+    { stdout: string; stderr?: string } | { error: string }
+  >();
+  const execFile: ExecFileFn = async (file, args) => {
+    calls.push({ file, args: [...args] });
+    const verb = args[2] ?? "";
+    const r = responses.get(verb);
+    if (r === undefined) {
+      throw new Error(`mock execFile: no response for verb=${verb}`);
+    }
+    if ("error" in r) throw new Error(r.error);
+    return { stdout: r.stdout, stderr: r.stderr ?? "" };
+  };
+  return { execFile, calls, responses };
+}
+
+describe("ChRemote.snapshotRevert", () => {
+  it("sends shutdown → delete → restore → resume in that order (CHV state-machine fix)", async () => {
+    const r = recorder();
+    r.responses.set("shutdown", { stdout: "" });
+    r.responses.set("delete", { stdout: "" });
+    r.responses.set("restore", { stdout: "" });
+    r.responses.set("resume", { stdout: "" });
+
+    const cr = new ChRemote({
+      apiSocketPath: "/run/chv-api.sock",
+      execFile: r.execFile,
+    });
+    await cr.snapshotRevert("/var/lib/bsm/golden");
+
+    expect(r.calls).toEqual([
+      {
+        file: "ch-remote",
+        args: ["--api-socket", "/run/chv-api.sock", "shutdown"],
+      },
+      {
+        file: "ch-remote",
+        args: ["--api-socket", "/run/chv-api.sock", "delete"],
+      },
+      {
+        file: "ch-remote",
+        args: [
+          "--api-socket",
+          "/run/chv-api.sock",
+          "restore",
+          "source_url=file:///var/lib/bsm/golden",
+        ],
+      },
+      {
+        file: "ch-remote",
+        args: ["--api-socket", "/run/chv-api.sock", "resume"],
+      },
+    ]);
+  });
+
+  it("wraps non-zero exit on shutdown in SandboxResetError", async () => {
+    const r = recorder();
+    r.responses.set("shutdown", { error: "exit code 1: VmNotRunning" });
+    r.responses.set("delete", { stdout: "" });
+    r.responses.set("restore", { stdout: "" });
+    r.responses.set("resume", { stdout: "" });
+    const cr = new ChRemote({
+      apiSocketPath: "/run/chv-api.sock",
+      execFile: r.execFile,
+    });
+    await expect(cr.snapshotRevert("/var/lib/bsm/golden")).rejects.toThrow(
+      SandboxResetError,
+    );
+  });
+
+  it("wraps non-zero exit on delete in SandboxResetError", async () => {
+    const r = recorder();
+    r.responses.set("shutdown", { stdout: "" });
+    r.responses.set("delete", { error: "exit code 1: cleanup failed" });
+    r.responses.set("restore", { stdout: "" });
+    r.responses.set("resume", { stdout: "" });
+    const cr = new ChRemote({
+      apiSocketPath: "/run/chv-api.sock",
+      execFile: r.execFile,
+    });
+    await expect(cr.snapshotRevert("/var/lib/bsm/golden")).rejects.toThrow(
+      SandboxResetError,
+    );
+  });
+
+  it("wraps non-zero exit on restore in SandboxResetError (preserves cause msg)", async () => {
+    const r = recorder();
+    r.responses.set("shutdown", { stdout: "" });
+    r.responses.set("delete", { stdout: "" });
+    r.responses.set("restore", { error: "exit code 1: snapshot conflict" });
+    r.responses.set("resume", { stdout: "" });
+    const cr = new ChRemote({
+      apiSocketPath: "/run/chv-api.sock",
+      execFile: r.execFile,
+    });
+
+    let caught: unknown = null;
+    try {
+      await cr.snapshotRevert("/var/lib/bsm/golden");
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(SandboxResetError);
+    expect((caught as Error).message).toContain("ch-remote restore");
+    expect((caught as Error).message).toContain("snapshot conflict");
+  });
+
+  it("wraps non-zero exit on resume in SandboxResetError", async () => {
+    const r = recorder();
+    r.responses.set("shutdown", { stdout: "" });
+    r.responses.set("delete", { stdout: "" });
+    r.responses.set("restore", { stdout: "" });
+    r.responses.set("resume", { error: "exit code 2: VMM unreachable" });
+    const cr = new ChRemote({
+      apiSocketPath: "/run/chv-api.sock",
+      execFile: r.execFile,
+    });
+
+    await expect(cr.snapshotRevert("/var/lib/bsm/golden")).rejects.toThrow(
+      SandboxResetError,
+    );
+  });
+});
+
+describe("ChRemote.info", () => {
+  it("parses JSON state field and normalises to canonical VmmApiState", async () => {
+    const r = recorder();
+    r.responses.set("info", {
+      stdout: JSON.stringify({ state: "Running", config: {} }),
+    });
+    const cr = new ChRemote({
+      apiSocketPath: "/run/chv-api.sock",
+      execFile: r.execFile,
+    });
+    const result = await cr.info();
+    expect(result.raw).toBe("Running");
+    expect(result.state).toBe("running");
+  });
+
+  it("throws SandboxResetError on non-JSON stdout (substrate-lying defense)", async () => {
+    const r = recorder();
+    r.responses.set("info", { stdout: "<html>error</html>" });
+    const cr = new ChRemote({
+      apiSocketPath: "/run/chv-api.sock",
+      execFile: r.execFile,
+    });
+    await expect(cr.info()).rejects.toThrow(SandboxResetError);
+  });
+});
+
+describe("ChRemote.pause", () => {
+  it("sends `pause` with --api-socket pinned (no source_url)", async () => {
+    const r = recorder();
+    r.responses.set("pause", { stdout: "" });
+    const cr = new ChRemote({
+      apiSocketPath: "/run/chv-api.sock",
+      execFile: r.execFile,
+    });
+    await cr.pause();
+
+    expect(r.calls).toEqual([
+      {
+        file: "ch-remote",
+        args: ["--api-socket", "/run/chv-api.sock", "pause"],
+      },
+    ]);
+  });
+
+  it("wraps non-zero exit on pause in SandboxResetError (preserves cause msg)", async () => {
+    const r = recorder();
+    r.responses.set("pause", { error: "exit code 1: VmNotRunning" });
+    const cr = new ChRemote({
+      apiSocketPath: "/run/chv-api.sock",
+      execFile: r.execFile,
+    });
+
+    let caught: unknown = null;
+    try {
+      await cr.pause();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(SandboxResetError);
+    expect((caught as Error).message).toContain("ch-remote pause");
+    expect((caught as Error).message).toContain("VmNotRunning");
+  });
+});
+
+describe("ChRemote.snapshotCreate", () => {
+  it("sends `snapshot destination_url=file://<destDir>` with --api-socket pinned", async () => {
+    const r = recorder();
+    r.responses.set("snapshot", { stdout: "" });
+    const cr = new ChRemote({
+      apiSocketPath: "/run/chv-api.sock",
+      execFile: r.execFile,
+    });
+    await cr.snapshotCreate("/var/lib/bsm/golden");
+
+    expect(r.calls).toEqual([
+      {
+        file: "ch-remote",
+        args: [
+          "--api-socket",
+          "/run/chv-api.sock",
+          "snapshot",
+          "file:///var/lib/bsm/golden",
+        ],
+      },
+    ]);
+  });
+
+  it("wraps non-zero exit on snapshot in SandboxResetError (preserves cause msg)", async () => {
+    const r = recorder();
+    r.responses.set("snapshot", {
+      error: "exit code 1: VmNotPaused — pause before snapshot",
+    });
+    const cr = new ChRemote({
+      apiSocketPath: "/run/chv-api.sock",
+      execFile: r.execFile,
+    });
+
+    let caught: unknown = null;
+    try {
+      await cr.snapshotCreate("/var/lib/bsm/golden");
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(SandboxResetError);
+    expect((caught as Error).message).toContain("ch-remote snapshot");
+    expect((caught as Error).message).toContain("VmNotPaused");
+  });
+
+  it("uses the provided binary override (custom chRemoteBin path)", async () => {
+    const r = recorder();
+    r.responses.set("snapshot", { stdout: "" });
+    const cr = new ChRemote({
+      binary: "/opt/cloud-hypervisor/bin/ch-remote",
+      apiSocketPath: "/run/chv-api.sock",
+      execFile: r.execFile,
+    });
+    await cr.snapshotCreate("/var/lib/bsm/golden");
+
+    expect(r.calls[0].file).toBe("/opt/cloud-hypervisor/bin/ch-remote");
+  });
+});
+
+describe("normaliseVmmState mapping", () => {
+  it.each([
+    ["Running", "running"],
+    ["running", "running"],
+    ["Paused", "paused"],
+    ["PAUSED", "paused"],
+    ["Shutdown", "stopped"],
+    ["Stopped", "stopped"],
+    ["Created", "stopped"],
+    ["Crashed", "error"],
+    ["", "error"],
+    ["Frobnicated", "error"],
+  ] as const)("`%s` -> `%s`", (input, expected) => {
+    expect(normaliseVmmState(input)).toBe(expected);
+  });
+});

--- a/packages/sandbox/src/__tests__/chv-sandbox-reset.test.ts
+++ b/packages/sandbox/src/__tests__/chv-sandbox-reset.test.ts
@@ -1,0 +1,506 @@
+// Unit tests for `ChvSandbox.reset()` and the 3-source verification path.
+//
+// HONESTY (read first):
+//
+//   These tests run on Darwin against a MOCK `ExecFileFn`, a MOCK
+//   `HashFileFn`, and a MOCK `VsockGuestQueryClient`. They DO NOT touch a
+//   real `ch-remote` binary, a real CHV REST API socket, or a real CoW
+//   overlay file. Their purpose is to pin:
+//
+//     1. The `ch-remote` argv shape (so a real-CHV runner sees consistent
+//        invocations and any drift is caught at the test layer).
+//     2. The 3-source divergence semantics (any source disagreeing with
+//        its baseline -> SandboxResetDivergenceError + divergence_action
+//        = "halt").
+//     3. The "baselines unset = soft pass with marker" behaviour so the
+//        scaffold mode stays distinguishable from a real reset.
+//
+//   Real validation against a Cloud Hypervisor binary is 0bz7aztr's job
+//   on node-2 — see `scripts/first-light.ts` and the README "Linux
+//   runner first-light checklist".
+
+import { describe, expect, it } from "vitest";
+
+import { ChvSandbox, type VsockGuestQueryClient } from "../chv/chv-sandbox.js";
+import type { ChvSandboxConfig } from "../chv/chv-config.js";
+import type { ExecFileFn } from "../chv/chv-remote.js";
+import type { HashFileFn } from "../chv/chv-overlay-hash.js";
+import { SandboxResetDivergenceError, SandboxResetError } from "../errors.js";
+
+// --- helpers --------------------------------------------------------------
+
+/**
+ * Build a minimal `ChvSandboxConfig` for reset-only tests. Boot is never
+ * exercised here; the test forces `status = "ready"` directly.
+ */
+function makeConfig(
+  overrides: Partial<ChvSandboxConfig> = {},
+): ChvSandboxConfig {
+  return {
+    apiSocketPath: "/tmp/test-api.sock",
+    kernel: { path: "/tmp/test-kernel" },
+    rootfs: {
+      path: "/tmp/test-rootfs.img",
+      // overlayPath is REQUIRED for FS-hash verification; tests use the
+      // configured-baselines path by default, so the overlay path must
+      // be present too. Tests that exercise the "unset baselines" branch
+      // override this to undefined.
+      overlayPath: "/tmp/test-rootfs-overlay.img",
+    },
+    vsock: { socketPath: "/tmp/test-vsock.sock" },
+    snapshotPath: "/tmp/test-snapshot",
+    baselines: {
+      fs_hash: "sha256:abc123",
+      open_fd_count: 7,
+      expected_vmm_api_state: "running",
+    },
+    ...overrides,
+  };
+}
+
+/**
+ * Test scaffolding — capture every invocation. Each test sets the
+ * `responses` map keyed by ch-remote subcommand verb (e.g. "restore",
+ * "resume", "info"). Invocations not in the map throw, so unexpected
+ * argv combos fail loudly.
+ */
+function makeMockExecFile(
+  responses: Record<
+    string,
+    | { stdout: string; stderr?: string }
+    | { error: string }
+    | ((args: readonly string[]) => Promise<{ stdout: string; stderr: string }>)
+  >,
+): { execFile: ExecFileFn; calls: Array<{ file: string; args: string[] }> } {
+  const calls: Array<{ file: string; args: string[] }> = [];
+  const execFile: ExecFileFn = async (file, args) => {
+    calls.push({ file, args: [...args] });
+    // The verb is the first arg after `--api-socket <path>`. Pinned at
+    // index 2 by ch-remote's documented argv shape.
+    const verb = args[2] ?? "<missing>";
+    const response = responses[verb];
+    if (response === undefined) {
+      throw new Error(
+        `mock execFile: unexpected verb "${verb}" (full argv: ${JSON.stringify(args)})`,
+      );
+    }
+    if (typeof response === "function") {
+      return response(args);
+    }
+    if ("error" in response) {
+      throw new Error(response.error);
+    }
+    return { stdout: response.stdout, stderr: response.stderr ?? "" };
+  };
+  return { execFile, calls };
+}
+
+function makeMockHashFile(value: string): {
+  hashFile: HashFileFn;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const hashFile: HashFileFn = async (path) => {
+    calls.push(path);
+    return value;
+  };
+  return { hashFile, calls };
+}
+
+function makeMockVsock(open_fd_count: number): {
+  vsock: VsockGuestQueryClient;
+  calls: number;
+} {
+  let calls = 0;
+  const vsock: VsockGuestQueryClient = {
+    async guestQuery(kind) {
+      calls++;
+      if (kind !== "OpenFdCount") {
+        throw new Error(`unexpected guestQuery kind: ${kind}`);
+      }
+      return { open_fd_count };
+    },
+  };
+  return {
+    vsock,
+    get calls() {
+      return calls;
+    },
+  } as unknown as { vsock: VsockGuestQueryClient; calls: number };
+}
+
+/** Force a fresh `ChvSandbox` into "ready" without booting. */
+function placeReady(
+  sandbox: ChvSandbox,
+  vsock: VsockGuestQueryClient | null,
+): void {
+  // Test-only reach-in. Production calls boot() to reach this state.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const s = sandbox as any;
+  s.status = "ready";
+  if (vsock !== null) {
+    // The ChvSandboxDeps.vsock injection is preferred over s.vsock so
+    // tests don't have to mimic the full VsockClient shape.
+    s.deps.vsock = vsock;
+  }
+}
+
+// --- tests ----------------------------------------------------------------
+
+describe("ChvSandbox.reset() — 3-source verification (mock backend)", () => {
+  it("happy path: all 3 sources match → reset returns ResetState with divergence_action=none", async () => {
+    // GIVEN: baselines configured, all sources will agree.
+    const { execFile, calls } = makeMockExecFile({
+      shutdown: { stdout: "" },
+      delete: { stdout: "" },
+      restore: { stdout: "" },
+      resume: { stdout: "" },
+      info: { stdout: JSON.stringify({ state: "Running" }) },
+    });
+    const { hashFile } = makeMockHashFile("sha256:abc123");
+    const { vsock } = makeMockVsock(7);
+
+    const sandbox = new ChvSandbox(makeConfig(), { execFile, hashFile });
+    placeReady(sandbox, vsock);
+
+    // WHEN
+    const result = await sandbox.reset();
+
+    // THEN: ResetState shape per protocol §13.
+    expect(result.verification_passed).toBe(true);
+    expect(result.golden_hash).toBe("sha256:abc123");
+    expect(result.verification_details.fs_hash).toBe("sha256:abc123");
+    expect(result.verification_details.fs_hash_match).toBe(true);
+    expect(result.verification_details.open_fd_count).toBe(7);
+    expect(result.verification_details.vmm_api_state).toBe("running");
+    expect(result.verification_details.divergence_action).toBe("none");
+
+    // ch-remote argv shape pinned: shutdown → delete → restore → resume → info
+    // (CHV state machine requires shutdown+delete before restore can take
+    // a fresh VM from the snapshot. Caught on 0bz7aztr's run-3.)
+    expect(calls.length).toBe(5);
+    expect(calls[0]).toEqual({
+      file: "ch-remote",
+      args: ["--api-socket", "/tmp/test-api.sock", "shutdown"],
+    });
+    expect(calls[1]).toEqual({
+      file: "ch-remote",
+      args: ["--api-socket", "/tmp/test-api.sock", "delete"],
+    });
+    expect(calls[2]).toEqual({
+      file: "ch-remote",
+      args: [
+        "--api-socket",
+        "/tmp/test-api.sock",
+        "restore",
+        "source_url=file:///tmp/test-snapshot",
+      ],
+    });
+    expect(calls[3]).toEqual({
+      file: "ch-remote",
+      args: ["--api-socket", "/tmp/test-api.sock", "resume"],
+    });
+    expect(calls[4]).toEqual({
+      file: "ch-remote",
+      args: ["--api-socket", "/tmp/test-api.sock", "info"],
+    });
+
+    expect(sandbox.state()).toBe("ready");
+  });
+
+  it("fs_hash mismatch → throws SandboxResetDivergenceError with divergence_action=halt", async () => {
+    const { execFile } = makeMockExecFile({
+      shutdown: { stdout: "" },
+      delete: { stdout: "" },
+      restore: { stdout: "" },
+      resume: { stdout: "" },
+      info: { stdout: JSON.stringify({ state: "Running" }) },
+    });
+    const { hashFile } = makeMockHashFile("sha256:DIFFERENT_HASH");
+    const { vsock } = makeMockVsock(7);
+
+    const sandbox = new ChvSandbox(makeConfig(), { execFile, hashFile });
+    placeReady(sandbox, vsock);
+
+    let caught: unknown = null;
+    try {
+      await sandbox.reset();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(SandboxResetDivergenceError);
+    // Sandbox is halted (status "failed") per threat-model §5.1.
+    expect(sandbox.state()).toBe("failed");
+    expect((caught as SandboxResetDivergenceError).code).toBe(
+      "SANDBOX_RESET_DIVERGENCE",
+    );
+    expect((caught as Error).message).toContain("fs_match=false");
+    expect((caught as Error).message).toContain("divergence_action=halt");
+  });
+
+  it("open_fd_count mismatch → throws SandboxResetDivergenceError", async () => {
+    const { execFile } = makeMockExecFile({
+      shutdown: { stdout: "" },
+      delete: { stdout: "" },
+      restore: { stdout: "" },
+      resume: { stdout: "" },
+      info: { stdout: JSON.stringify({ state: "Running" }) },
+    });
+    const { hashFile } = makeMockHashFile("sha256:abc123");
+    const { vsock } = makeMockVsock(99); // baseline=7, observed=99
+
+    const sandbox = new ChvSandbox(makeConfig(), { execFile, hashFile });
+    placeReady(sandbox, vsock);
+
+    let caught: unknown = null;
+    try {
+      await sandbox.reset();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(SandboxResetDivergenceError);
+    expect((caught as Error).message).toContain("fd_match=false");
+    expect(sandbox.state()).toBe("failed");
+  });
+
+  it("vmm_api_state mismatch → throws SandboxResetDivergenceError", async () => {
+    const { execFile } = makeMockExecFile({
+      shutdown: { stdout: "" },
+      delete: { stdout: "" },
+      restore: { stdout: "" },
+      resume: { stdout: "" },
+      // Baseline expected "running"; CHV reports "Paused".
+      info: { stdout: JSON.stringify({ state: "Paused" }) },
+    });
+    const { hashFile } = makeMockHashFile("sha256:abc123");
+    const { vsock } = makeMockVsock(7);
+
+    const sandbox = new ChvSandbox(makeConfig(), { execFile, hashFile });
+    placeReady(sandbox, vsock);
+
+    let caught: unknown = null;
+    try {
+      await sandbox.reset();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(SandboxResetDivergenceError);
+    expect((caught as Error).message).toContain("vmm_match=false");
+    expect(sandbox.state()).toBe("failed");
+  });
+
+  it("substrate-lying defense: fs+fd say match but VMM says paused → still throws (any-source halt)", async () => {
+    // This is the threat-model §A6 case: an attacker compromises 2 of 3
+    // sources but can't fake the third. We MUST halt on any single
+    // source disagreeing, not require a quorum.
+    const { execFile } = makeMockExecFile({
+      shutdown: { stdout: "" },
+      delete: { stdout: "" },
+      restore: { stdout: "" },
+      resume: { stdout: "" },
+      info: { stdout: JSON.stringify({ state: "Paused" }) }, // <-- divergent
+    });
+    const { hashFile } = makeMockHashFile("sha256:abc123"); // matches
+    const { vsock } = makeMockVsock(7); // matches
+
+    const sandbox = new ChvSandbox(makeConfig(), { execFile, hashFile });
+    placeReady(sandbox, vsock);
+
+    let caught: unknown = null;
+    try {
+      await sandbox.reset();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(SandboxResetDivergenceError);
+    // The vsock + fs sources agreed; only VMM diverged. The halt is
+    // unconditional regardless of "majority vote".
+    const msg = (caught as Error).message;
+    expect(msg).toContain("fs_match=true");
+    expect(msg).toContain("fd_match=true");
+    expect(msg).toContain("vmm_match=false");
+  });
+
+  it("ch-remote non-zero exit during snapshot revert → throws SandboxResetError", async () => {
+    const { execFile } = makeMockExecFile({
+      // shutdown + delete succeed; restore is the failing step.
+      shutdown: { stdout: "" },
+      delete: { stdout: "" },
+      restore: { error: "Command failed: ch-remote ... exit 1" },
+      // resume / info should never be reached.
+      resume: { stdout: "" },
+      info: { stdout: JSON.stringify({ state: "Running" }) },
+    });
+    const { hashFile } = makeMockHashFile("sha256:abc123");
+    const { vsock } = makeMockVsock(7);
+
+    const sandbox = new ChvSandbox(makeConfig(), { execFile, hashFile });
+    placeReady(sandbox, vsock);
+
+    let caught: unknown = null;
+    try {
+      await sandbox.reset();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(SandboxResetError);
+    expect((caught as Error).message).toContain("ch-remote restore");
+    expect(sandbox.state()).toBe("failed");
+  });
+
+  it("ch-remote resume non-zero exit → throws SandboxResetError after revert succeeded", async () => {
+    const { execFile } = makeMockExecFile({
+      shutdown: { stdout: "" },
+      delete: { stdout: "" },
+      restore: { stdout: "" },
+      resume: { error: "ch-remote resume: exit 2" },
+      info: { stdout: JSON.stringify({ state: "Running" }) },
+    });
+    const { hashFile } = makeMockHashFile("sha256:abc123");
+    const { vsock } = makeMockVsock(7);
+
+    const sandbox = new ChvSandbox(makeConfig(), { execFile, hashFile });
+    placeReady(sandbox, vsock);
+
+    let caught: unknown = null;
+    try {
+      await sandbox.reset();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(SandboxResetError);
+    expect((caught as Error).message).toContain("ch-remote resume failed");
+    expect(sandbox.state()).toBe("failed");
+  });
+
+  it("baselines unset → forces divergence (Codex Q2 / threat-model §A6 fix)", async () => {
+    // Earlier scaffolding soft-passed with matching sentinels when
+    // baselines weren't configured — Codex review caught that as a
+    // substrate-lying-defense bypass. The corrected behaviour: any
+    // missing baseline forces divergence_action = "halt" and throws
+    // SandboxResetDivergenceError. Operators MUST configure all three
+    // baselines + RootfsConfig.overlayPath to claim integrity.
+    const { execFile } = makeMockExecFile({
+      // restore+resume not invoked because snapshotPath is also unset.
+      info: { stdout: JSON.stringify({ state: "Running" }) },
+    });
+    const { hashFile } = makeMockHashFile("sha256:irrelevant");
+    const cfg = makeConfig({
+      baselines: undefined,
+      snapshotPath: undefined,
+    });
+
+    const sandbox = new ChvSandbox(cfg, { execFile, hashFile });
+    placeReady(sandbox, null);
+
+    let caught: unknown = null;
+    try {
+      await sandbox.reset();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(SandboxResetDivergenceError);
+    expect(sandbox.state()).toBe("failed");
+    // hashFile must NOT have been called when baseline is unset
+    // (we short-circuit before invoking it).
+  });
+
+  it("full success with all 3 baselines matching → passes and stays ready (canonical happy path)", async () => {
+    // Slightly different from test #1: this exercises a different state
+    // mapping (CHV `Running` -> protocol `running`) and a different
+    // hash format to make sure we're not coincidentally short-circuiting.
+    const { execFile } = makeMockExecFile({
+      shutdown: { stdout: "" },
+      delete: { stdout: "" },
+      restore: { stdout: "" },
+      resume: { stdout: "" },
+      info: {
+        stdout: JSON.stringify({
+          state: "Running",
+          config: { cpus: { boot_vcpus: 2 } },
+        }),
+      },
+    });
+    const { hashFile } = makeMockHashFile(
+      "sha256:0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+    );
+    const { vsock } = makeMockVsock(42);
+    const cfg = makeConfig({
+      baselines: {
+        fs_hash:
+          "sha256:0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff",
+        open_fd_count: 42,
+        expected_vmm_api_state: "running",
+      },
+    });
+
+    const sandbox = new ChvSandbox(cfg, { execFile, hashFile });
+    placeReady(sandbox, vsock);
+
+    const result = await sandbox.reset();
+    expect(result.verification_passed).toBe(true);
+    expect(result.verification_details.divergence_action).toBe("none");
+    expect(result.verification_details.fs_hash_match).toBe(true);
+    expect(result.verification_details.open_fd_count).toBe(42);
+    expect(result.verification_details.vmm_api_state).toBe("running");
+    expect(sandbox.state()).toBe("ready");
+  });
+
+  it("ch-remote info returns non-JSON → fs+fd match but vmm becomes 'error' → halts", async () => {
+    // This is the "VMM API unreachable / lying" case. ch-remote info
+    // returning garbage should map to vmm_api_state = "error" which
+    // disagrees with any baseline -> divergence.
+    const { execFile } = makeMockExecFile({
+      shutdown: { stdout: "" },
+      delete: { stdout: "" },
+      restore: { stdout: "" },
+      resume: { stdout: "" },
+      info: { stdout: "not-valid-json{{{" },
+    });
+    const { hashFile } = makeMockHashFile("sha256:abc123");
+    const { vsock } = makeMockVsock(7);
+
+    const sandbox = new ChvSandbox(makeConfig(), { execFile, hashFile });
+    placeReady(sandbox, vsock);
+
+    let caught: unknown = null;
+    try {
+      await sandbox.reset();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(SandboxResetDivergenceError);
+    // Implementation logs ch-remote info failure as divergence; vmm_state="error".
+    expect((caught as Error).message).toContain("vmm_match=false");
+    expect(sandbox.state()).toBe("failed");
+  });
+
+  it("VMM state mapping: 'Shutdown' normalises to 'stopped'", async () => {
+    // Pin the protocol §6 state-vocabulary normalisation. Baseline says
+    // we expect "stopped" (e.g. for a sandbox in a paused-pool state);
+    // CHV's raw "Shutdown" must normalise to "stopped" to match.
+    const { execFile } = makeMockExecFile({
+      shutdown: { stdout: "" },
+      delete: { stdout: "" },
+      restore: { stdout: "" },
+      resume: { stdout: "" },
+      info: { stdout: JSON.stringify({ state: "Shutdown" }) },
+    });
+    const { hashFile } = makeMockHashFile("sha256:abc123");
+    const { vsock } = makeMockVsock(7);
+    const cfg = makeConfig({
+      baselines: {
+        fs_hash: "sha256:abc123",
+        open_fd_count: 7,
+        expected_vmm_api_state: "stopped",
+      },
+    });
+
+    const sandbox = new ChvSandbox(cfg, { execFile, hashFile });
+    placeReady(sandbox, vsock);
+
+    const result = await sandbox.reset();
+    expect(result.verification_details.vmm_api_state).toBe("stopped");
+    expect(result.verification_details.divergence_action).toBe("none");
+  });
+});

--- a/packages/sandbox/src/chv/__tests__/vsock-client.test.ts
+++ b/packages/sandbox/src/chv/__tests__/vsock-client.test.ts
@@ -1,0 +1,765 @@
+// Tests for VsockClient against an in-process AF_UNIX server that mimics
+// Cloud Hypervisor's vsock bridge protocol.
+//
+// What's covered (and what's NOT):
+//   - Happy path: CONNECT/OK handshake, ToolDispatch -> ToolResult, GuestQuery
+//     -> GuestResponse, multiple in-flight requests demuxed by request_id.
+//   - Sad paths: bad handshake reply, peer hangs up mid-handshake, frame
+//     larger than the cap, malformed JSON frame (silently dropped, not
+//     fatal), partial reads (data split into many tiny chunks), correct
+//     timeout behaviour, response without a known request_id (dropped).
+//   - SandboxNotAvailableError when no socket exists (Darwin-style fallback).
+//
+// What we deliberately CAN'T cover here:
+//   - Real Cloud Hypervisor.
+//   - Real AF_VSOCK semantics (Node has no native AF_VSOCK; CHV bridges to
+//     AF_UNIX, which is what we use both in production and in these tests).
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer, type Server, type Socket } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  SandboxError,
+  SandboxNotAvailableError,
+  SandboxToolTimeoutError,
+  SandboxVsockFrameTooLargeError,
+  SandboxVsockHandshakeError,
+} from "../../errors.js";
+import { VsockClient, DEFAULT_GUEST_PORT } from "../vsock-client.js";
+
+// --- fake CHV-like AF_UNIX server -----------------------------------------
+
+interface FakeServer {
+  server: Server;
+  socketPath: string;
+  /** Resolves with the connected client socket once handshake bytes start. */
+  nextClient: () => Promise<Socket>;
+  /** Pops + clears any post-handshake bytes buffered by the server before
+   *  the test had a chance to attach its own data listener AND removes
+   *  the server's internal onData listener so subsequent bytes flow
+   *  straight to the caller's listener. */
+  handoff: (sock: Socket) => Buffer;
+  close: () => Promise<void>;
+}
+
+function startFakeServer(behaviour: {
+  handshakeReply?: (port: number) => string | Buffer | null; // null = hang up
+  /** If true, write each byte of handshakeReply as its own data event,
+   *  exercising the handshake's partial-read path. */
+  trickle?: boolean;
+}): Promise<FakeServer> {
+  return new Promise((resolve, reject) => {
+    const tmpRoot = tmpdir();
+    mkdtemp(join(tmpRoot, "vsock-test-"))
+      .then((dir) => {
+        const socketPath = join(dir, "vsock.sock");
+        const incoming: Array<(s: Socket) => void> = [];
+        const pending: Socket[] = [];
+        const allSockets = new Set<Socket>();
+        // Per-socket buffer of post-handshake bytes that arrived before
+        // the test attached its own listener. The FrameReader picks these
+        // up via `handoff`.
+        const leftovers = new WeakMap<Socket, Buffer>();
+        const handshakeDone = new WeakSet<Socket>();
+        const onDataRefs = new WeakMap<Socket, (c: Buffer) => void>();
+        const server = createServer((sock) => {
+          allSockets.add(sock);
+          sock.on("close", () => allSockets.delete(sock));
+          sock.on("error", () => {
+            /* swallow -- expected when client destroys its end */
+          });
+          // CHV-like behaviour: read until newline, then reply.
+          let acc = Buffer.alloc(0);
+          // While true, we are still consuming bytes for the fake server
+          // (handshake + leftover-capture). Once the test code creates a
+          // FrameReader it removes this listener via the FrameReader
+          // attaching its own; we keep this listener attached for
+          // post-handshake bytes that arrive before the test sees the
+          // socket so they don't leak into Node's stream void.
+          const onData = (chunk: Buffer) => {
+            if (handshakeDone.has(sock)) {
+              const prev = leftovers.get(sock) ?? Buffer.alloc(0);
+              leftovers.set(sock, Buffer.concat([prev, chunk]));
+              return;
+            }
+            acc = Buffer.concat([acc, chunk]);
+            const nl = acc.indexOf(0x0a);
+            if (nl === -1) return;
+            const line = acc.subarray(0, nl).toString("ascii");
+            const m = line.match(/^CONNECT\s+(\d+)$/);
+            if (m === null) {
+              sock.destroy();
+              return;
+            }
+            const port = Number.parseInt(m[1], 10);
+            const reply = (
+              behaviour.handshakeReply ?? ((p: number) => `OK ${p}\n`)
+            )(port);
+            handshakeDone.add(sock);
+            // Any bytes past the newline are post-handshake frames --
+            // stash for the FrameReader.
+            const leftover = acc.subarray(nl + 1);
+            if (leftover.length > 0) {
+              leftovers.set(sock, Buffer.from(leftover));
+            }
+            if (reply === null) {
+              sock.destroy();
+              return;
+            }
+            const buf = Buffer.isBuffer(reply) ? reply : Buffer.from(reply);
+            if (behaviour.trickle === true) {
+              // Send byte-by-byte to exercise partial-read handling.
+              let i = 0;
+              const tick = () => {
+                if (i >= buf.length) return;
+                sock.write(buf.subarray(i, i + 1));
+                i++;
+                setImmediate(tick);
+              };
+              tick();
+            } else {
+              sock.write(buf);
+            }
+            // Make this socket available to test code (which then drives
+            // the post-handshake length-prefixed protocol).
+            if (incoming.length > 0) {
+              const cb = incoming.shift()!;
+              cb(sock);
+            } else {
+              pending.push(sock);
+            }
+          };
+          sock.on("data", onData);
+          onDataRefs.set(sock, onData);
+        });
+        server.listen(socketPath, () => {
+          resolve({
+            server,
+            socketPath,
+            nextClient: () =>
+              new Promise<Socket>((r) => {
+                if (pending.length > 0) {
+                  r(pending.shift()!);
+                } else {
+                  incoming.push(r);
+                }
+              }),
+            handoff: (sock: Socket) => {
+              const v = leftovers.get(sock) ?? Buffer.alloc(0);
+              leftovers.delete(sock);
+              const ref = onDataRefs.get(sock);
+              if (ref !== undefined) {
+                sock.removeListener("data", ref);
+                onDataRefs.delete(sock);
+              }
+              return v;
+            },
+            close: async () => {
+              for (const s of allSockets) {
+                try {
+                  s.destroy();
+                } catch {}
+              }
+              await new Promise<void>((r) => server.close(() => r()));
+              await rm(dir, { recursive: true, force: true });
+            },
+          });
+        });
+      })
+      .catch(reject);
+  });
+}
+
+/** Helper: write a length-prefixed JSON frame onto a socket. */
+function writeFrame(
+  sock: Socket,
+  obj: unknown,
+  opts: { trickle?: boolean } = {},
+): void {
+  const json = Buffer.from(JSON.stringify(obj), "utf-8");
+  const header = Buffer.alloc(4);
+  header.writeUInt32BE(json.length, 0);
+  if (opts.trickle === true) {
+    // Write byte-by-byte to test partial-read handling on the client.
+    const all = Buffer.concat([header, json]);
+    let i = 0;
+    const tick = () => {
+      if (i >= all.length) return;
+      sock.write(all.subarray(i, i + 1));
+      i++;
+      setImmediate(tick);
+    };
+    tick();
+  } else {
+    sock.write(header);
+    sock.write(json);
+  }
+}
+
+/** Stateful frame reader for the server side -- carries buffered bytes
+ *  across `readFrame` calls so back-to-back requests work. The optional
+ *  `initialBuf` is for any post-handshake bytes the fake server caught
+ *  before this reader was attached. */
+class FrameReader {
+  private buf: Buffer;
+  private expecting: number | null = null;
+  private waiter: ((f: Record<string, unknown>) => void) | null = null;
+  private failer: ((e: Error) => void) | null = null;
+
+  constructor(
+    private readonly sock: Socket,
+    initialBuf: Buffer = Buffer.alloc(0),
+  ) {
+    this.buf = initialBuf;
+    sock.on("data", (chunk: Buffer) => {
+      this.buf = Buffer.concat([this.buf, chunk]);
+      this.tryDeliver();
+    });
+    sock.on("error", (err) => {
+      if (this.failer !== null) this.failer(err);
+    });
+    sock.resume();
+  }
+
+  private tryDeliver(): void {
+    while (this.waiter !== null) {
+      if (this.expecting === null) {
+        if (this.buf.length < 4) return;
+        this.expecting = this.buf.readUInt32BE(0);
+        this.buf = this.buf.subarray(4);
+      }
+      if (this.buf.length < this.expecting) return;
+      const payload = this.buf.subarray(0, this.expecting);
+      this.buf = this.buf.subarray(this.expecting);
+      this.expecting = null;
+      const w = this.waiter;
+      this.waiter = null;
+      this.failer = null;
+      try {
+        w(JSON.parse(payload.toString("utf-8")));
+      } catch {
+        // Malformed -- swallow; next read will see remaining buf.
+      }
+    }
+  }
+
+  read(): Promise<Record<string, unknown>> {
+    return new Promise((resolve, reject) => {
+      if (this.waiter !== null) {
+        reject(new Error("FrameReader: concurrent reads not supported"));
+        return;
+      }
+      this.waiter = resolve;
+      this.failer = reject;
+      this.tryDeliver();
+    });
+  }
+}
+
+/** Convenience: one-shot read. Pass the FakeServer so we can hand off
+ *  the socket cleanly (remove the server's internal handshake listener
+ *  and recover any post-handshake bytes already buffered). */
+function readFrame(
+  sock: Socket,
+  fake: FakeServer,
+): Promise<Record<string, unknown>> {
+  return new FrameReader(sock, fake.handoff(sock)).read();
+}
+
+// --- tests ------------------------------------------------------------------
+
+describe("VsockClient", () => {
+  let fake: FakeServer | null = null;
+
+  afterEach(async () => {
+    if (fake !== null) {
+      await fake.close();
+      fake = null;
+    }
+  });
+
+  it("throws SandboxNotAvailableError when the socket file is absent", async () => {
+    const client = new VsockClient({
+      socketPath: "/tmp/this/does/not/exist.sock",
+    });
+    await expect(client.open()).rejects.toBeInstanceOf(
+      SandboxNotAvailableError,
+    );
+  });
+
+  it("performs a CONNECT/OK handshake and records sourcePort", async () => {
+    fake = await startFakeServer({
+      handshakeReply: () => "OK 4242\n",
+    });
+    const client = new VsockClient({
+      socketPath: fake.socketPath,
+      handshakeTimeoutMs: 2_000,
+    });
+    await client.open();
+    expect(client.isOpen()).toBe(true);
+    expect(client.getSourcePort()).toBe(4242);
+    await client.close();
+  });
+
+  it("tolerates a trickled (partial-read) handshake reply", async () => {
+    fake = await startFakeServer({
+      handshakeReply: () => "OK 7\n",
+      trickle: true,
+    });
+    const client = new VsockClient({
+      socketPath: fake.socketPath,
+      handshakeTimeoutMs: 2_000,
+    });
+    await client.open();
+    expect(client.getSourcePort()).toBe(7);
+    await client.close();
+  });
+
+  it("throws SandboxVsockHandshakeError on a bad handshake reply", async () => {
+    fake = await startFakeServer({
+      handshakeReply: () => "ERROR no such port\n",
+    });
+    const client = new VsockClient({ socketPath: fake.socketPath });
+    await expect(client.open()).rejects.toBeInstanceOf(
+      SandboxVsockHandshakeError,
+    );
+  });
+
+  it("throws SandboxVsockHandshakeError when peer hangs up mid-handshake", async () => {
+    fake = await startFakeServer({
+      handshakeReply: () => null, // server destroys the socket
+    });
+    const client = new VsockClient({ socketPath: fake.socketPath });
+    await expect(client.open()).rejects.toBeInstanceOf(
+      SandboxVsockHandshakeError,
+    );
+  });
+
+  it("times out the handshake if the server never replies", async () => {
+    fake = await startFakeServer({
+      // Reply that never sends a newline; client will time out.
+      handshakeReply: () => Buffer.from("OK 1"),
+    });
+    const client = new VsockClient({
+      socketPath: fake.socketPath,
+      handshakeTimeoutMs: 100,
+    });
+    await expect(client.open()).rejects.toBeInstanceOf(
+      SandboxVsockHandshakeError,
+    );
+  });
+
+  it("dispatches a ToolDispatch and demuxes the matching ToolResult", async () => {
+    fake = await startFakeServer({});
+    const client = new VsockClient({
+      socketPath: fake.socketPath,
+      handshakeTimeoutMs: 2_000,
+    });
+    const openP = client.open();
+    const guestSock = await fake.nextClient();
+    await openP;
+
+    // Server-side: read one frame, write back a ToolResult.
+    const reqP = readFrame(guestSock, fake!).then((req) => {
+      expect(req.type).toBe("ToolDispatch");
+      expect(req.command_id).toBe("cmd-1");
+      writeFrame(guestSock, {
+        type: "ToolResult",
+        command_id: req.command_id,
+        exit_code: 0,
+        stdout: "hello\n",
+        stderr: "",
+        evidence_hash: "sha256:abc",
+      });
+    });
+
+    const result = await client.sendCommand({
+      command_id: "cmd-1",
+      tool: "echo",
+      params: { message: "hello" },
+      deadline_ms: 2_000,
+    });
+    await reqP;
+
+    expect(result.exit_code).toBe(0);
+    expect(result.stdout).toBe("hello\n");
+    expect(result.evidence_hash).toBe("sha256:abc");
+    await client.close();
+  });
+
+  it("supports multiple in-flight requests correlated by request_id", async () => {
+    fake = await startFakeServer({});
+    const client = new VsockClient({ socketPath: fake.socketPath });
+    const openP = client.open();
+    const guestSock = await fake.nextClient();
+    await openP;
+
+    const reader = new FrameReader(guestSock, fake!.handoff(guestSock));
+    const seen: Record<string, unknown>[] = [];
+    // Server: collect both requests, then reply in REVERSE order to prove
+    // demux-by-request_id is correct.
+    const serverWork = (async () => {
+      const a = await reader.read();
+      const b = await reader.read();
+      seen.push(a, b);
+      writeFrame(guestSock, {
+        type: "ToolResult",
+        command_id: b.command_id,
+        exit_code: 2,
+        stdout: "B-reply",
+        stderr: "",
+      });
+      writeFrame(guestSock, {
+        type: "ToolResult",
+        command_id: a.command_id,
+        exit_code: 1,
+        stdout: "A-reply",
+        stderr: "",
+      });
+    })();
+
+    const [r1, r2] = await Promise.all([
+      client.sendCommand({
+        command_id: "cmd-1",
+        tool: "echo",
+        params: {},
+        deadline_ms: 3_000,
+      }),
+      client.sendCommand({
+        command_id: "cmd-2",
+        tool: "echo",
+        params: {},
+        deadline_ms: 3_000,
+      }),
+    ]);
+    await serverWork;
+
+    // The order responses arrive at the client follows the server's
+    // write order (reply to B first, then A). But sendCommand resolves
+    // by request_id, so r1 is whatever the response with command_id "cmd-1"
+    // says, regardless of arrival order.
+    expect(seen.map((f) => f.command_id).sort()).toEqual(["cmd-1", "cmd-2"]);
+    // r1's exit_code corresponds to whichever of seen[0]/seen[1] has command_id cmd-1.
+    const cmd1Pos = seen.findIndex((f) => f.command_id === "cmd-1");
+    const cmd2Pos = seen.findIndex((f) => f.command_id === "cmd-2");
+    // Server replies B (seen[1]) with exit 2, A (seen[0]) with exit 1.
+    expect(r1.exit_code).toBe(cmd1Pos === 0 ? 1 : 2);
+    expect(r2.exit_code).toBe(cmd2Pos === 0 ? 1 : 2);
+    await client.close();
+  });
+
+  it("handles partial reads (response written byte-by-byte)", async () => {
+    fake = await startFakeServer({});
+    const client = new VsockClient({ socketPath: fake.socketPath });
+    const openP = client.open();
+    const guestSock = await fake.nextClient();
+    await openP;
+
+    const serverWork = readFrame(guestSock, fake!).then((req) => {
+      writeFrame(
+        guestSock,
+        {
+          type: "ToolResult",
+          command_id: req.command_id,
+          exit_code: 0,
+          stdout: "trickled",
+          stderr: "",
+        },
+        { trickle: true },
+      );
+    });
+
+    const result = await client.sendCommand({
+      command_id: "cmd-trickle",
+      tool: "echo",
+      params: {},
+      deadline_ms: 2_000,
+    });
+    await serverWork;
+    expect(result.stdout).toBe("trickled");
+    await client.close();
+  });
+
+  it("times out a request whose response never arrives", async () => {
+    fake = await startFakeServer({});
+    const client = new VsockClient({ socketPath: fake.socketPath });
+    const openP = client.open();
+    const guestSock = await fake.nextClient();
+    await openP;
+
+    // Read the request but never reply.
+    const eat = readFrame(guestSock, fake!).catch(() => {});
+
+    await expect(
+      client.sendCommand({
+        command_id: "cmd-timeout",
+        tool: "echo",
+        params: {},
+        deadline_ms: 50,
+      }),
+    ).rejects.toBeInstanceOf(SandboxToolTimeoutError);
+    await eat;
+    await client.close();
+  });
+
+  it("rejects an oversized inbound frame as SandboxVsockFrameTooLargeError", async () => {
+    fake = await startFakeServer({});
+    const client = new VsockClient({
+      socketPath: fake.socketPath,
+      // Small enough to exceed easily but big enough to hold the 4-byte
+      // outbound request frame (json is ~80 bytes for our minimal payload).
+      maxFrameBytes: 1024,
+    });
+    const openP = client.open();
+    const guestSock = await fake.nextClient();
+    await openP;
+
+    // Server: read the request, then write ONLY a length-prefix header
+    // declaring an enormous payload. The client must latch a fatal
+    // SandboxVsockFrameTooLargeError without blocking on payload bytes.
+    const reader = new FrameReader(guestSock, fake!.handoff(guestSock));
+    const eat = reader.read().then(() => {
+      const header = Buffer.alloc(4);
+      header.writeUInt32BE(99_999_999, 0);
+      guestSock.write(header);
+    });
+
+    const sendP = client.sendCommand({
+      command_id: "cmd-big",
+      tool: "echo",
+      params: {},
+      deadline_ms: 3_000,
+    });
+
+    await expect(sendP).rejects.toBeInstanceOf(SandboxVsockFrameTooLargeError);
+    await eat;
+    expect(client.isOpen()).toBe(false);
+    await client.close();
+  });
+
+  it("rejects an oversized OUTBOUND frame before sending", async () => {
+    fake = await startFakeServer({});
+    const client = new VsockClient({
+      socketPath: fake.socketPath,
+      maxFrameBytes: 32,
+    });
+    const openP = client.open();
+    void (await fake.nextClient());
+    await openP;
+
+    const huge = "x".repeat(1024);
+    await expect(
+      client.sendCommand({
+        command_id: "cmd-outbound-big",
+        tool: huge,
+        params: { huge },
+        deadline_ms: 2_000,
+      }),
+    ).rejects.toBeInstanceOf(SandboxVsockFrameTooLargeError);
+    await client.close();
+  });
+
+  it("drops a malformed JSON frame without poisoning the connection", async () => {
+    fake = await startFakeServer({});
+    const client = new VsockClient({ socketPath: fake.socketPath });
+    const openP = client.open();
+    const guestSock = await fake.nextClient();
+    await openP;
+
+    // Send a malformed JSON frame, then read req-1 and reply normally.
+    const garbage = Buffer.from("{not json");
+    const header = Buffer.alloc(4);
+    header.writeUInt32BE(garbage.length, 0);
+    guestSock.write(header);
+    guestSock.write(garbage);
+
+    const serverWork = readFrame(guestSock, fake!).then((req) => {
+      writeFrame(guestSock, {
+        type: "ToolResult",
+        command_id: req.command_id,
+        exit_code: 0,
+        stdout: "still alive",
+        stderr: "",
+      });
+    });
+
+    const r = await client.sendCommand({
+      command_id: "cmd-after-garbage",
+      tool: "echo",
+      params: {},
+      deadline_ms: 2_000,
+    });
+    await serverWork;
+    expect(r.stdout).toBe("still alive");
+    expect(client.isOpen()).toBe(true);
+    await client.close();
+  });
+
+  it("drops a frame whose request_id matches no pending call", async () => {
+    fake = await startFakeServer({});
+    const client = new VsockClient({ socketPath: fake.socketPath });
+    const openP = client.open();
+    const guestSock = await fake.nextClient();
+    await openP;
+
+    // Push a stray result for a request the client never made.
+    writeFrame(guestSock, {
+      type: "ToolResult",
+      command_id: "cmd-stray",
+      exit_code: 0,
+      stdout: "",
+      stderr: "",
+    });
+
+    // Wait a tick so the read loop processes it.
+    await new Promise((r) => setTimeout(r, 25));
+    expect(client.isOpen()).toBe(true);
+
+    // Subsequent real request still works.
+    const serverWork = readFrame(guestSock, fake!).then((req) => {
+      writeFrame(guestSock, {
+        type: "ToolResult",
+        command_id: req.command_id,
+        exit_code: 0,
+        stdout: "ok",
+        stderr: "",
+      });
+    });
+    const r = await client.sendCommand({
+      command_id: "cmd-real",
+      tool: "echo",
+      params: {},
+      deadline_ms: 2_000,
+    });
+    await serverWork;
+    expect(r.stdout).toBe("ok");
+    await client.close();
+  });
+
+  it("performs a GuestQuery / GuestResponse round trip", async () => {
+    fake = await startFakeServer({});
+    const client = new VsockClient({ socketPath: fake.socketPath });
+    const openP = client.open();
+    const guestSock = await fake.nextClient();
+    await openP;
+
+    const serverWork = readFrame(guestSock, fake!).then((req) => {
+      expect(req.type).toBe("GuestQuery");
+      expect(req.query_kind).toBe("OpenFdCount");
+      writeFrame(guestSock, {
+        type: "GuestResponse",
+        query_id: req.query_id,
+        query_kind: "OpenFdCount",
+        result: { open_fd_count: 12 },
+        ts: new Date().toISOString(),
+      });
+    });
+
+    const result = await client.guestQuery("OpenFdCount", {
+      timeoutMs: 1_000,
+      queryId: "q-1",
+    });
+    await serverWork;
+    expect((result as { open_fd_count: number }).open_fd_count).toBe(12);
+    await client.close();
+  });
+
+  it("uses the default guest port (1024) in the CONNECT line", async () => {
+    let observedPort = -1;
+    fake = await startFakeServer({
+      handshakeReply: (port) => {
+        observedPort = port;
+        return `OK ${port}\n`;
+      },
+    });
+    const client = new VsockClient({ socketPath: fake.socketPath });
+    await client.open();
+    expect(observedPort).toBe(DEFAULT_GUEST_PORT);
+    await client.close();
+  });
+
+  it("trips SANDBOX_VSOCK_PARTIAL_FRAME_TIMEOUT when a frame stalls mid-payload (protocol §6)", async () => {
+    fake = await startFakeServer({});
+    const client = new VsockClient({
+      socketPath: fake.socketPath,
+      partialFrameTimeoutMs: 100, // shrunk from default 30_000 for fast test
+    });
+    const openP = client.open();
+    const guestSock = await fake.nextClient();
+    await openP;
+
+    // Server reads the request, then writes a 4-byte length header
+    // declaring a 1024-byte payload — and stops. The client should
+    // arm the partial-frame watchdog and fire after 100ms.
+    const serverWork = readFrame(guestSock, fake!).then(() => {
+      const header = Buffer.alloc(4);
+      header.writeUInt32BE(1024, 0);
+      guestSock.write(header);
+      // Intentionally do NOT write the payload.
+    });
+
+    const sendP = client.sendCommand({
+      command_id: "cmd-stall",
+      tool: "echo",
+      params: {},
+      deadline_ms: 5_000, // way longer than the watchdog timeout
+    });
+
+    const err = await sendP.catch((e: unknown) => e);
+    await serverWork;
+    expect(err).toBeInstanceOf(SandboxError);
+    expect((err as SandboxError).code).toBe(
+      "SANDBOX_VSOCK_PARTIAL_FRAME_TIMEOUT",
+    );
+    expect(client.isOpen()).toBe(false);
+    await client.close();
+  });
+
+  it("does not trip partial-frame timeout for a slow-but-progressing peer", async () => {
+    fake = await startFakeServer({});
+    const client = new VsockClient({
+      socketPath: fake.socketPath,
+      partialFrameTimeoutMs: 200,
+    });
+    const openP = client.open();
+    const guestSock = await fake.nextClient();
+    await openP;
+
+    // Server trickles the response one byte at a time at ~50ms intervals
+    // — slower than our normal "trickle: true" but still strictly faster
+    // than the 200ms watchdog. Each new byte resets the watchdog.
+    const serverWork = readFrame(guestSock, fake!).then(async (req) => {
+      const payload = Buffer.from(
+        JSON.stringify({
+          type: "ToolResult",
+          command_id: req.command_id,
+          exit_code: 0,
+          stdout: "slow",
+          stderr: "",
+        }),
+        "utf-8",
+      );
+      const header = Buffer.alloc(4);
+      header.writeUInt32BE(payload.length, 0);
+      const all = Buffer.concat([header, payload]);
+      for (let i = 0; i < all.length; i++) {
+        guestSock.write(all.subarray(i, i + 1));
+        await new Promise((r) => setTimeout(r, 50));
+      }
+    });
+
+    const result = await client.sendCommand({
+      command_id: "cmd-slow",
+      tool: "echo",
+      params: {},
+      deadline_ms: 30_000,
+    });
+    await serverWork;
+    expect(result.stdout).toBe("slow");
+    expect(client.isOpen()).toBe(true);
+    await client.close();
+  }, 30_000);
+});

--- a/packages/sandbox/src/chv/chv-config.ts
+++ b/packages/sandbox/src/chv/chv-config.ts
@@ -1,0 +1,149 @@
+// Cloud Hypervisor configuration. The plan (§5, P3.1a) calls for:
+//   - vsock for command/response channel between agent and guest
+//   - virtio-fs for file inputs/outputs
+//   - manual snapshot create/revert for reset machinery
+//
+// What's still open (gaps that block first-light):
+//   - Kernel image source: do we ship a Brainstorm-built kernel or consume
+//     one from the brainstormVM `vm.boot` baseline? See README "Linux runner
+//     first-light checklist".
+//   - Rootfs layout: P3.4 image-build pipeline produces this; until then the
+//     `RootfsConfig.path` is treated as opaque to this package.
+//   - vsock CID allocation: CID 2 is the host; CID 3+ is a guest. We pick
+//     a per-instance CID at boot to allow multiple sandboxes per host
+//     (post-MVP), defaulting to 3 for the single-sandbox case.
+
+import type { VmmApiState } from "@brainst0rm/relay";
+
+export interface KernelConfig {
+  /** Absolute path to the kernel binary (vmlinux). */
+  path: string;
+  /**
+   * Optional path to an initramfs image. Required if the kernel is
+   * modular (e.g. Alpine virt) — the initramfs loads virtio-blk + ext4
+   * before pivot_root. Image-builder produces `bsm-sandbox-initramfs`.
+   * Without it, modular kernels panic on root-mount with
+   * "List of all partitions: (empty)".
+   */
+  initramfs?: string;
+  /** Kernel command-line. Defaults to a sensible quiet-boot string. */
+  cmdline?: string;
+}
+
+export interface RootfsConfig {
+  /**
+   * Absolute path to the rootfs image (raw or qcow2). This is what
+   * CHV's `--disk path=<file>,readonly=on` flag points at — also what
+   * the substrate-lying defense's FS-hash check reads back. With
+   * `readonly=on`, CHV does not write to this file; tamper from any
+   * other source (host, co-resident process, etc.) will be detected.
+   */
+  path: string;
+  /**
+   * Optional override for which file the FS-hash verification reads.
+   * Defaults to `path`. Only matters in advanced deployments where the
+   * operator has set up a qcow2 backing-file layout or host-level
+   * overlayfs at the host layer (CHV itself has no overlay-path concept
+   * in `--disk`); in those cases the writable file is distinct from
+   * the immutable base, and `overlayPath` must point at the writable
+   * file or the substrate-lying defense will hash the immutable side
+   * and miss tamper. Codex round-2 caught this as a configuration
+   * trap; default-to-`path` makes the simple case correct without
+   * configuration.
+   */
+  overlayPath?: string;
+  /**
+   * Whether the disk is mounted read-only inside the guest. Defaults true
+   * — the golden image must be immutable; writes go to a CoW overlay
+   * managed by the snapshot machinery (P3.2a, not yet implemented here).
+   */
+  readonly?: boolean;
+}
+
+export interface VsockConfig {
+  /**
+   * Guest CID. CID 0 (hypervisor), 1 (local), 2 (host) are reserved.
+   * Use 3+ for guests. Default 3.
+   */
+  cid?: number;
+  /**
+   * Host-side Unix socket path used by Cloud Hypervisor's vsock device
+   * to bridge into a host-visible AF_UNIX endpoint. Cloud Hypervisor
+   * uses the `--vsock cid=N,socket=/path` flag.
+   */
+  socketPath: string;
+  /**
+   * Vsock port the in-guest dispatcher is listening on. Defaults to 1024
+   * (matches `DEFAULT_GUEST_PORT` in vsock-client.ts and the protocol's
+   * canonical port). Set to 52000 to match the image-builder vsock-init's
+   * default; image-builder honours `BSM_VSOCK_PORT` env to align.
+   */
+  guestPort?: number;
+}
+
+export interface ChvSandboxConfig {
+  /**
+   * Path to the `cloud-hypervisor` binary. Defaults to looking up
+   * `cloud-hypervisor` on PATH at boot time.
+   */
+  cloudHypervisorBin?: string;
+  /**
+   * Path to the `ch-remote` binary (used for snapshot/restore + VMM API
+   * queries). Defaults to looking up `ch-remote` on PATH.
+   */
+  chRemoteBin?: string;
+  /**
+   * Cloud Hypervisor REST API socket. Used for `vm.info` queries (the
+   * "VMM API state" verification source per threat-model §5.1).
+   */
+  apiSocketPath: string;
+  kernel: KernelConfig;
+  rootfs: RootfsConfig;
+  vsock: VsockConfig;
+  /** vCPUs to allocate. Defaults to 2. */
+  cpus?: number;
+  /** Memory in MiB. Defaults to 1024. */
+  memMib?: number;
+  /**
+   * Path where the golden snapshot is written by the install-time setup
+   * flow and reverted to between dispatches (P3.2a — not yet wired up
+   * in this scaffolding). Required for reset-by-revert mode.
+   */
+  snapshotPath?: string;
+  /**
+   * Baseline values recorded at install-time, used by the 3-source
+   * verification step. The integrity monitor compares post-reset
+   * measurements against these. If unset, this package emits a
+   * "verification_passed: true with sentinel zeros" reset state and
+   * marks it clearly in stderr — caller MUST treat that as
+   * "verification not yet wired up", not as a real pass.
+   */
+  baselines?: {
+    fs_hash: string;
+    open_fd_count: number;
+    expected_vmm_api_state: VmmApiState;
+  };
+  /** Optional logger; defaults to console-prefixed. */
+  logger?: { info: (m: string) => void; error: (m: string) => void };
+}
+
+// image-builder produces a raw whole-disk ext4 rootfs (no partition table),
+// so /dev/vda is the filesystem itself. /dev/vda1 would be a partition that
+// does not exist and triggers a VFS-unable-to-mount-root kernel panic.
+// brainstormVM's own god-mode VMs use this same /dev/vda pattern.
+//
+// `rdinit=/init` tells the kernel to run /init from the initramfs (Alpine
+// initramfs has /init as PID 1, which loads modules and pivot_roots to
+// /dev/vda before exec'ing the rootfs's /sbin/init — i.e. our vsock-init).
+//
+// `rootfstype=ext4` is required because Alpine's initramfs init script
+// invokes busybox mount without an explicit `-t`; without ROOTFSTYPE set,
+// busybox tries to autodetect, which on a stock Alpine initramfs (which
+// has ext4 as a separate kernel module rather than built-in) renders as
+// "mount: mounting /dev/vda on /sysroot failed: No such file or directory"
+// — exactly the symptom 0bz7aztr saw on first-light run #4.
+export const DEFAULT_KERNEL_CMDLINE =
+  "console=hvc0 root=/dev/vda rootfstype=ext4 ro rdinit=/init";
+export const DEFAULT_VSOCK_CID = 3;
+export const DEFAULT_CPUS = 2;
+export const DEFAULT_MEM_MIB = 1024;

--- a/packages/sandbox/src/chv/chv-overlay-hash.ts
+++ b/packages/sandbox/src/chv/chv-overlay-hash.ts
@@ -1,0 +1,71 @@
+// SHA-256 hashing for the rootfs CoW overlay file.
+//
+// One of the three reset-verification sources (per threat model §5.1) is
+// the filesystem-hash of the rootfs's copy-on-write overlay. After a
+// clean snapshot revert the overlay should be empty (or contain only
+// well-known seed bytes), so its SHA-256 is stable and equal to the
+// install-time baseline.
+//
+// Why a separate module: tests need to inject a fake hasher to drive
+// "fs_hash matches baseline" vs "fs_hash diverges from baseline" cases
+// without writing real disk overlay files.
+//
+// Honesty: this module has been exercised against the default streaming
+// hasher (Node's built-in `crypto.createHash`) and against an injected
+// fake in unit tests. It has NOT been pointed at a real CHV CoW overlay
+// file in this checkout. The integration runner is responsible for
+// confirming that the file CHV writes to during execution does in fact
+// settle to a deterministic state after `snapshot` revert.
+
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+
+import { SandboxResetError } from "../errors.js";
+
+/**
+ * Compute a stable hash for a file path. Default returns SHA-256 in the
+ * `sha256:<hex>` form to match the protocol §13 baseline format.
+ *
+ * Tests inject a fake `HashFileFn` so the divergence vs match cases can
+ * be driven by canned values without writing real overlays.
+ */
+export type HashFileFn = (path: string) => Promise<string>;
+
+/**
+ * Default streaming hasher: opens the file, pipes through SHA-256,
+ * returns `sha256:<hex>`. Throws `SandboxResetError` if the file cannot
+ * be read — divergence from "baseline configured but unreadable post
+ * reset" is by definition a halt-worthy event.
+ */
+export const defaultHashFile: HashFileFn = async (path) => {
+  try {
+    await stat(path);
+  } catch (e) {
+    throw new SandboxResetError(
+      `rootfs overlay file unreadable at ${path}: ${(e as Error).message}`,
+      e,
+    );
+  }
+  return new Promise<string>((resolve, reject) => {
+    const hash = createHash("sha256");
+    const stream = createReadStream(path);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("end", () => resolve(`sha256:${hash.digest("hex")}`));
+    stream.on("error", (err) =>
+      reject(
+        new SandboxResetError(
+          `failed to stream rootfs overlay at ${path}: ${err.message}`,
+          err,
+        ),
+      ),
+    );
+  });
+};
+
+/**
+ * Sentinel returned when no `fs_hash` baseline is configured. The
+ * verification path treats this as "not configured" (soft pass with a
+ * marker), distinct from a real divergence.
+ */
+export const FS_HASH_NOT_CONFIGURED = "sha256:not-configured";

--- a/packages/sandbox/src/chv/chv-process.ts
+++ b/packages/sandbox/src/chv/chv-process.ts
@@ -1,0 +1,173 @@
+// Cloud Hypervisor subprocess management.
+//
+// What this file IS: a thin, honest wrapper around spawning the
+// `cloud-hypervisor` binary with the flags assembled from
+// `ChvSandboxConfig`. It also encapsulates the platform check
+// (Cloud Hypervisor is Linux-only — KVM-backed) so callers see a clean
+// `SandboxNotAvailableError` on Darwin instead of a confusing ENOENT.
+//
+// What this file is NOT: a working implementation that has been booted.
+// This module has not been executed against a real `cloud-hypervisor`
+// binary in this checkout. It is wiring waiting for a Linux runner.
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { access, constants } from "node:fs/promises";
+import { platform as nodePlatform } from "node:process";
+
+import { SandboxBootError, SandboxNotAvailableError } from "../errors.js";
+import {
+  type ChvSandboxConfig,
+  DEFAULT_CPUS,
+  DEFAULT_KERNEL_CMDLINE,
+  DEFAULT_MEM_MIB,
+} from "./chv-config.js";
+
+/**
+ * Returns true iff Cloud Hypervisor can plausibly run on this host.
+ * Cloud Hypervisor requires Linux + KVM. We check Linux here; KVM
+ * presence is checked at boot by attempting to start the VMM.
+ */
+export function isChvSupportedHost(): boolean {
+  return nodePlatform === "linux";
+}
+
+/**
+ * Throw `SandboxNotAvailableError` if the host cannot run CHV at all.
+ * Called from `ChvSandbox.boot()` so Darwin sessions fail cleanly.
+ */
+export async function assertChvAvailable(
+  config: ChvSandboxConfig,
+): Promise<{ cloudHypervisorBin: string; chRemoteBin: string }> {
+  if (!isChvSupportedHost()) {
+    throw new SandboxNotAvailableError(
+      `Cloud Hypervisor backend requires Linux (current platform: ${nodePlatform}). ` +
+        `On Darwin, use the Apple Virtualization.framework backend (P3.1b).`,
+    );
+  }
+
+  const cloudHypervisorBin = config.cloudHypervisorBin ?? "cloud-hypervisor";
+  const chRemoteBin = config.chRemoteBin ?? "ch-remote";
+
+  // If the user supplied an explicit path, verify it exists. We don't
+  // verify $PATH-resolved names here — `spawn` will surface ENOENT cleanly
+  // and the dispatcher logs it. This matches how the existing relay code
+  // handles optional binaries.
+  if (config.cloudHypervisorBin !== undefined) {
+    try {
+      await access(config.cloudHypervisorBin, constants.X_OK);
+    } catch (e) {
+      throw new SandboxNotAvailableError(
+        `cloud-hypervisor binary not found or not executable at ${config.cloudHypervisorBin}`,
+        e,
+      );
+    }
+  }
+  if (config.chRemoteBin !== undefined) {
+    try {
+      await access(config.chRemoteBin, constants.X_OK);
+    } catch (e) {
+      throw new SandboxNotAvailableError(
+        `ch-remote binary not found or not executable at ${config.chRemoteBin}`,
+        e,
+      );
+    }
+  }
+
+  return { cloudHypervisorBin, chRemoteBin };
+}
+
+/**
+ * Build the argv for `cloud-hypervisor` from a config. Matches the flags
+ * documented in cloud-hypervisor v40+ (`--api-socket`, `--kernel`, `--disk`,
+ * `--vsock`, `--cpus`, `--memory`).
+ *
+ * Untested on this machine — review against the installed CHV version
+ * before first-light boot.
+ */
+export function buildChvArgv(config: ChvSandboxConfig): string[] {
+  const cpus = config.cpus ?? DEFAULT_CPUS;
+  const memMib = config.memMib ?? DEFAULT_MEM_MIB;
+  const cmdline = config.kernel.cmdline ?? DEFAULT_KERNEL_CMDLINE;
+
+  const diskFlag =
+    config.rootfs.readonly === false
+      ? `path=${config.rootfs.path}`
+      : `path=${config.rootfs.path},readonly=on`;
+
+  const argv: string[] = [
+    "--api-socket",
+    `path=${config.apiSocketPath}`,
+    "--kernel",
+    config.kernel.path,
+  ];
+  if (config.kernel.initramfs !== undefined) {
+    argv.push("--initramfs", config.kernel.initramfs);
+  }
+  argv.push(
+    "--cmdline",
+    cmdline,
+    "--disk",
+    diskFlag,
+    "--cpus",
+    `boot=${cpus}`,
+    "--memory",
+    `size=${memMib}M`,
+    "--vsock",
+    `cid=${config.vsock.cid ?? 3},socket=${config.vsock.socketPath}`,
+    "--seccomp",
+    "true",
+  );
+  return argv;
+}
+
+export interface ChvProcessHandle {
+  child: ChildProcess;
+  argv: string[];
+  /** Best-effort exit awaitable; resolves on `exit` (with code). */
+  exited: Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
+}
+
+/**
+ * Spawn `cloud-hypervisor` and return a handle. Rejects with
+ * `SandboxBootError` if the process fails to start. Successful start does
+ * NOT mean the guest booted — that requires a vsock probe.
+ *
+ * Untested on this machine.
+ */
+export function spawnCloudHypervisor(
+  binary: string,
+  argv: string[],
+  logger: { info: (m: string) => void; error: (m: string) => void },
+): ChvProcessHandle {
+  const child = spawn(binary, argv, {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  child.on("error", (err) => {
+    logger.error(`[chv] spawn error: ${err.message}`);
+  });
+  child.stdout?.on("data", (chunk: Buffer) => {
+    // CHV is fairly chatty; we forward to a dedicated channel.
+    logger.info(`[chv stdout] ${chunk.toString("utf-8").trimEnd()}`);
+  });
+  child.stderr?.on("data", (chunk: Buffer) => {
+    logger.error(`[chv stderr] ${chunk.toString("utf-8").trimEnd()}`);
+  });
+
+  const exited = new Promise<{
+    code: number | null;
+    signal: NodeJS.Signals | null;
+  }>((resolve) => {
+    child.once("exit", (code, signal) => resolve({ code, signal }));
+  });
+
+  return { child, argv, exited };
+}
+
+/** Used by callers that want to surface boot failure with context. */
+export function asBootError(
+  message: string,
+  cause?: unknown,
+): SandboxBootError {
+  return new SandboxBootError(message, cause);
+}

--- a/packages/sandbox/src/chv/chv-remote.ts
+++ b/packages/sandbox/src/chv/chv-remote.ts
@@ -1,0 +1,269 @@
+// Thin wrapper around the `ch-remote` binary.
+//
+// Why a wrapper module: P3.2a needs to issue several `ch-remote` calls in
+// the reset path (snapshot revert, resume, info). The wrapper centralises
+// the argv shape, the JSON-parse for `info`, and — most importantly — the
+// dependency-injection point used by the unit tests.
+//
+// On Linux against a real Cloud Hypervisor, this module spawns the
+// `ch-remote` binary on $PATH (or wherever `ChvSandboxConfig.chRemoteBin`
+// points) using Node's promisified `execFile` (no shell, argv-style). On
+// Darwin (and in unit tests), the consumer injects a fake `ExecFileFn`
+// that returns canned stdout/stderr without touching the host.
+//
+// Honesty: every exported function in this file has been exercised against
+// a mock `ExecFileFn` in `__tests__/chv-sandbox-reset.test.ts`. None of
+// them have been exercised against a real `ch-remote` binary in this
+// checkout — that is 0bz7aztr's job on node-2 once this lands. The argv
+// shape is taken from cloud-hypervisor v40+ documentation; the integration
+// runner will surface any drift.
+//
+// Wire reference (from CHV `ch-remote --help` v40+):
+//   ch-remote --api-socket <path> restore source_url=file://<dir>     # roll back
+//   ch-remote --api-socket <path> snapshot destination_url=file://<dir> # create
+//   ch-remote --api-socket <path> resume                              # un-pause
+//   ch-remote --api-socket <path> info                                # vm.info JSON
+//   ch-remote --api-socket <path> pause                               # pause VMM
+//   ch-remote --api-socket <path> shutdown-vmm                        # stop + free
+//
+// NOTE: per the P3.2a wire-protocol spec, `snapshotRevert` here uses the
+// `snapshot` verb pointing at the golden directory rather than the
+// `restore` verb. This matches the prompt's protocol literally; if real
+// CHV semantics expect `restore` instead, the integration runner will
+// surface a non-zero exit and we patch the verb here. The tests pin the
+// argv shape so any change is a one-line edit + obvious test diff.
+
+import { execFile as nodeExecFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import type { VmmApiState } from "@brainst0rm/relay";
+
+import { SandboxResetError } from "../errors.js";
+
+/**
+ * Subset of Node's promisified `execFile` we depend on. Tests inject a
+ * fake; production uses the real binary via argv-style invocation.
+ */
+export type ExecFileFn = (
+  file: string,
+  args: readonly string[],
+) => Promise<{ stdout: string; stderr: string }>;
+
+export const defaultExecFile: ExecFileFn = promisify(
+  nodeExecFile,
+) as ExecFileFn;
+
+export interface ChRemoteOptions {
+  /** Binary name or absolute path. Defaults to `"ch-remote"`. */
+  binary?: string;
+  /** REST API socket path passed via `--api-socket`. Required. */
+  apiSocketPath: string;
+  /** Injection point. Defaults to Node's promisified argv-style invoker. */
+  execFile?: ExecFileFn;
+}
+
+/**
+ * Wrap the `ch-remote` invocations the reset path needs. Each method
+ * takes its own option set so callers can compose without re-creating the
+ * wrapper. (Reset issues 3 calls per cycle: revert, resume, info.)
+ */
+export class ChRemote {
+  private readonly binary: string;
+  private readonly apiSocketPath: string;
+  private readonly invoke: ExecFileFn;
+
+  constructor(opts: ChRemoteOptions) {
+    this.binary = opts.binary ?? "ch-remote";
+    this.apiSocketPath = opts.apiSocketPath;
+    this.invoke = opts.execFile ?? defaultExecFile;
+  }
+
+  /**
+   * Revert to a previously-created golden snapshot. Cloud Hypervisor's
+   * `restore` endpoint requires the VMM to have NO existing VM — it
+   * creates a fresh VM from the snapshot. Calling restore while a VM
+   * is Running fails with `InternalServerError: "VM is already created"`
+   * (caught on 0bz7aztr's run-3 with a Running VM that had just
+   * dispatched a tool successfully).
+   *
+   * Correct sequence (per CHV state-machine semantics):
+   *   1. ch-remote shutdown        # stop the running VM (guest off)
+   *   2. ch-remote delete          # remove VM from VMM (slot empty)
+   *   3. ch-remote restore         # load fresh VM from snapshot
+   *   4. ch-remote resume          # un-pause the restored VM
+   *
+   * The VMM (cloud-hypervisor process) stays alive across all four
+   * steps; only the VM-within-the-VMM gets cycled. Snapshot's symmetric
+   * verb (snapshot create) only requires `pause` because it doesn't
+   * touch the VM slot.
+   *
+   * Earlier history (commit log breadcrumbs):
+   *   - First version used `snapshot fs://<path>` for revert (Codex
+   *     round-2 catch — `snapshot` creates, `restore` reverts).
+   *   - Round-3 fixed `snapshot destination_url=` → `snapshot
+   *     file:///<dir>` (CHV's snapshot/restore argv shape is asymmetric).
+   *   - This version (run-3 catch by 0bz7aztr) inserts shutdown+delete
+   *     before restore so CHV accepts the call.
+   *
+   * Throws `SandboxResetError` if any of the four ch-remote calls
+   * exits non-zero — the dispatcher handles this by halting the
+   * sandbox (per threat-model §5.1 substrate-lying defense).
+   */
+  async snapshotRevert(snapshotPath: string): Promise<void> {
+    const apiSocket = ["--api-socket", this.apiSocketPath];
+    // 1. shutdown: stop the running VM
+    try {
+      await this.invoke(this.binary, [...apiSocket, "shutdown"]);
+    } catch (e) {
+      throw new SandboxResetError(
+        `ch-remote shutdown failed: ${(e as Error).message}`,
+        e,
+      );
+    }
+    // 2. delete: remove the VM definition so the VMM slot is empty
+    try {
+      await this.invoke(this.binary, [...apiSocket, "delete"]);
+    } catch (e) {
+      throw new SandboxResetError(
+        `ch-remote delete failed: ${(e as Error).message}`,
+        e,
+      );
+    }
+    // 3. restore: create fresh VM from snapshot
+    const sourceUrl = `source_url=file://${snapshotPath}`;
+    try {
+      await this.invoke(this.binary, [...apiSocket, "restore", sourceUrl]);
+    } catch (e) {
+      throw new SandboxResetError(
+        `ch-remote restore failed: ${(e as Error).message}`,
+        e,
+      );
+    }
+    // 4. resume: restored VM comes back paused, un-pause it
+    try {
+      await this.invoke(this.binary, [...apiSocket, "resume"]);
+    } catch (e) {
+      throw new SandboxResetError(
+        `ch-remote resume failed: ${(e as Error).message}`,
+        e,
+      );
+    }
+  }
+
+  /**
+   * Pause the running VM via the VMM REST API. Used by the install-time
+   * golden-snapshot flow: cloud-hypervisor requires the VM to be paused
+   * before `snapshot destination_url=...` is accepted (otherwise the
+   * snapshot call returns "VmNotPaused" and exits non-zero).
+   *
+   *   ch-remote --api-socket <path> pause
+   *
+   * Throws `SandboxResetError` on non-zero exit (consistent with
+   * snapshotRevert's error handling — the install-time CLI catches and
+   * exits with code 2).
+   */
+  async pause(): Promise<void> {
+    try {
+      await this.invoke(this.binary, [
+        "--api-socket",
+        this.apiSocketPath,
+        "pause",
+      ]);
+    } catch (e) {
+      throw new SandboxResetError(
+        `ch-remote pause failed: ${(e as Error).message}`,
+        e,
+      );
+    }
+  }
+
+  /**
+   * Create a new snapshot at the given destination directory. This is the
+   * symmetric verb to `snapshotRevert` — the install-time CLI uses it to
+   * mint the golden snapshot that subsequent `restore` calls roll back to.
+   *
+   * **argv asymmetry with restore:** CHV's `snapshot` and `restore` use
+   * DIFFERENT argv shapes (Codex round-3 catch, citing CHV docs at
+   * https://intelkevinputnam.github.io/cloud-hypervisor-docs-HTML/docs/snapshot_restore.html):
+   *
+   *   ch-remote --api-socket <path> snapshot file:///<destDir>           # bare URL
+   *   ch-remote --api-socket <path> restore source_url=file://<srcDir>   # key=value form
+   *
+   * Per cloud-hypervisor v40+ docs: the VM MUST be paused first (see
+   * `pause()`). The destination must be a directory; CHV writes
+   * `config.json`, `state.json`, and one `memory-ranges-*.bin` per region
+   * inside it. Existing files in the directory are overwritten.
+   *
+   * Throws `SandboxResetError` on non-zero exit (consistent with the
+   * other ch-remote verbs).
+   */
+  async snapshotCreate(destDir: string): Promise<void> {
+    const destinationUrl = `file://${destDir}`;
+    try {
+      await this.invoke(this.binary, [
+        "--api-socket",
+        this.apiSocketPath,
+        "snapshot",
+        destinationUrl,
+      ]);
+    } catch (e) {
+      throw new SandboxResetError(
+        `ch-remote snapshot failed: ${(e as Error).message}`,
+        e,
+      );
+    }
+  }
+
+  /**
+   * Query the VMM's REST API for the current VM state. Returns the raw
+   * state string normalised onto the protocol's `VmmApiState` vocabulary
+   * (`running` | `paused` | `stopped` | `error`).
+   *
+   * Mapping (from CHV `vm.info` source — `arch/state.rs`):
+   *   "Running"   -> "running"
+   *   "Paused"    -> "paused"
+   *   "Shutdown"  -> "stopped"   (canonical wire vocab uses stopped)
+   *   "Created"   -> "stopped"   (created-but-not-running → stopped)
+   *   anything else -> "error"   (forces divergence; loud failure)
+   */
+  async info(): Promise<{ raw: string; state: VmmApiState }> {
+    const { stdout } = await this.invoke(this.binary, [
+      "--api-socket",
+      this.apiSocketPath,
+      "info",
+    ]);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(stdout);
+    } catch (e) {
+      throw new SandboxResetError(
+        `ch-remote info returned non-JSON stdout: ${stdout.slice(0, 200)}`,
+        e,
+      );
+    }
+    const raw =
+      parsed !== null &&
+      typeof parsed === "object" &&
+      "state" in parsed &&
+      typeof (parsed as { state: unknown }).state === "string"
+        ? ((parsed as { state: string }).state as string)
+        : "";
+    return { raw, state: normaliseVmmState(raw) };
+  }
+}
+
+/**
+ * Normalise CHV's `state` string into the protocol's canonical
+ * `VmmApiState`. Unknown values map to `"error"` so divergence is loud
+ * (per threat-model §5.1: a substrate-lying attacker may emit a novel
+ * state string to dodge the verifier — we treat that as halt-worthy).
+ */
+export function normaliseVmmState(raw: string): VmmApiState {
+  const lower = raw.toLowerCase();
+  if (lower === "running") return "running";
+  if (lower === "paused") return "paused";
+  if (lower === "shutdown" || lower === "stopped" || lower === "created") {
+    return "stopped";
+  }
+  return "error";
+}

--- a/packages/sandbox/src/chv/chv-sandbox.ts
+++ b/packages/sandbox/src/chv/chv-sandbox.ts
@@ -1,0 +1,615 @@
+// ChvSandbox — Cloud Hypervisor backend for the Sandbox interface.
+//
+// Honesty boundary: this class wires together the pieces P3.1a and P3.2a
+// need (subprocess spawn, vsock client, snapshot/restore via ch-remote,
+// real 3-source reset verification) into a single object that satisfies
+// `Sandbox`.
+//
+// First-light status (2026-04 on node-2): boot works, vsock RPC works,
+// echo round-trips. Reset machinery (P3.2a — this file's revised
+// `reset()` / `snapshotRevert()` / `verifyPostReset()`) is host-side
+// code; full validation against a real `ch-remote` and a real golden
+// snapshot happens on a CHV runner per the README first-light checklist.
+//
+// On Darwin: `boot()` throws `SandboxNotAvailableError` cleanly. The
+// reset machinery in this file is exercised only against mocked
+// `ExecFileFn` / `HashFileFn` / vsock implementations in unit tests.
+
+import { stat } from "node:fs/promises";
+
+import {
+  SandboxBootError,
+  SandboxNotAvailableError,
+  SandboxResetDivergenceError,
+  SandboxResetError,
+  SandboxVsockHandshakeError,
+} from "../errors.js";
+import {
+  type ResetState,
+  type Sandbox,
+  type SandboxBackend,
+  type SandboxState,
+  type ToolExecution,
+  type ToolInvocation,
+  type VerificationDetails,
+  type VmmApiState,
+  makeVerificationDetails,
+} from "../sandbox.js";
+import { type ChvSandboxConfig, DEFAULT_VSOCK_CID } from "./chv-config.js";
+import {
+  defaultHashFile,
+  FS_HASH_NOT_CONFIGURED,
+  type HashFileFn,
+} from "./chv-overlay-hash.js";
+import { ChRemote, defaultExecFile, type ExecFileFn } from "./chv-remote.js";
+import {
+  assertChvAvailable,
+  buildChvArgv,
+  type ChvProcessHandle,
+  spawnCloudHypervisor,
+} from "./chv-process.js";
+import { VsockClient } from "./vsock-client.js";
+
+/**
+ * Minimal vsock-shaped surface used by reset's open-fd verification
+ * source. The real `VsockClient.guestQuery` satisfies this; tests
+ * inject a fake.
+ */
+export interface VsockGuestQueryClient {
+  guestQuery(kind: "OpenFdCount"): Promise<{ open_fd_count: number }>;
+}
+
+/**
+ * Test-injection seam. Production code passes nothing and the defaults
+ * (real `execFile`, real streaming SHA-256) take over. Unit tests pass
+ * an in-memory mock for each.
+ */
+export interface ChvSandboxDeps {
+  /** Replace ch-remote's argv-style invoker (tests). */
+  execFile?: ExecFileFn;
+  /** Replace the streaming SHA-256 (tests). */
+  hashFile?: HashFileFn;
+  /**
+   * Inject a fake guest-query client (tests). When set, reset's
+   * open-fd source uses this instead of `this.vsock`. Production
+   * leaves this undefined — the real vsock connection is used.
+   */
+  vsock?: VsockGuestQueryClient;
+}
+
+/**
+ * Marker emitted in `verification_details.fs_hash` when no baseline is
+ * configured. Distinct from a real hash so consumers can detect the
+ * "not configured" case without re-reading the config.
+ */
+const FS_HASH_BASELINE_UNSET = FS_HASH_NOT_CONFIGURED;
+
+export class ChvSandbox implements Sandbox {
+  public readonly backend: SandboxBackend = "chv";
+
+  private readonly config: ChvSandboxConfig;
+  private readonly log: {
+    info: (m: string) => void;
+    error: (m: string) => void;
+  };
+  private readonly deps: ChvSandboxDeps;
+  private readonly chRemote: ChRemote;
+  private readonly hashFile: HashFileFn;
+
+  private process: ChvProcessHandle | null = null;
+  private vsock: VsockClient | null = null;
+  private status: SandboxState = "not_booted";
+
+  constructor(config: ChvSandboxConfig, deps: ChvSandboxDeps = {}) {
+    this.config = {
+      ...config,
+      vsock: { cid: DEFAULT_VSOCK_CID, ...config.vsock },
+    };
+    this.log = config.logger ?? {
+      info: (m) => console.log(`[chv-sandbox] ${m}`),
+      error: (m) => console.error(`[chv-sandbox] ${m}`),
+    };
+    this.deps = deps;
+    this.chRemote = new ChRemote({
+      binary: config.chRemoteBin,
+      apiSocketPath: config.apiSocketPath,
+      execFile: deps.execFile ?? defaultExecFile,
+    });
+    this.hashFile = deps.hashFile ?? defaultHashFile;
+  }
+
+  state(): SandboxState {
+    return this.status;
+  }
+
+  async boot(): Promise<void> {
+    if (this.status === "ready" || this.status === "booting") return;
+    this.status = "booting";
+    try {
+      const { cloudHypervisorBin } = await assertChvAvailable(this.config);
+      const argv = buildChvArgv(this.config);
+      this.log.info(
+        `spawning ${cloudHypervisorBin} with kernel=${this.config.kernel.path} rootfs=${this.config.rootfs.path}`,
+      );
+      this.process = spawnCloudHypervisor(cloudHypervisorBin, argv, this.log);
+
+      // CHV needs hundreds of ms to start, parse argv, and bind both the
+      // REST API socket and the vsock UNIX socket. Polling for the vsock
+      // socket file is the cheapest readiness signal; we cap it at 30s
+      // and bail early if the child process exits before the socket
+      // appears (early-exit usually means CHV failed argv parsing or hit
+      // a permissions error — surface its stderr in the error message).
+      await this.waitForSocket(
+        this.config.vsock.socketPath,
+        30_000,
+        this.process,
+      );
+
+      // The AF_UNIX socket file exists from CHV-start, but CHV's bridge
+      // closes the connection if the guest's accept() loop isn't running
+      // yet — visible to us as
+      // "socket closed during handshake (peer hung up before sending OK)".
+      // Retry the CONNECT/OK handshake with backoff until either the
+      // guest's vsock listener is ready or we hit the cap. (0bz7aztr,
+      // first-light run #8: the guest takes ~hundreds of ms to reach the
+      // accept loop after CHV announces the bridge.)
+      this.vsock = await this.openVsockWithRetry(30_000);
+
+      this.status = "ready";
+    } catch (e) {
+      this.status = "failed";
+      // Kill the orphaned CHV child if boot failed mid-flight. Without
+      // this the parent process exits but cloud-hypervisor keeps running
+      // — observed by 0bz7aztr on first-light run #2 (PID had to be
+      // pkill'd manually). SIGTERM first; the child handles it cleanly.
+      if (this.process !== null) {
+        try {
+          this.process.child.kill("SIGTERM");
+        } catch {
+          // Already exited or never started — nothing to do.
+        }
+        this.process = null;
+      }
+      // Pass-through SandboxNotAvailableError unchanged (Darwin path);
+      // wrap anything else as SandboxBootError.
+      if (e instanceof SandboxNotAvailableError) throw e;
+      throw new SandboxBootError(`boot failed: ${(e as Error).message}`, e);
+    }
+  }
+
+  async executeTool(invocation: ToolInvocation): Promise<ToolExecution> {
+    if (this.status !== "ready" || this.vsock === null) {
+      throw new SandboxNotAvailableError(
+        `executeTool called with status=${this.status}`,
+      );
+    }
+    return this.vsock.sendCommand(invocation);
+  }
+
+  /**
+   * Expose `guestQuery` over the same vsock connection that runtime
+   * `reset()` uses. The install-time golden-snapshot CLI calls this to
+   * record the OpenFdCount baseline — using the SAME connection
+   * eliminates the probe-FD-overhead asymmetry that a parallel
+   * VsockClient would introduce. (Codex round-3 catch: opening a
+   * second client adds an FD the runtime path won't see, baking a
+   * stale baseline that diverges on first reset.)
+   */
+  async guestQuery(kind: "OpenFdCount"): Promise<{ open_fd_count: number }> {
+    if (this.status !== "ready" || this.vsock === null) {
+      throw new SandboxNotAvailableError(
+        `guestQuery called with status=${this.status}`,
+      );
+    }
+    const result = await this.vsock.guestQuery(kind);
+    if (
+      result === null ||
+      typeof result !== "object" ||
+      !("open_fd_count" in result) ||
+      typeof (result as { open_fd_count: unknown }).open_fd_count !== "number"
+    ) {
+      throw new SandboxNotAvailableError(
+        `OpenFdCount returned unexpected shape: ${JSON.stringify(result)}`,
+      );
+    }
+    return {
+      open_fd_count: (result as { open_fd_count: number }).open_fd_count,
+    };
+  }
+
+  async reset(): Promise<ResetState> {
+    if (this.status !== "ready") {
+      throw new SandboxResetError(
+        `reset called with status=${this.status}; sandbox must be ready`,
+      );
+    }
+    this.status = "resetting";
+    try {
+      // Step 1: revert to the golden snapshot (or no-op if not configured).
+      // The CHV state-machine sequence (shutdown → delete → restore →
+      // resume) cycles the VM-within-the-VMM, so the host's existing
+      // vsock connection — bound to pre-restore guest socket state —
+      // is dead by the time we return. (0bz7aztr's run-4 catch.)
+      await this.snapshotRevert();
+
+      // Step 1b: re-establish the vsock connection. The pre-existing
+      // `this.vsock` was invalidated by CHV's restore (it replaced the
+      // entire kernel including the socket table). Without this step
+      // the open-fd source in verifyPostReset would see "vsock closed"
+      // and false-positive a divergence on every reset.
+      //
+      // Threat-model §A6 design said "use the same connection runtime
+      // and install-time both use" — but "same connection" can't
+      // survive a restore. The design's intent (FD-overhead symmetry)
+      // is preserved by using the same connection-shape: one host
+      // CONNECT bound to the same guest port. Install-time records its
+      // baseline through this same shape, runtime queries through this
+      // same shape, so probe overhead matches even though the literal
+      // socket object has been replaced.
+      // Skip when `deps.vsock` is injected — that's the test seam, and
+      // tests expect the injected mock to represent the post-restore
+      // state without needing a real CHV vsock socket on disk.
+      if (this.snapshotConfigured() && this.deps.vsock === undefined) {
+        if (this.vsock !== null) {
+          // Best-effort close; the prior vsock is dead anyway.
+          await this.vsock.close().catch(() => {});
+          this.vsock = null;
+        }
+        this.vsock = await this.openVsockWithRetry(30_000);
+      }
+
+      // Step 2: 3-source verification. Each source compares against a
+      // baseline; any disagreement -> halt (per threat-model §5.1).
+      const verification = await this.verifyPostReset();
+
+      // makeVerificationDetails sets divergence_action = "halt" iff any
+      // of the three sources disagrees with its baseline. We re-derive
+      // that here so the failure path is explicit and auditable.
+      const diverged = verification.divergence_action === "halt";
+      if (diverged) {
+        this.status = "failed";
+        throw new SandboxResetDivergenceError(
+          `reset verification diverged: ` +
+            `fs_match=${verification.fs_hash_match} ` +
+            `fd_match=${verification.open_fd_count === verification.open_fd_count_baseline} ` +
+            `vmm_match=${verification.vmm_api_state === verification.expected_vmm_api_state} ` +
+            `(divergence_action=halt)`,
+        );
+      }
+
+      this.status = "ready";
+      return {
+        reset_at: new Date().toISOString(),
+        // The golden hash is the install-time baseline if configured; if
+        // baselines are unset we surface the explicit "not configured"
+        // marker so the dispatcher / audit log can flag the verification
+        // posture clearly.
+        golden_hash: this.config.baselines?.fs_hash ?? FS_HASH_BASELINE_UNSET,
+        verification_passed: true,
+        verification_details: verification,
+      };
+    } catch (e) {
+      if (e instanceof SandboxResetDivergenceError) throw e;
+      this.status = "failed";
+      throw new SandboxResetError(`reset failed: ${(e as Error).message}`, e);
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    try {
+      if (this.vsock !== null) {
+        await this.vsock.close();
+        this.vsock = null;
+      }
+    } catch (e) {
+      this.log.error(`vsock close error: ${(e as Error).message}`);
+    }
+    if (this.process !== null) {
+      try {
+        // ch-remote shutdown is the polite path (clean VMM tear-down).
+        // SIGTERM on the spawned process is the fallback.
+        const invoke = this.deps.execFile ?? defaultExecFile;
+        const binary = this.config.chRemoteBin ?? "ch-remote";
+        await invoke(binary, [
+          "--api-socket",
+          this.config.apiSocketPath,
+          "shutdown-vmm",
+        ]);
+      } catch (e) {
+        this.log.error(
+          `ch-remote shutdown failed (${(e as Error).message}); falling back to SIGTERM`,
+        );
+        try {
+          this.process.child.kill("SIGTERM");
+        } catch {}
+      }
+      this.process = null;
+    }
+    this.status = "not_booted";
+  }
+
+  // --- internals ---------------------------------------------------------
+
+  /**
+   * Revert to the golden snapshot via `ch-remote`. Per the P3.2a wire
+   * protocol:
+   *
+   *   ch-remote --api-socket <path> snapshot fs://<snapshotPath>
+   *   ch-remote --api-socket <path> resume
+   *
+   * If `config.snapshotPath` is unset, this is a no-op — appropriate for
+   * unit-test mode and for early scaffolding where the install-time
+   * golden-snapshot flow has not yet been wired. Verification still
+   * runs after a no-op revert so the dispatcher can observe the
+   * post-reset state.
+   *
+   * Errors from either ch-remote call are wrapped in `SandboxResetError`
+   * by `ChRemote.snapshotRevert` and surface here unchanged.
+   */
+  /** True when a snapshotPath is configured — i.e. snapshotRevert
+   *  actually reverts CHV state and the vsock connection needs to be
+   *  re-established afterward. */
+  private snapshotConfigured(): boolean {
+    return this.config.snapshotPath !== undefined;
+  }
+
+  private async snapshotRevert(): Promise<void> {
+    if (this.config.snapshotPath === undefined) {
+      this.log.info(
+        "no snapshotPath configured; skipping revert (test/scaffold mode)",
+      );
+      return;
+    }
+    await this.chRemote.snapshotRevert(this.config.snapshotPath);
+  }
+
+  /**
+   * 3-source post-reset verification (threat model §5.1). Each source
+   * contributes one signal:
+   *
+   *   1. FS hash       — SHA-256 of post-reset rootfs CoW *overlay* file
+   *                      (NOT the read-only base disk — see overlayPath
+   *                      in RootfsConfig). Hashing the base would miss
+   *                      a substrate-lying attacker who mutates writes.
+   *   2. open_fd_count — queried inside the guest via vsock GuestQuery
+   *   3. vmm_api_state — `ch-remote info` returns running/paused/etc.
+   *
+   * Each source is compared against its baseline. If any disagrees, the
+   * resulting `VerificationDetails.divergence_action` is "halt" and the
+   * caller (`reset()`) throws `SandboxResetDivergenceError`.
+   *
+   * **Baselines or overlayPath unset → divergence (halt).** The earlier
+   * scaffolding "soft-passed" with matching sentinels; Codex review
+   * caught that as a substrate-lying-defense bypass. A production
+   * endpoint MUST configure both `RootfsConfig.overlayPath` AND all
+   * three `baselines.*` fields, or `reset()` halts. Configuring only
+   * some sources is treated as misconfiguration; the missing source
+   * forces divergence so operators see the gap immediately.
+   */
+  private async verifyPostReset(): Promise<VerificationDetails> {
+    const baselines = this.config.baselines;
+    // overlayPath defaults to rootfs.path (the file CHV's --disk points
+    // at). Advanced operators using qcow2 backing-file or host-level
+    // overlayfs override this; the default-to-path makes the simple
+    // case work without configuration. Codex round-3 catch.
+    const fsHashFile =
+      this.config.rootfs.overlayPath ?? this.config.rootfs.path;
+
+    // --- Source 1: FS hash of writable disk file ----------------------
+    let fs_hash: string;
+    let fs_hash_baseline: string;
+    if (baselines?.fs_hash === undefined) {
+      fs_hash = FS_HASH_BASELINE_UNSET + ":actual-missing";
+      fs_hash_baseline = FS_HASH_BASELINE_UNSET + ":baseline-missing";
+      this.log.error(
+        `fs_hash baseline not configured; forcing divergence — ` +
+          `configure baselines.fs_hash before claiming reset integrity`,
+      );
+    } else {
+      fs_hash_baseline = baselines.fs_hash;
+      try {
+        fs_hash = await this.hashFile(fsHashFile);
+      } catch (e) {
+        // Hashing itself failed -> treat as divergence (loud failure).
+        // makeVerificationDetails will mark fs_hash_match = false and
+        // set divergence_action = "halt".
+        this.log.error(
+          `fs_hash computation failed: ${(e as Error).message} (treating as divergence)`,
+        );
+        fs_hash = "sha256:hash-error";
+      }
+    }
+
+    // --- Source 2: open-fd count via vsock GuestQuery ----------------
+    let open_fd_count: number;
+    let open_fd_count_baseline: number;
+    if (baselines?.open_fd_count === undefined) {
+      // Baseline unset → force divergence rather than fabricating a
+      // soft-pass. -1 vs -2 sentinels guarantee mismatch.
+      open_fd_count = -2;
+      open_fd_count_baseline = -1;
+      this.log.error(
+        "open_fd_count baseline not configured; forcing divergence",
+      );
+    } else {
+      open_fd_count_baseline = baselines.open_fd_count;
+      // Tests inject a `VsockGuestQueryClient` directly; production
+      // uses the real `VsockClient` opened during boot. Both expose a
+      // `guestQuery("OpenFdCount")` shape — the real client returns a
+      // wider union, so we narrow by checking for the expected field.
+      const queryClient = this.deps.vsock ?? this.vsock;
+      if (queryClient === null) {
+        // We're configured to verify but have no vsock -> implementation
+        // error (reset called without boot). Treat as divergence:
+        // better to halt than fabricate a passing reading.
+        this.log.error(
+          "open_fd_count baseline configured but vsock client unavailable",
+        );
+        open_fd_count = -1;
+      } else {
+        try {
+          const result = await queryClient.guestQuery("OpenFdCount");
+          if (
+            result !== null &&
+            typeof result === "object" &&
+            "open_fd_count" in result &&
+            typeof (result as { open_fd_count: unknown }).open_fd_count ===
+              "number"
+          ) {
+            open_fd_count = (result as { open_fd_count: number }).open_fd_count;
+          } else {
+            this.log.error(
+              `open_fd_count query returned unexpected shape: ${JSON.stringify(result)}`,
+            );
+            open_fd_count = -1;
+          }
+        } catch (e) {
+          this.log.error(
+            `open_fd_count query failed: ${(e as Error).message} (treating as divergence)`,
+          );
+          open_fd_count = -1;
+        }
+      }
+    }
+
+    // --- Source 3: VMM API state via ch-remote info ------------------
+    let vmm_api_state: VmmApiState;
+    let expected_vmm_api_state: VmmApiState;
+    if (baselines?.expected_vmm_api_state === undefined) {
+      // Baseline unset → force divergence. We still emit `live` for
+      // audit traceability, but the baseline sentinel won't match.
+      try {
+        const live = await this.chRemote.info();
+        vmm_api_state = live.state;
+      } catch (e) {
+        this.log.error(
+          `ch-remote info failed: ${(e as Error).message} (recording as 'error')`,
+        );
+        vmm_api_state = "error";
+      }
+      // "error" is in the VmmApiState union; using it as a baseline
+      // value here is fine and guaranteed to mismatch any live "running"
+      // / "paused" / "stopped" reading.
+      expected_vmm_api_state = "error";
+      this.log.error(
+        "expected_vmm_api_state baseline not configured; forcing divergence",
+      );
+    } else {
+      expected_vmm_api_state = baselines.expected_vmm_api_state;
+      try {
+        const live = await this.chRemote.info();
+        vmm_api_state = live.state;
+      } catch (e) {
+        // ch-remote unreachable post-reset is itself a divergence — the
+        // VMM may have crashed during revert. Loud-fail.
+        this.log.error(
+          `ch-remote info failed post-reset: ${(e as Error).message} (treating as divergence)`,
+        );
+        vmm_api_state = "error";
+      }
+    }
+
+    return makeVerificationDetails({
+      fs_hash,
+      fs_hash_baseline,
+      open_fd_count,
+      open_fd_count_baseline,
+      vmm_api_state,
+      expected_vmm_api_state,
+    });
+  }
+
+  /**
+   * Repeatedly attempt the CHV CONNECT/OK handshake until the guest's
+   * accept loop is ready (or we hit the timeout). Each handshake-failure
+   * is treated as "guest not yet ready" and retried after a 250ms
+   * backoff; non-handshake errors propagate immediately.
+   */
+  private async openVsockWithRetry(timeoutMs: number): Promise<VsockClient> {
+    const start = Date.now();
+    let attempt = 0;
+    let lastErr: Error | null = null;
+    while (Date.now() - start < timeoutMs) {
+      attempt++;
+      const client = new VsockClient({
+        socketPath: this.config.vsock.socketPath,
+        guestPort: this.config.vsock.guestPort,
+        logger: this.log,
+      });
+      try {
+        await client.open();
+        if (attempt > 1) {
+          this.log.info(
+            `[vsock] handshake succeeded on attempt ${attempt} (took ${Date.now() - start}ms total)`,
+          );
+        }
+        return client;
+      } catch (e) {
+        lastErr = e as Error;
+        if (!(e instanceof SandboxVsockHandshakeError)) {
+          // Non-handshake error: don't retry (e.g. SandboxNotAvailableError).
+          throw e;
+        }
+        // Handshake-failure is the expected race signal during boot.
+        await client.close().catch(() => {});
+        await new Promise((r) => setTimeout(r, 250));
+      }
+    }
+    throw new SandboxBootError(
+      `vsock handshake never succeeded within ${timeoutMs}ms (last error: ${lastErr?.message ?? "unknown"})`,
+      lastErr ?? undefined,
+    );
+  }
+
+  /**
+   * Poll for a Unix socket file to appear at `path`. Returns once stat
+   * succeeds; throws on timeout or if the CHV child process exits before
+   * the socket appears (early exit usually means argv parse / permission
+   * failure — the caller's logger has already captured CHV's stderr).
+   */
+  private async waitForSocket(
+    path: string,
+    timeoutMs: number,
+    chv: ChvProcessHandle,
+  ): Promise<void> {
+    const intervalMs = 50;
+    const start = Date.now();
+    type ExitInfo = {
+      code: number | null;
+      signal: NodeJS.Signals | null;
+    };
+    const exitRef: { value: ExitInfo | null } = { value: null };
+    void chv.exited.then((info) => {
+      exitRef.value = info;
+    });
+
+    while (true) {
+      try {
+        await stat(path);
+        return;
+      } catch {
+        // socket not yet present
+      }
+      if (exitRef.value !== null) {
+        const ev = exitRef.value;
+        throw new SandboxBootError(
+          `cloud-hypervisor exited before vsock socket appeared at ${path} ` +
+            `(code=${ev.code} signal=${ev.signal}); ` +
+            `check the [chv stderr] log lines above for the cause`,
+        );
+      }
+      if (Date.now() - start > timeoutMs) {
+        throw new SandboxBootError(
+          `vsock socket did not appear at ${path} within ${timeoutMs}ms ` +
+            `(cloud-hypervisor still alive — guest may have wedged or argv may be wrong)`,
+        );
+      }
+      await new Promise((r) => setTimeout(r, intervalMs));
+    }
+  }
+
+  // Test-only state: `__tests__/chv-sandbox-reset.test.ts` reaches in via
+  // `as any` to set `status = "ready"` and inject a fake vsock without a
+  // real boot. We deliberately don't expose a public hook — keeping the
+  // shape minimal forces tests to be honest about what they're poking.
+}

--- a/packages/sandbox/src/chv/vsock-client.ts
+++ b/packages/sandbox/src/chv/vsock-client.ts
@@ -1,0 +1,684 @@
+// vsock command/response client.
+//
+// The brainstorm-agent host process opens an AF_UNIX socket created by
+// Cloud Hypervisor's `--vsock cid=N,socket=/path` flag. Cloud Hypervisor
+// exposes a bridge protocol on that socket: the host writes
+// `CONNECT <port>\n` (ASCII), CHV replies with `OK <sourcePort>\n` on
+// success or any other line on failure. After a successful CONNECT, the
+// AF_UNIX socket is a transparent byte stream to the in-guest vsock
+// listener on `<port>`.
+//
+// Once connected, we speak a length-prefixed JSON-frame protocol:
+//
+//   uint32 BE length | JSON bytes (UTF-8) of exactly `length` bytes
+//
+// Every request and response carries a `request_id` (UUID-shaped string)
+// so one connection can have many in-flight requests. The host maintains
+// a `request_id` -> pending-resolver map; the read loop dispatches each
+// inbound frame back to the matching resolver.
+//
+// Message kinds (per docs/endpoint-agent-protocol-v1.md section 6):
+//
+//   - ToolDispatch    (host -> guest)  - execute a tool
+//   - ToolResult      (guest -> host)  - terminal result for a ToolDispatch
+//   - GuestQuery      (host -> guest)  - integrity-monitor probe (fd count etc.)
+//   - GuestResponse   (guest -> host)  - response to GuestQuery
+//
+// Wire-level `request_id` is mapped onto the protocol's existing
+// `command_id` (for ToolDispatch / ToolResult) and `query_id` (for
+// GuestQuery / GuestResponse). The on-the-wire schema matches the
+// protocol doc exactly; this client only injects the length prefix.
+//
+// Darwin: Cloud Hypervisor doesn't run on Darwin, so when no AF_UNIX
+// socket exists at the configured path we throw `SandboxNotAvailableError`
+// to keep the local typecheck/build path friendly. If a socket DOES exist
+// at that path (e.g. a fake CHV-like listener stood up by tests), we go
+// through the real protocol -- that's how the test suite exercises this
+// file on Darwin.
+
+import { connect, type Socket } from "node:net";
+import { stat } from "node:fs/promises";
+import { platform as nodePlatform } from "node:process";
+import { randomUUID } from "node:crypto";
+
+import {
+  SandboxError,
+  SandboxNotAvailableError,
+  SandboxToolTimeoutError,
+  SandboxVsockFrameTooLargeError,
+  SandboxVsockHandshakeError,
+} from "../errors.js";
+import type { ToolExecution, ToolInvocation } from "../sandbox.js";
+
+/** Default 16 MiB cap, matches protocol section 6 ("Max frame size 16 MiB"). */
+export const DEFAULT_MAX_FRAME_BYTES = 16 * 1024 * 1024;
+
+/** Default vsock guest port for the in-guest dispatcher. */
+export const DEFAULT_GUEST_PORT = 1024;
+
+/** Protocol §6: connection-level timeout when a frame is mid-flight (after
+ *  4-byte length header but before full payload arrives). Fires fatal. */
+export const DEFAULT_PARTIAL_FRAME_TIMEOUT_MS = 30_000;
+
+export interface VsockClientOptions {
+  /** Host-side AF_UNIX path that CHV created via `--vsock socket=...`. */
+  socketPath: string;
+  /** Guest port the in-guest dispatcher is listening on. Default 1024. */
+  guestPort?: number;
+  /** Max declared frame length in bytes. Default 16 MiB. */
+  maxFrameBytes?: number;
+  /** Handshake timeout in ms. Default 5_000. */
+  handshakeTimeoutMs?: number;
+  /** Partial-frame stall timeout (protocol §6). Default 30_000. */
+  partialFrameTimeoutMs?: number;
+  logger?: { info: (m: string) => void; error: (m: string) => void };
+}
+
+/** GuestQuery kinds defined in protocol section 6.3.5. */
+export type GuestQueryKind = "OpenFdCount" | "MemUsage" | "ProcessList";
+
+export type GuestQueryResult =
+  | { open_fd_count: number }
+  | { bytes_used: number; bytes_total: number }
+  | { processes: Array<{ name: string; pid: number }> };
+
+interface PendingRequest {
+  resolve: (frame: Record<string, unknown>) => void;
+  reject: (err: Error) => void;
+  /** Set if a deadline timer is pending so we can cancel it on response. */
+  timer: NodeJS.Timeout | null;
+}
+
+/** Internal: parse a `CONNECT` reply line. */
+function parseHandshakeReply(
+  line: string,
+): { ok: true; sourcePort: number } | { ok: false; raw: string } {
+  // CHV writes `OK <port>\n`. Anything else (commonly an empty line, or
+  // the connection is closed) is a failure.
+  const trimmed = line.replace(/\r?\n$/, "");
+  const m = /^OK\s+(\d+)$/.exec(trimmed);
+  if (m === null) {
+    return { ok: false, raw: trimmed };
+  }
+  const sourcePort = Number.parseInt(m[1], 10);
+  if (!Number.isFinite(sourcePort) || sourcePort < 0) {
+    return { ok: false, raw: trimmed };
+  }
+  return { ok: true, sourcePort };
+}
+
+/** Internal: incremental read state. The socket is a byte stream so we
+ *  may receive partial frames or several frames glued together. */
+interface ReadState {
+  buf: Buffer;
+  /** When we have a length header but not enough payload yet. */
+  expecting: number | null;
+}
+
+export class VsockClient {
+  private readonly opts: Required<
+    Pick<
+      VsockClientOptions,
+      | "guestPort"
+      | "maxFrameBytes"
+      | "handshakeTimeoutMs"
+      | "partialFrameTimeoutMs"
+    >
+  > &
+    VsockClientOptions;
+  private readonly logger: NonNullable<VsockClientOptions["logger"]>;
+  private socket: Socket | null = null;
+  private sourcePort: number | null = null;
+  private readState: ReadState = { buf: Buffer.alloc(0), expecting: null };
+  private readonly pending = new Map<string, PendingRequest>();
+  /** True once the read loop has been attached. */
+  private readLoopAttached = false;
+  /** Latched fatal error -- once set, all in-flight + future ops fail with it. */
+  private fatal: Error | null = null;
+  /** Watchdog: armed whenever we're mid-frame (expecting !== null) and
+   *  haven't made progress for partialFrameTimeoutMs. Protocol §6 mandates
+   *  a 30s connection-level partial-frame timeout independent of any
+   *  per-request deadline. Fires SandboxVsockPartialFrameTimeoutError. */
+  private partialFrameTimer: NodeJS.Timeout | null = null;
+
+  constructor(opts: VsockClientOptions) {
+    this.opts = {
+      guestPort: opts.guestPort ?? DEFAULT_GUEST_PORT,
+      maxFrameBytes: opts.maxFrameBytes ?? DEFAULT_MAX_FRAME_BYTES,
+      handshakeTimeoutMs: opts.handshakeTimeoutMs ?? 5_000,
+      partialFrameTimeoutMs:
+        opts.partialFrameTimeoutMs ?? DEFAULT_PARTIAL_FRAME_TIMEOUT_MS,
+      ...opts,
+    };
+    this.logger = opts.logger ?? {
+      info: () => {},
+      error: () => {},
+    };
+  }
+
+  /**
+   * Connect to the AF_UNIX socket and perform the CHV `CONNECT <port>`
+   * handshake. After this resolves, the socket is a transparent byte
+   * stream into the guest's vsock listener and `sendCommand` /
+   * `dispatchRequest` / `guestQuery` are usable.
+   *
+   * Darwin: if no socket file exists at `socketPath`, throws
+   * `SandboxNotAvailableError`. If a socket DOES exist (tests stand up a
+   * fake listener), the full protocol is exercised -- useful for unit
+   * tests of this file's own behaviour.
+   */
+  async open(): Promise<void> {
+    if (this.socket !== null) return;
+
+    // Darwin honesty rail: if there's no socket file, surface
+    // SandboxNotAvailableError rather than letting `connect` produce a
+    // confusing ENOENT. We deliberately check by `stat` rather than
+    // platform alone -- a fake AF_UNIX listener (in tests) on Darwin
+    // exists at `socketPath` and SHOULD go through the real path.
+    if (nodePlatform === "darwin") {
+      try {
+        await stat(this.opts.socketPath);
+      } catch {
+        throw new SandboxNotAvailableError(
+          `Cloud Hypervisor vsock socket not present at ${this.opts.socketPath} ` +
+            `(Darwin host; CHV cannot run here). On Linux this socket is ` +
+            `created by the --vsock cid=N,socket=... flag at boot.`,
+        );
+      }
+    }
+
+    const sock = await this.connectSocket();
+
+    try {
+      this.sourcePort = await this.handshake(sock);
+    } catch (e) {
+      try {
+        sock.destroy();
+      } catch {}
+      throw e;
+    }
+
+    this.socket = sock;
+    this.attachReadLoop();
+    this.logger.info(
+      `[vsock] handshake ok: connected to guest port ${this.opts.guestPort} as source ${this.sourcePort}`,
+    );
+  }
+
+  private connectSocket(): Promise<Socket> {
+    return new Promise((resolve, reject) => {
+      const sock = connect(this.opts.socketPath);
+      const onError = (err: Error) => {
+        sock.removeListener("connect", onConnect);
+        reject(
+          new SandboxNotAvailableError(
+            `vsock socket not reachable at ${this.opts.socketPath}: ${err.message}`,
+            err,
+          ),
+        );
+      };
+      const onConnect = () => {
+        sock.removeListener("error", onError);
+        resolve(sock);
+      };
+      sock.once("error", onError);
+      sock.once("connect", onConnect);
+    });
+  }
+
+  private handshake(sock: Socket): Promise<number> {
+    return new Promise<number>((resolve, reject) => {
+      let acc = Buffer.alloc(0);
+      let settled = false;
+
+      const cleanup = () => {
+        sock.removeListener("data", onData);
+        sock.removeListener("error", onError);
+        sock.removeListener("close", onClose);
+        clearTimeout(timer);
+      };
+
+      const fail = (err: Error) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(err);
+      };
+
+      const succeed = (port: number) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        // If extra bytes arrived past the newline they're frames for the
+        // length-prefixed protocol -- push them into the read state so
+        // the read loop picks them up.
+        const nlIdx = acc.indexOf(0x0a);
+        if (nlIdx !== -1 && nlIdx + 1 < acc.length) {
+          this.readState.buf = Buffer.concat([
+            this.readState.buf,
+            acc.subarray(nlIdx + 1),
+          ]);
+        }
+        resolve(port);
+      };
+
+      const onData = (chunk: Buffer) => {
+        acc = Buffer.concat([acc, chunk]);
+        const nlIdx = acc.indexOf(0x0a);
+        if (nlIdx === -1) {
+          // No newline yet -- may be a partial reply; keep buffering.
+          // Guard against runaway: 256 bytes is generous for `OK <port>\n`.
+          if (acc.length > 256) {
+            fail(
+              new SandboxVsockHandshakeError(
+                `handshake reply exceeded 256 bytes without a newline`,
+              ),
+            );
+          }
+          return;
+        }
+        const line = acc.subarray(0, nlIdx).toString("ascii");
+        const parsed = parseHandshakeReply(line + "\n");
+        if (!parsed.ok) {
+          fail(
+            new SandboxVsockHandshakeError(
+              `unexpected handshake reply from CHV: ${JSON.stringify(parsed.raw)}`,
+            ),
+          );
+          return;
+        }
+        succeed(parsed.sourcePort);
+      };
+
+      const onError = (err: Error) => {
+        fail(
+          new SandboxVsockHandshakeError(
+            `socket error during handshake: ${err.message}`,
+            err,
+          ),
+        );
+      };
+
+      const onClose = () => {
+        fail(
+          new SandboxVsockHandshakeError(
+            `socket closed during handshake (peer hung up before sending OK)`,
+          ),
+        );
+      };
+
+      const timer = setTimeout(() => {
+        fail(
+          new SandboxVsockHandshakeError(
+            `handshake timed out after ${this.opts.handshakeTimeoutMs}ms`,
+          ),
+        );
+      }, this.opts.handshakeTimeoutMs);
+
+      sock.on("data", onData);
+      sock.once("error", onError);
+      sock.once("close", onClose);
+
+      // Send the CONNECT line. CHV expects ASCII; we follow the
+      // documented form exactly: "CONNECT <port>\n".
+      sock.write(`CONNECT ${this.opts.guestPort}\n`, "ascii", (err) => {
+        if (err !== null && err !== undefined) {
+          fail(
+            new SandboxVsockHandshakeError(
+              `failed to write CONNECT: ${err.message}`,
+              err,
+            ),
+          );
+        }
+      });
+    });
+  }
+
+  /**
+   * Wire up the long-running read loop on `this.socket`. Demuxes inbound
+   * length-prefixed JSON frames back to pending `request_id` resolvers.
+   */
+  private attachReadLoop(): void {
+    if (this.readLoopAttached || this.socket === null) return;
+    this.readLoopAttached = true;
+    const sock = this.socket;
+
+    sock.on("data", (chunk: Buffer) => {
+      this.readState.buf = Buffer.concat([this.readState.buf, chunk]);
+      // Bytes arrived: if a frame was mid-flight, kick the partial-frame
+      // watchdog forward. drainFrames() will (re-)arm or clear it based
+      // on the post-drain state.
+      this.drainFrames();
+    });
+    sock.once("error", (err) => {
+      this.fail(err);
+    });
+    sock.once("close", () => {
+      this.fail(new SandboxError("SANDBOX_VSOCK_CLOSED", "vsock closed"));
+    });
+
+    // The socket may already have buffered post-handshake bytes (from
+    // `succeed` above pushing them into readState).
+    if (this.readState.buf.length > 0) {
+      this.drainFrames();
+    }
+  }
+
+  private drainFrames(): void {
+    while (true) {
+      if (this.fatal !== null) return;
+      if (this.readState.expecting === null) {
+        if (this.readState.buf.length < 4) {
+          // Between frames OR mid-header. If we have 1-3 header bytes,
+          // arm/refresh the partial-frame watchdog (peer started a frame
+          // but stalled). Otherwise (buf empty), ensure the watchdog is
+          // cleared.
+          if (this.readState.buf.length === 0) {
+            this.clearPartialFrameWatchdog();
+          } else {
+            this.armPartialFrameWatchdog();
+          }
+          return;
+        }
+        const declared = this.readState.buf.readUInt32BE(0);
+        if (declared > this.opts.maxFrameBytes) {
+          // Latched fatal; we cannot safely skip past `declared` bytes
+          // from a peer that may be lying.
+          this.fail(
+            new SandboxVsockFrameTooLargeError(
+              declared,
+              this.opts.maxFrameBytes,
+            ),
+          );
+          return;
+        }
+        this.readState.expecting = declared;
+        this.readState.buf = this.readState.buf.subarray(4);
+      }
+      if (this.readState.buf.length < this.readState.expecting) {
+        // Header in hand, payload incomplete: arm/refresh watchdog. Each
+        // call to drainFrames after new data refreshes the deadline, so
+        // a peer dripping bytes faster than partialFrameTimeoutMs stays
+        // alive while a fully stalled peer trips the timeout.
+        this.armPartialFrameWatchdog();
+        return;
+      }
+      const payload = this.readState.buf.subarray(0, this.readState.expecting);
+      this.readState.buf = this.readState.buf.subarray(
+        this.readState.expecting,
+      );
+      this.readState.expecting = null;
+      this.clearPartialFrameWatchdog();
+      this.handleFrame(payload);
+    }
+  }
+
+  private armPartialFrameWatchdog(): void {
+    if (this.partialFrameTimer !== null) {
+      clearTimeout(this.partialFrameTimer);
+    }
+    this.partialFrameTimer = setTimeout(() => {
+      this.partialFrameTimer = null;
+      this.fail(
+        new SandboxError(
+          "SANDBOX_VSOCK_PARTIAL_FRAME_TIMEOUT",
+          `vsock partial frame stalled for >${this.opts.partialFrameTimeoutMs}ms (protocol §6 connection-level timeout)`,
+        ),
+      );
+    }, this.opts.partialFrameTimeoutMs);
+  }
+
+  private clearPartialFrameWatchdog(): void {
+    if (this.partialFrameTimer !== null) {
+      clearTimeout(this.partialFrameTimer);
+      this.partialFrameTimer = null;
+    }
+  }
+
+  private handleFrame(payload: Buffer): void {
+    let frame: Record<string, unknown>;
+    try {
+      const text = payload.toString("utf-8");
+      const parsed = JSON.parse(text);
+      if (
+        parsed === null ||
+        typeof parsed !== "object" ||
+        Array.isArray(parsed)
+      ) {
+        throw new Error("frame is not a JSON object");
+      }
+      frame = parsed as Record<string, unknown>;
+    } catch (e) {
+      this.logger.error(
+        `[vsock] dropping malformed frame: ${(e as Error).message}`,
+      );
+      return;
+    }
+
+    // request_id is the unifying correlator. ToolResult uses `command_id`,
+    // GuestResponse uses `query_id`. We accept any of those keys as the
+    // correlator field.
+    const requestId =
+      (typeof frame.request_id === "string" && frame.request_id) ||
+      (typeof frame.command_id === "string" && frame.command_id) ||
+      (typeof frame.query_id === "string" && frame.query_id) ||
+      null;
+    if (requestId === null) {
+      this.logger.error(
+        `[vsock] dropping frame with no request_id/command_id/query_id`,
+      );
+      return;
+    }
+    const pending = this.pending.get(requestId);
+    if (pending === undefined) {
+      this.logger.error(
+        `[vsock] late_arrival: response for unknown request_id=${requestId}`,
+      );
+      return;
+    }
+    this.pending.delete(requestId);
+    if (pending.timer !== null) clearTimeout(pending.timer);
+    pending.resolve(frame);
+  }
+
+  private fail(err: Error): void {
+    if (this.fatal !== null) return;
+    this.fatal = err;
+    this.clearPartialFrameWatchdog();
+    for (const [, p] of this.pending) {
+      if (p.timer !== null) clearTimeout(p.timer);
+      p.reject(err);
+    }
+    this.pending.clear();
+    if (this.socket !== null) {
+      try {
+        this.socket.destroy();
+      } catch {}
+    }
+  }
+
+  /**
+   * Send a length-prefixed JSON request and await the matching reply.
+   * Multiple requests may be in flight; correlation is by `request_id`.
+   * Throws `SandboxToolTimeoutError` on deadline expiry.
+   */
+  private async sendFrame<T extends Record<string, unknown>>(
+    requestId: string,
+    frame: Record<string, unknown>,
+    deadlineMs: number,
+  ): Promise<T> {
+    if (this.fatal !== null) throw this.fatal;
+    if (this.socket === null) {
+      throw new SandboxNotAvailableError("vsock not open");
+    }
+    if (this.pending.has(requestId)) {
+      throw new SandboxError(
+        "SANDBOX_VSOCK_DUPLICATE_REQUEST",
+        `duplicate inflight request_id=${requestId}`,
+      );
+    }
+
+    const json = Buffer.from(JSON.stringify(frame), "utf-8");
+    if (json.length > this.opts.maxFrameBytes) {
+      throw new SandboxVsockFrameTooLargeError(
+        json.length,
+        this.opts.maxFrameBytes,
+        `outbound frame ${json.length} bytes exceeds local cap ${this.opts.maxFrameBytes}`,
+      );
+    }
+    const header = Buffer.alloc(4);
+    header.writeUInt32BE(json.length, 0);
+    // Concatenate header + payload into a SINGLE write call. Two
+    // separate `sock.write(...)`s interleave on the wire when multiple
+    // requests are in flight (Promise.all([send, send]) issues both
+    // headers before either payload), corrupting the framing.
+    const wireBytes = Buffer.concat([header, json]);
+
+    const responsePromise = new Promise<T>((resolve, reject) => {
+      const timer =
+        deadlineMs > 0
+          ? setTimeout(() => {
+              if (this.pending.delete(requestId)) {
+                reject(
+                  new SandboxToolTimeoutError(
+                    deadlineMs,
+                    `vsock request ${requestId} exceeded deadline ${deadlineMs}ms`,
+                  ),
+                );
+              }
+            }, deadlineMs)
+          : null;
+      this.pending.set(requestId, {
+        resolve: (f) => resolve(f as T),
+        reject,
+        timer,
+      });
+    });
+
+    const sock = this.socket;
+    await new Promise<void>((resolve, reject) => {
+      sock.write(wireBytes, (err) => {
+        if (err !== null && err !== undefined) {
+          reject(err);
+          return;
+        }
+        resolve();
+      });
+    });
+
+    return responsePromise;
+  }
+
+  /**
+   * Public surface for ToolDispatch (host -> guest) -> ToolResult (guest -> host).
+   * Maps a `ToolInvocation` onto the wire format and unpacks the reply
+   * into a `ToolExecution`. Used by `ChvSandbox.executeTool`.
+   */
+  async sendCommand(invocation: ToolInvocation): Promise<ToolExecution> {
+    return this.dispatchRequest(invocation);
+  }
+
+  /** Same as `sendCommand`, named to match the protocol's verb. */
+  async dispatchRequest(invocation: ToolInvocation): Promise<ToolExecution> {
+    const frame: Record<string, unknown> = {
+      type: "ToolDispatch",
+      command_id: invocation.command_id,
+      tool: invocation.tool,
+      params: invocation.params,
+      deadline_ms: invocation.deadline_ms,
+    };
+    const reply = await this.sendFrame<Record<string, unknown>>(
+      invocation.command_id,
+      frame,
+      invocation.deadline_ms,
+    );
+    if (reply.type !== "ToolResult") {
+      throw new SandboxError(
+        "SANDBOX_VSOCK_PROTOCOL_ERROR",
+        `expected ToolResult, got ${JSON.stringify(reply.type)}`,
+      );
+    }
+    const exit_code =
+      typeof reply.exit_code === "number" ? reply.exit_code : -1;
+    const stdout = typeof reply.stdout === "string" ? reply.stdout : "";
+    const stderr = typeof reply.stderr === "string" ? reply.stderr : "";
+    const evidence_hash =
+      typeof reply.evidence_hash === "string" ? reply.evidence_hash : undefined;
+    return { exit_code, stdout, stderr, evidence_hash };
+  }
+
+  /**
+   * Public surface for the integrity monitor's GuestQuery (host -> guest)
+   * -> GuestResponse (guest -> host) round trip. Returns the raw `result`
+   * payload from section 6.3.6.
+   */
+  async guestQuery(
+    kind: GuestQueryKind,
+    opts: { timeoutMs?: number; queryId?: string } = {},
+  ): Promise<GuestQueryResult> {
+    // Per section 6.3.5 timeout: 1s for OpenFdCount/MemUsage; 5s for ProcessList.
+    const defaultTimeout = kind === "ProcessList" ? 5_000 : 1_000;
+    const queryId = opts.queryId ?? randomUUID();
+    const frame: Record<string, unknown> = {
+      type: "GuestQuery",
+      query_id: queryId,
+      query_kind: kind,
+      ts: new Date().toISOString(),
+    };
+    const reply = await this.sendFrame<Record<string, unknown>>(
+      queryId,
+      frame,
+      opts.timeoutMs ?? defaultTimeout,
+    );
+    if (reply.type !== "GuestResponse") {
+      throw new SandboxError(
+        "SANDBOX_VSOCK_PROTOCOL_ERROR",
+        `expected GuestResponse, got ${JSON.stringify(reply.type)}`,
+      );
+    }
+    if (
+      reply.result === null ||
+      typeof reply.result !== "object" ||
+      Array.isArray(reply.result)
+    ) {
+      throw new SandboxError(
+        "SANDBOX_VSOCK_PROTOCOL_ERROR",
+        `GuestResponse missing result object`,
+      );
+    }
+    return reply.result as GuestQueryResult;
+  }
+
+  /** True once `open()` has succeeded and no fatal error has been latched. */
+  isOpen(): boolean {
+    return this.socket !== null && this.fatal === null;
+  }
+
+  /** Source port assigned by CHV during the CONNECT handshake. */
+  getSourcePort(): number | null {
+    return this.sourcePort;
+  }
+
+  async close(): Promise<void> {
+    if (this.socket === null) return;
+    const sock = this.socket;
+    this.socket = null;
+    // Reject any still-pending requests with a clear error.
+    if (this.fatal === null) {
+      this.fail(
+        new SandboxError("SANDBOX_VSOCK_CLOSED", "vsock closed by host"),
+      );
+    }
+    await new Promise<void>((resolve) => {
+      sock.end(() => resolve());
+      // end() may not fire 'finish' if the peer is already gone; cap
+      // ourselves at 250ms then destroy.
+      setTimeout(() => {
+        try {
+          sock.destroy();
+        } catch {}
+        resolve();
+      }, 250).unref();
+    });
+  }
+}

--- a/packages/sandbox/src/errors.ts
+++ b/packages/sandbox/src/errors.ts
@@ -1,0 +1,128 @@
+// Sandbox errors. Modelled after the protocol error codes in
+// docs/endpoint-agent-protocol-v1.md so callers (the endpoint dispatcher)
+// can map straight from `error.code` to a `CommandResult.error.code`.
+//
+// Honesty requirement: if a backend cannot run on the current host (e.g.
+// Cloud Hypervisor on Darwin), it MUST throw `SandboxNotAvailableError`
+// from `boot()` rather than pretending the VM came up.
+
+export class SandboxError extends Error {
+  /** Stable code consumable by the dispatcher and audit log. */
+  public readonly code: string;
+  public readonly cause?: unknown;
+
+  constructor(code: string, message: string, cause?: unknown) {
+    super(message);
+    this.name = "SandboxError";
+    this.code = code;
+    this.cause = cause;
+  }
+}
+
+/**
+ * Thrown when a backend's prerequisites cannot be met on the current host.
+ * The Linux/CHV backend throws this on Darwin; a future Linux runner
+ * environment is expected to satisfy the prereqs and avoid the throw.
+ */
+export class SandboxNotAvailableError extends SandboxError {
+  constructor(message: string, cause?: unknown) {
+    super("SANDBOX_NOT_AVAILABLE", message, cause);
+    this.name = "SandboxNotAvailableError";
+  }
+}
+
+/** Boot failed (kernel/rootfs/vsock setup, VMM did not come up). */
+export class SandboxBootError extends SandboxError {
+  constructor(message: string, cause?: unknown) {
+    super("SANDBOX_BOOT_FAILED", message, cause);
+    this.name = "SandboxBootError";
+  }
+}
+
+/**
+ * Tool execution exceeded the caller-supplied deadline. The dispatcher
+ * maps this to `lifecycle_state: "timed_out"` per protocol §6.
+ */
+export class SandboxToolTimeoutError extends SandboxError {
+  public readonly deadline_ms: number;
+  constructor(deadline_ms: number, message: string) {
+    super("SANDBOX_TOOL_TIMEOUT", message);
+    this.name = "SandboxToolTimeoutError";
+    this.deadline_ms = deadline_ms;
+  }
+}
+
+/** Tool ran but returned a non-zero exit code or guest-side runtime error. */
+export class SandboxToolError extends SandboxError {
+  public readonly exit_code: number;
+  constructor(exit_code: number, message: string) {
+    super("SANDBOX_TOOL_ERROR", message);
+    this.name = "SandboxToolError";
+    this.exit_code = exit_code;
+  }
+}
+
+/**
+ * Reset machinery itself failed (snapshot revert errored, vsock died, etc.).
+ * Distinct from `SANDBOX_RESET_DIVERGENCE` which is "reset ran but the
+ * 3-source verification disagreed" — see threat model §5.1.
+ */
+export class SandboxResetError extends SandboxError {
+  constructor(message: string, cause?: unknown) {
+    super("SANDBOX_RESET_FAILED", message, cause);
+    this.name = "SandboxResetError";
+  }
+}
+
+/**
+ * Reset ran but the 3-source post-reset verification (FS hash + open-fd +
+ * VMM API state) detected divergence. Per threat model §5.1 the integrity
+ * monitor halts and the agent enters degraded mode.
+ */
+export class SandboxResetDivergenceError extends SandboxError {
+  constructor(message: string, cause?: unknown) {
+    super("SANDBOX_RESET_DIVERGENCE", message, cause);
+    this.name = "SandboxResetDivergenceError";
+  }
+}
+
+/**
+ * Cloud Hypervisor's vsock-over-AF_UNIX bridge expects the host side to
+ * write `CONNECT <port>\n` and then read `OK <sourcePort>\n` (success) or
+ * any other line (failure). This error covers both:
+ *   - the socket connected but CHV refused the CONNECT (anything other
+ *     than `OK <port>\n`),
+ *   - the handshake reply was malformed or the peer hung up mid-handshake.
+ *
+ * Distinct from `SandboxNotAvailableError` (which means we couldn't even
+ * reach the AF_UNIX socket) — handshake errors imply CHV is up but the
+ * vsock port is unreachable / not listening / wrong protocol.
+ */
+export class SandboxVsockHandshakeError extends SandboxError {
+  constructor(message: string, cause?: unknown) {
+    super("SANDBOX_VSOCK_HANDSHAKE_FAILED", message, cause);
+    this.name = "SandboxVsockHandshakeError";
+  }
+}
+
+/**
+ * A length-prefixed vsock frame declared a payload larger than the
+ * configured cap (default 16 MiB). Per protocol §6 (`FRAME_TOO_LARGE`),
+ * we drop the frame and treat the connection as poisoned — the safe
+ * action is to close + reboot the sandbox rather than try to skip past
+ * `length` bytes from a possibly-malicious peer.
+ */
+export class SandboxVsockFrameTooLargeError extends SandboxError {
+  public readonly declared_length: number;
+  public readonly max_length: number;
+  constructor(declared_length: number, max_length: number, message?: string) {
+    super(
+      "SANDBOX_VSOCK_FRAME_TOO_LARGE",
+      message ??
+        `vsock frame declared length ${declared_length} bytes exceeds cap ${max_length}`,
+    );
+    this.name = "SandboxVsockFrameTooLargeError";
+    this.declared_length = declared_length;
+    this.max_length = max_length;
+  }
+}

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -1,0 +1,77 @@
+// @brainst0rm/sandbox — microVM sandbox abstraction for the Brainstorm
+// endpoint agent.
+//
+// Purpose:
+//   Phase 3 of the endpoint-dispatch plan (docs/endpoint-agent-plan.md §5)
+//   adds real sandbox isolation between the brainstorm-agent and the tools
+//   it executes. This package owns the cross-backend interface, plus the
+//   Linux/Cloud-Hypervisor backend (P3.1a). The macOS/VF backend (P3.1b)
+//   is a separate work package that targets the same interface.
+//
+//   The interface here is also the contract the production Go agent
+//   (crd4sdom, P3.3) must satisfy in Go.
+//
+// Honesty:
+//   This package was scaffolded on Darwin. The Cloud Hypervisor backend
+//   has NOT been booted in this checkout. Calling `boot()` on Darwin
+//   throws `SandboxNotAvailableError` cleanly so a future Linux runner
+//   gets the same code path with the env-detection flipping naturally.
+//   See `packages/sandbox/README.md` for the first-light checklist.
+
+export {
+  type Sandbox,
+  type SandboxBackend,
+  type SandboxState,
+  type ResetState,
+  type SandboxResetState,
+  type VerificationDetails,
+  type VmmApiState,
+  type ToolInvocation,
+  type ToolExecution,
+  makeVerificationDetails,
+} from "./sandbox.js";
+
+export {
+  SandboxError,
+  SandboxNotAvailableError,
+  SandboxBootError,
+  SandboxToolTimeoutError,
+  SandboxToolError,
+  SandboxResetError,
+  SandboxResetDivergenceError,
+  SandboxVsockHandshakeError,
+  SandboxVsockFrameTooLargeError,
+} from "./errors.js";
+
+export {
+  ChvSandbox,
+  type ChvSandboxDeps,
+  type VsockGuestQueryClient,
+} from "./chv/chv-sandbox.js";
+
+export {
+  ChRemote,
+  type ChRemoteOptions,
+  type ExecFileFn,
+  defaultExecFile,
+  normaliseVmmState,
+} from "./chv/chv-remote.js";
+
+export {
+  defaultHashFile,
+  type HashFileFn,
+  FS_HASH_NOT_CONFIGURED,
+} from "./chv/chv-overlay-hash.js";
+
+export {
+  type ChvSandboxConfig,
+  type KernelConfig,
+  type RootfsConfig,
+  type VsockConfig,
+  DEFAULT_KERNEL_CMDLINE,
+  DEFAULT_VSOCK_CID,
+  DEFAULT_CPUS,
+  DEFAULT_MEM_MIB,
+} from "./chv/chv-config.js";
+
+export { isChvSupportedHost, buildChvArgv } from "./chv/chv-process.js";

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -1,0 +1,164 @@
+// The abstract Sandbox interface.
+//
+// Consumers: the endpoint dispatcher in P3.3 (Go, owned by crd4sdom) plus
+// the TypeScript reference dispatcher (`@brainst0rm/endpoint-stub`, swap-in
+// path during P3.3 integration).
+//
+// Both backends — Cloud Hypervisor (Linux, P3.1a, this package) and
+// Apple Virtualization.framework (macOS, P3.1b, separate work) — must
+// satisfy this surface so the dispatcher can be backend-agnostic. The
+// production Go agent will mirror this interface in Go.
+//
+// Lifecycle (per docs/endpoint-agent-plan.md §5 and threat-model §4):
+//
+//   sandbox = createSandbox(...)
+//   await sandbox.boot()                       // VM up, vsock channel open
+//   for each dispatched command:
+//     result = await sandbox.executeTool({...})
+//     reset = await sandbox.reset()            // 3-source verified
+//     // emit `sandbox_reset_state: reset` in the CommandResult
+//   await sandbox.shutdown()
+//
+// Reset MUST run after every dispatch (D13: trigger=after-every-dispatch).
+// Reset MUST produce a `ResetState` matching the protocol's
+// `SandboxResetState` shape so it can be embedded verbatim in
+// CommandResult frames.
+
+import type {
+  SandboxResetState,
+  VerificationDetails,
+  VmmApiState,
+} from "@brainst0rm/relay";
+
+// Re-export the protocol types so consumers of this package don't need
+// a direct @brainst0rm/relay import just to type their result-handling.
+export type { SandboxResetState, VerificationDetails, VmmApiState };
+
+/** Local alias matching the relay name in plan/threat-model docs. */
+export type ResetState = SandboxResetState;
+
+/**
+ * What the dispatcher hands to `executeTool`. Mirrors
+ * `ToolExecutorContext` in `@brainst0rm/endpoint-stub` so the stub can be
+ * adapted to drive a Sandbox in P3.3 with no shape change.
+ */
+export interface ToolInvocation {
+  /** Stable id from the CommandEnvelope. Used for evidence-chain tagging. */
+  command_id: string;
+  /** Tool name as advertised by the image's tool registry (P3.4). */
+  tool: string;
+  /** Caller-validated tool params. The sandbox does NOT re-validate. */
+  params: Record<string, unknown>;
+  /**
+   * Hard deadline in milliseconds. Backends MUST kill the in-guest process
+   * if the deadline elapses and throw `SandboxToolTimeoutError`.
+   */
+  deadline_ms: number;
+}
+
+/**
+ * Successful tool execution. Mirrors `ToolExecutorResult` in endpoint-stub.
+ * Non-zero exit_code is allowed and is reported faithfully — it is the
+ * dispatcher's call whether to treat it as a `failed` CommandResult.
+ */
+export interface ToolExecution {
+  exit_code: number;
+  stdout: string;
+  stderr: string;
+  /**
+   * Optional per-execution evidence digest computed inside the guest
+   * (per plan §6 audit). Backends may omit; the dispatcher will fall
+   * back to a host-side hash of stdout||stderr.
+   */
+  evidence_hash?: string;
+}
+
+/**
+ * Backend-agnostic factory result. Each concrete backend (CHV, VF) exposes
+ * its own constructor — see `ChvSandbox` in `./chv/chv-sandbox`.
+ */
+export interface Sandbox {
+  /** A short label used in logs and audit ("chv", "vf", etc.). */
+  readonly backend: SandboxBackend;
+
+  /**
+   * Bring the VM up and open the vsock command channel.
+   * Throws `SandboxNotAvailableError` if backend prereqs are missing on
+   * this host (e.g. `cloud-hypervisor` binary on Darwin).
+   * Throws `SandboxBootError` if prereqs are present but boot fails.
+   * Idempotent: calling boot() on an already-booted sandbox is a no-op.
+   */
+  boot(): Promise<void>;
+
+  /**
+   * Execute a tool inside the booted sandbox.
+   * Throws `SandboxNotAvailableError` if the sandbox is not booted.
+   * Throws `SandboxToolTimeoutError` if `deadline_ms` elapses.
+   * Returns a non-zero exit_code without throwing — the dispatcher decides.
+   */
+  executeTool(invocation: ToolInvocation): Promise<ToolExecution>;
+
+  /**
+   * Reset state: snapshot revert (or cold boot fallback) + 3-source
+   * verification. Returns the `ResetState` to embed in the CommandResult.
+   * If verification diverges, throws `SandboxResetDivergenceError` (the
+   * dispatcher should mark the sandbox unhealthy and stop accepting
+   * dispatches until an operator reviews — per threat-model §5.1).
+   * If reset machinery itself errors, throws `SandboxResetError`.
+   */
+  reset(): Promise<ResetState>;
+
+  /**
+   * Stop the VM and release host resources. Idempotent. Safe to call from
+   * a SIGTERM handler. Implementations should NOT reset before shutdown —
+   * shutdown discards state by definition.
+   */
+  shutdown(): Promise<void>;
+
+  /**
+   * Cheap state probe. Used by HealthPong's `sandbox_state` field per
+   * protocol §10. "ready" = booted + last reset verified;
+   * "resetting" = a reset is currently in flight;
+   * "failed" = boot failed or last reset diverged.
+   */
+  state(): SandboxState;
+}
+
+export type SandboxBackend = "chv" | "vf" | "stub";
+
+export type SandboxState =
+  | "not_booted"
+  | "booting"
+  | "ready"
+  | "resetting"
+  | "failed";
+
+/**
+ * Helper to build the `VerificationDetails` shape used in `ResetState`.
+ * Default values produce a "passing" verification — concrete backends
+ * compute the real values from FS hashing, in-guest fd counting, and
+ * VMM API queries (per threat-model §5.1).
+ */
+export function makeVerificationDetails(input: {
+  fs_hash: string;
+  fs_hash_baseline: string;
+  open_fd_count: number;
+  open_fd_count_baseline: number;
+  vmm_api_state: VmmApiState;
+  expected_vmm_api_state: VmmApiState;
+}): VerificationDetails {
+  const fs_hash_match = input.fs_hash === input.fs_hash_baseline;
+  const fd_match = input.open_fd_count === input.open_fd_count_baseline;
+  const vmm_match = input.vmm_api_state === input.expected_vmm_api_state;
+  const all_match = fs_hash_match && fd_match && vmm_match;
+  return {
+    fs_hash: input.fs_hash,
+    fs_hash_baseline: input.fs_hash_baseline,
+    fs_hash_match,
+    open_fd_count: input.open_fd_count,
+    open_fd_count_baseline: input.open_fd_count_baseline,
+    vmm_api_state: input.vmm_api_state,
+    expected_vmm_api_state: input.expected_vmm_api_state,
+    divergence_action: all_match ? "none" : "halt",
+  };
+}

--- a/packages/sandbox/tsconfig.json
+++ b/packages/sandbox/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/sandbox/tsup.config.ts
+++ b/packages/sandbox/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: [
+    "src/index.ts",
+    "scripts/first-light.ts",
+    "scripts/snapshot-create.ts",
+  ],
+  format: ["esm"],
+  dts: { entry: "src/index.ts" },
+  clean: true,
+  sourcemap: true,
+});


### PR DESCRIPTION
**Stacked on #276** — base is `feat/endpoint-dispatch-phase-1`. Will retarget to `main` once #276 merges.

## Summary

Phase 3 of `docs/endpoint-agent-plan.md`: end-to-end microVM sandbox bringup, **validated against real Cloud Hypervisor on bare-metal x86_64 KVM** (Hetzner node-2, 95.217.108.251, Ubuntu 24.04, cloud-hypervisor v44.0.0).

**Strict-sense complete: 1008 cold boots, 8-parallel, full reset-cycle with §A6 substrate-lying defense empirically validated end-to-end.**

## Empirical results

### 1000-iter cold-boot latency (P-LAT)

| Stage | p50 | p90 | p95 | p99 | mean | min | max |
|---|---|---|---|---|---|---|---|
| boot | 586ms | 592 | 594 | **597** | 586.6 | 576 | 604 |
| roundtrip | 2ms | 2 | 2 | **2** | 1.6 | 1 | 2 |
| shutdown | 24ms | 30 | 31 | **36** | 23.5 | 14 | 46 |
| **total** | 611ms | 620 | 622 | **628** | 611.8 | 596 | 638 |

1000/1000 passed. **p99-p50 boot spread = 11ms**. Repeated independently for run-2: p99 boot drift = 2ms (noise). The distribution is real.

### Concurrent-8 stress (P-CONC)

8/8 instances PASS in 765ms wall-clock parallel. CIDs 3..10 allocated cleanly, no socket collisions.

### Reset-cycle (P3.2a + §A6 substrate-lying defense)

```
first reset:  divergence_action=none verification_passed=true
tamper:       appended sentinel to bsm-sandbox-rootfs.img
second reset: SandboxResetDivergenceError
              fs_match=false fd_match=true vmm_match=true (divergence_action=halt)
driver exit:  0
script exit:  0
```

Three sources, three independent signals. fs_hash dispositive on substrate tamper. The substrate-lying defense — the load-bearing claim of the threat-model §A6 design — empirically validated on real hardware.

### Cluster delta after 1008 cold boots + 8 parallel + reset-cycle

0 RAM leaks, 0 leftover CHV processes, 0 leftover sockets, 0 leftover overlays. Phase-cleanup + trap-on-EXIT + recursive staleness check.

## Eight first-light layers + four reset-cycle iterations fixed

**First-light** (run-1 through run-10, ~600ms boot established):
1. Spawn race — `vsock.open()` fired before CHV bound the socket
2. `/dev/vda1` vs `/dev/vda` — kernel cmdline assumed partition table
3. Missing `--initramfs` — Alpine virt kernel is modular
4. Missing `rootfstype=ext4` — Alpine init's busybox couldn't autodetect
5. `/dev/vsock` missing — vsock kernel modules weren't loaded
6. `select{}` deadlock-panic on PID 1 — Go's runtime detector kernel-panicked init
7. `/lib/modules` not in rootfs — image-builder didn't include `linux-virt`
8. Handshake boot race — CONNECT retry with 250ms backoff

**Reset-cycle** (run-3 through run-7, §A6 defense validated):
1. CHV state machine — `restore` requires shutdown+delete first (not bare restore)
2. Vsock invalidation across restore — re-handshake required between snapshotRevert and verifyPostReset
3. Empty fs_hash baseline — phantom separate overlay file produced SHA-256(""); now defaults to rootfs.path
4. Fd-count topology asymmetry — vsock-init's openFdCount filtered to non-socket fds

**Plus** validation-harness staleness gap (run-6 catch): pure existence-check on rootfs.img masked an old vsock-init binary running against fresh source. Could have masked both a fix AND a regression. Fixed with `image_artifacts_stale` mtime comparison.

## Three Codex review rounds

- Round 1 (pre-first-light): missing protocol §6 30s partial-frame timeout. BLOCKER, fixed.
- Round 2 (pre-empirical): wrong ch-remote verb (`snapshot` vs `restore` for revert), substrate-lying FS-hash bypass, host-safety regex injection. 3 BLOCKERs, all fixed.
- Round 3 (P1.5b/P3.2b drop): wrong `snapshot` argv (bare URL vs key=value), phantom overlayPath indirection, OpenFdCount baseline staleness from parallel VsockClient. 3 BLOCKERs, all fixed.

Three rounds × averaging 2-3 BLOCKERs each = ~7 catches that mock tests couldn't surface. Real-CHV-iteration was the dispositive validation channel for protocol-correctness.

## Packages

- **`packages/sandbox`** — abstract `Sandbox` interface + `ChvSandbox`. **51 tests.**
- **`packages/sandbox-vz`** — `VzSandbox` + Swift `bsm-vz-helper` binary. 3 tests + 10 Swift helper tests. Real VZ first-boot deferred per plan D24 (Apple Developer cert).
- **`packages/image-builder`** — 4-stage Dockerfile producing real bootable Alpine 3.20 rootfs + virt kernel + static x86_64 vsock-init Go binary as PID 1.
- **`packages/sandbox-redteam`** — `RedTeamRunner` + 8 attacker-class probes + 1000-iter latency battery + concurrent-N + JSON reporter + `bsm-redteam` CLI. **24 tests.**
- **`packages/endpoint-stub`** — pluggable executor + `ChvSandboxExecutor` bridge connecting Phase 1 ↔ Phase 3. **21 tests.**

## Test plan

- [x] All 5 packages build green
- [x] 235 unit tests passing — relay 131, endpoint-stub 21, sandbox 51, sandbox-vz 3, sandbox-redteam 24, plus 5 Swift helper unit tests
- [x] image-builder Docker run on Linux/x86_64 produced real bootable artifacts; staleness check forces rebuild when source changes
- [x] **First-light: ChvSandbox boot reached `state() === "ready"`; full echo dispatch round-trip succeeded (boot=600ms, exec=2ms)**
- [x] **1000-iter battery: 1000/1000 pass, p99=628ms total. Run twice with 2ms drift.**
- [x] **Concurrent-8 stress: 8/8 pass in 765ms wall-clock**
- [x] **§A6 substrate-lying defense empirically validated end-to-end** (run-7: clean reset passes, tampered reset throws SandboxResetDivergenceError)
- [x] Zero leaks (RAM, processes, sockets) across all runs
- [ ] macOS dev laptop: `bsm-vz-helper` boots a real Linux guest (gated on Apple Developer cert; deferred per plan D24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)