### PR TITLE
chore: post-v0.1.0 cleanup pass

### DIFF
--- a/packages/eval/src/__tests__/scorer.test.ts
+++ b/packages/eval/src/__tests__/scorer.test.ts
@@ -4,7 +4,10 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 // Scorer tests spawn tsc --noEmit which takes ~6s. Increase timeout for full-suite runs.
-vi.setConfig({ testTimeout: 15_000 });
+// Bumped 15s -> 30s per issue #278: GitHub Actions runners are ~2x slower than local
+// dev machines; the existing 15s ceiling intermittently times out on CI for the
+// "returns a perfect score" case which does real FS+score work.
+vi.setConfig({ testTimeout: 30_000 });
 import { scoreProbe, type ProbeOutput } from "../scorer.js";
 import type { Probe } from "../types.js";
 

--- a/packages/sandbox-redteam/src/probes/p-a4-resource-exhaust.ts
+++ b/packages/sandbox-redteam/src/probes/p-a4-resource-exhaust.ts
@@ -1,8 +1,22 @@
 // P-A4-resource-exhaust
-// Threat model class: A3 ("compromised tool") going for resource starvation.
-//                     We bin this as A4-class red-team because the failure
-//                     mode (host DoS via guest resource burn) is the same
-//                     space as a build-time-malicious image's behaviour.
+//
+// Tagging note (post-v0.1.0 honesty pass):
+//   This probe is filename-prefixed "A4" for continuity with the rest of the
+//   probe set, but its actual scope is sandbox-runtime resource enforcement,
+//   NOT threat-model class A4. Per docs/endpoint-agent-threat-model.md §3.1:
+//
+//     A4 = compromised IMAGE at BUILD-TIME (image-builder pipeline tamper);
+//          explicitly OUT OF MVP SCOPE. Defended via reproducible builds +
+//          signed images post-MVP.
+//     A5 = compromised host AGENT (code execution inside brainstorm-agent);
+//          also OUT OF MVP SCOPE.
+//
+//   What this probe actually exercises is closer to A3 (compromised tool
+//   inside the sandbox) hitting host-side resource ceilings — the failure
+//   mode under test is "does the sandbox's runtime cgroup-memory/pids limit
+//   contain the runaway", which is a sandbox-runtime concern rather than an
+//   attacker-class emulation. Re-tagging to a synthetic
+//   `"sandbox-runtime-limit"` class instead of falsely claiming A4 coverage.
 //
 // Mechanics: tool tries to allocate 100 GiB and/or fork-bomb. Real CHV
 // applies cgroup memory + pids limits. The probe passes iff the tool is
@@ -18,13 +32,14 @@ import type { Probe, ProbeOutcome } from "../types.js";
 
 export const pA4ResourceExhaust: Probe = {
   name: "P-A4-resource-exhaust",
-  attackerClass: "A4",
+  attackerClass: "sandbox-runtime-limit",
   expectation: "should-fail",
   validatedAgainst: "mock-only",
   description:
-    "Compromised tool allocates 100 GiB / fork-bombs. Sandbox cgroup limits " +
-    "MUST kill the runaway. Tool exit_code MUST be non-zero with an " +
-    "OOM/limit-style stderr signal.",
+    "Sandbox-runtime resource-limit probe (NOT threat-model A4 — see file " +
+    "header). Compromised tool allocates 100 GiB / fork-bombs. Sandbox " +
+    "cgroup limits MUST kill the runaway. Tool exit_code MUST be non-zero " +
+    "with an OOM/limit-style stderr signal.",
   async run(sandbox: Sandbox): Promise<ProbeOutcome> {
     const exec = await sandbox.executeTool({
       command_id: "redteam-A4-rss",

--- a/packages/sandbox-redteam/src/probes/p-a5-time-bomb.ts
+++ b/packages/sandbox-redteam/src/probes/p-a5-time-bomb.ts
@@ -1,9 +1,20 @@
 // P-A5-time-bomb
-// Threat model class: A5 (compromised host agent) — the surface a runaway
-//                     in-guest tool exercises in the host process is the
-//                     same as a buggy/malicious agent failing to enforce
-//                     deadline_ms. The defender posture (G2) is "hard
-//                     deadline kill". This probe asserts that posture.
+//
+// Tagging note (post-v0.1.0 honesty pass):
+//   This probe is filename-prefixed "A5" for continuity with the rest of the
+//   probe set, but its actual scope is sandbox-runtime deadline enforcement,
+//   NOT threat-model class A5. Per docs/endpoint-agent-threat-model.md §3.1:
+//
+//     A5 = compromised host AGENT (attacker has code execution inside the
+//          brainstorm-agent process). HIGH severity, OUT OF MVP SCOPE,
+//          defended post-MVP via hardware-rooted attestation.
+//
+//   What this probe actually exercises is the sandbox's `deadline_ms`
+//   enforcement path — the surface a runaway in-guest tool exercises is
+//   nominally an A3 ("compromised tool") concern, and the defender posture
+//   under test is the runtime-limit guarantee (G2 / hard-deadline kill),
+//   not an A5 host-agent compromise. Re-tagging to the synthetic
+//   `"sandbox-runtime-limit"` class instead of falsely claiming A5 coverage.
 //
 // Mechanics: the tool sleeps for longer than `deadline_ms`. The Sandbox
 // MUST throw `SandboxToolTimeoutError`. If the call returns a result, the
@@ -19,11 +30,12 @@ import type { Probe, ProbeOutcome } from "../types.js";
 
 export const pA5TimeBomb: Probe = {
   name: "P-A5-time-bomb",
-  attackerClass: "A5",
+  attackerClass: "sandbox-runtime-limit",
   expectation: "should-fail",
   validatedAgainst: "mock-only",
   description:
-    "Tool runs longer than deadline_ms. Sandbox MUST throw " +
+    "Sandbox-runtime deadline-enforcement probe (NOT threat-model A5 — see " +
+    "file header). Tool runs longer than deadline_ms. Sandbox MUST throw " +
     "SandboxToolTimeoutError, NOT return a delayed-but-successful result.",
   async run(sandbox: Sandbox): Promise<ProbeOutcome> {
     const deadlineMs = 50;

--- a/packages/sandbox-redteam/src/types.ts
+++ b/packages/sandbox-redteam/src/types.ts
@@ -31,7 +31,13 @@ export type AttackerClass =
   | "A8" // cross-endpoint replay
   | "A9" // cross-context replay
   | "A10" // replay after agent restart
-  | "LAT"; // synthetic class for latency-distribution probes
+  | "LAT" // synthetic class for latency-distribution probes
+  | "sandbox-runtime-limit"; // synthetic class — sandbox-runtime resource/deadline
+  // limits, NOT one of the formal A1..A10 attacker classes. Used by probes that
+  // exercise host-side enforcement (cgroup OOM kill, deadline_ms cancellation)
+  // rather than emulating an actual attacker. See p-a4-resource-exhaust.ts and
+  // p-a5-time-bomb.ts for the rationale (the names are kept for filename
+  // continuity but the tagging is honest about scope).
 
 export type ProbeExpectation = "should-pass" | "should-fail";
 

--- a/packages/sandbox-vz/helper/Sources/bsm-vz-helper/Preflight.swift
+++ b/packages/sandbox-vz/helper/Sources/bsm-vz-helper/Preflight.swift
@@ -20,8 +20,12 @@ import Virtualization
 enum Preflight {
     /// Build the preflight result and emit it as a single NDJSON line on
     /// stdout. Returns the exit code the caller should `exit(...)` with.
+    ///
+    /// The TS-side `PreflightResult` schema is frozen at protocol v1.0.0
+    /// (no `reason` field). Diagnostic text for `ok=false` cases is
+    /// written to stderr — operator-visible, but kept off the wire.
     static func run() -> Int32 {
-        let result = computeResult()
+        let (result, diagnostic) = computeResult()
         do {
             let line = try WireEncoding.line(result)
             FileHandle.standardOutput.write(Data(line.utf8))
@@ -33,12 +37,20 @@ enum Preflight {
             )
             return HelperExitCode.internalBug.rawValue
         }
+        if !result.ok, let diagnostic, !diagnostic.isEmpty {
+            FileHandle.standardError.write(
+                Data("preflight: \(diagnostic)\n".utf8)
+            )
+        }
         return result.ok
             ? HelperExitCode.ok.rawValue
             : HelperExitCode.preflightFail.rawValue
     }
 
-    static func computeResult() -> PreflightResult {
+    /// Compute the preflight verdict plus an optional human-readable
+    /// diagnostic. The diagnostic is NOT serialized on the wire — it is
+    /// only used by `run()` to emit stderr context on failure.
+    static func computeResult() -> (PreflightResult, String?) {
         let macVersion = currentMacOSVersion()
         let arch = currentArch()
         let entitled = entitlementPresent()
@@ -53,7 +65,7 @@ enum Preflight {
 
         let ok = archIsSupported && macOSIsSupported && entitled && frameworkAvailable
 
-        var reason: String? = nil
+        var diagnostic: String? = nil
         if !ok {
             var pieces: [String] = []
             if !macOSIsSupported {
@@ -68,17 +80,17 @@ enum Preflight {
             if !entitled {
                 pieces.append("missing com.apple.security.virtualization entitlement")
             }
-            reason = pieces.joined(separator: "; ")
+            diagnostic = pieces.joined(separator: "; ")
         }
 
-        return PreflightResult(
+        let result = PreflightResult(
             ok: ok,
             macos_version: macVersion.string,
             arch: arch,
             fast_snapshot_supported: fastSnapshot,
-            entitlement_present: entitled,
-            reason: reason
+            entitlement_present: entitled
         )
+        return (result, diagnostic)
     }
 
     // MARK: - Internals

--- a/packages/sandbox-vz/helper/Sources/bsm-vz-helper/Protocol.swift
+++ b/packages/sandbox-vz/helper/Sources/bsm-vz-helper/Protocol.swift
@@ -168,22 +168,24 @@ struct HelperErrorPayload: Encodable {
 
 // MARK: - Preflight
 
-/// Result of `bsm-vz-helper preflight` — exact shape from helper-protocol.ts:
+/// Result of `bsm-vz-helper preflight` — exact shape from helper-protocol.ts
+/// `PreflightResult`:
 ///   { ok: bool,
 ///     macos_version: "14.4.1",
 ///     arch: "arm64",
 ///     fast_snapshot_supported: bool,
 ///     entitlement_present: bool }
+///
+/// The TS schema (`packages/sandbox-vz/src/helper-protocol.ts`) is FROZEN at
+/// v1.0.0 of the endpoint-agent protocol. No extra fields permitted on the
+/// Swift side; adding fields belongs in v1.1.0. Diagnostic text on
+/// preflight failure is surfaced via stderr instead (see `Preflight.run`).
 struct PreflightResult: Encodable {
     let ok: Bool
     let macos_version: String
     let arch: String
     let fast_snapshot_supported: Bool
     let entitlement_present: Bool
-    /// Optional human-readable diagnostic. NOT part of the strict TS
-    /// shape, but TS will tolerate extra fields (JSON.parse doesn't
-    /// reject unknowns). Useful when ok=false to surface why.
-    let reason: String?
 }
 
 // MARK: - AnyCodable

--- a/packages/sandbox-vz/helper/Tests/bsm-vz-helperTests/NDJSONLoopTests.swift
+++ b/packages/sandbox-vz/helper/Tests/bsm-vz-helperTests/NDJSONLoopTests.swift
@@ -253,7 +253,7 @@ final class NDJSONLoopTests: XCTestCase {
 
 final class PreflightTests: XCTestCase {
     func testPreflightResultShape() {
-        let r = Preflight.computeResult()
+        let (r, _diagnostic) = Preflight.computeResult()
         // Shape required by helper-protocol.ts.
         XCTAssertFalse(r.macos_version.isEmpty)
         XCTAssertFalse(r.arch.isEmpty)
@@ -267,6 +267,25 @@ final class PreflightTests: XCTestCase {
         } else {
             XCTAssertFalse(r.fast_snapshot_supported)
         }
+    }
+
+    func testPreflightEncodingHasNoReasonField() throws {
+        // Protocol v1.0.0 freezes the wire schema. The Swift Encodable
+        // for PreflightResult MUST NOT emit a `reason` key — the TS side
+        // (helper-protocol.ts `PreflightResult`) doesn't model it and
+        // strict consumers would fail to parse.
+        let (r, _) = Preflight.computeResult()
+        let line = try WireEncoding.line(r)
+        let data = Data(line.dropLast().utf8)
+        let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertNotNil(obj)
+        XCTAssertNil(obj?["reason"], "PreflightResult must not emit a `reason` field — TS schema is frozen at v1.0.0")
+        // Spot-check the five fields the TS schema DOES expect.
+        XCTAssertNotNil(obj?["ok"])
+        XCTAssertNotNil(obj?["macos_version"])
+        XCTAssertNotNil(obj?["arch"])
+        XCTAssertNotNil(obj?["fast_snapshot_supported"])
+        XCTAssertNotNil(obj?["entitlement_present"])
     }
 }
 


### PR DESCRIPTION
## Summary

Three small unrelated post-merge fixes from v0.1.0 (commits a1693f5 + 31a0194). One PR, no functional change to the dispatch path.

## Fixes

### 1. `@brainst0rm/eval` scorer.test.ts: bump testTimeout 15s → 30s

- File: `packages/eval/src/__tests__/scorer.test.ts`
- The scorer test spawns `tsc --noEmit` and does real FS+score work; the existing 15s ceiling intermittently timed out on GitHub Actions runners (~2× slower than local dev). Bumped to 30s.
- Tracked in issue #278 with full diagnostic context. Both PR #276 and PR #277 hit this on merge despite neither touching `@brainst0rm/eval`.

### 2. sandbox-vz Swift helper: drop `reason` from `PreflightResult`

- Files: `packages/sandbox-vz/helper/Sources/bsm-vz-helper/{Protocol,Preflight}.swift`, `Tests/bsm-vz-helperTests/NDJSONLoopTests.swift`
- Codex round-3 review caught: Swift `PreflightResult` Codable struct emitted a `reason` key the TS-side `helper-protocol.ts` schema doesn't model. The TS schema is FROZEN at protocol v1.0.0; adding fields belongs in v1.1.0.
- Picked option (a): drop `reason` from Swift, route diagnostic text to stderr instead. `Preflight.computeResult()` now returns `(PreflightResult, String?)` where the `String?` is the stderr-only diagnostic.
- Added regression test `testPreflightEncodingHasNoReasonField` so the field can't sneak back undetected.

### 3. sandbox-redteam P-A4/P-A5 probes: honest `attackerClass` re-tag

- Files: `packages/sandbox-redteam/src/probes/p-a{4,5}-*.ts`, `src/types.ts`
- Codex round-1 review noted: `p-a4-resource-exhaust.ts` and `p-a5-time-bomb.ts` self-tag as A4/A5 but the threat-model (`docs/endpoint-agent-threat-model.md` §3.1) defines A4 = build-time image compromise and A5 = host-agent compromise — both **explicitly out of MVP scope**.
- The probes actually exercise sandbox-runtime resource ceilings (cgroup-mem) and deadline enforcement (deadline_ms cancellation) — closer to A3 with host-side limit cross-check.
- Added a synthetic `"sandbox-runtime-limit"` member to the `AttackerClass` union and re-tagged both probes. Filenames kept for continuity; clear rationale in each probe's header so the next reader doesn't repeat the conflation.

## Test plan

- [x] `cd packages/eval && npx vitest run` — 41/41 pass
- [x] `cd packages/sandbox-vz/helper && swift build -c release` — clean
- [x] `cd packages/sandbox-vz/helper && swift test` — 11/11 pass (incl. new regression guard)
- [x] `cd packages/sandbox-redteam && npx vitest run` — 24/24 pass
- [x] `cd packages/sandbox-redteam && npx tsc --noEmit` — clean

## Refs

- Issue #278 (timeout context, will be commented with this PR's commit hash on merge)
- Codex round-1 + round-3 reviews of v0.1.0 (P-A4/A5 tagging; Preflight `reason` drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)