### PR TITLE
feat(relay): single-host deploy package — AWS-validated

### DIFF
--- a/packages/eval/src/__tests__/scorer.test.ts
+++ b/packages/eval/src/__tests__/scorer.test.ts
@@ -4,7 +4,10 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 // Scorer tests spawn tsc --noEmit which takes ~6s. Increase timeout for full-suite runs.
-vi.setConfig({ testTimeout: 15_000 });
+// Bumped 15s -> 30s per issue #278: GitHub Actions runners are ~2x slower than local
+// dev machines; the existing 15s ceiling intermittently times out on CI for the
+// "returns a perfect score" case which does real FS+score work.
+vi.setConfig({ testTimeout: 30_000 });
 import { scoreProbe, type ProbeOutput } from "../scorer.js";
 import type { Probe } from "../types.js";
 

--- a/packages/relay/deploy/Caddyfile.template
+++ b/packages/relay/deploy/Caddyfile.template
@@ -1,0 +1,35 @@
+# Brainstorm relay — Caddy TLS termination
+# Templated by bootstrap.sh: @@RELAY_HOSTNAME@@, @@WS_PORT@@, @@HTTP_PORT@@.
+#
+# Caddy auto-acquires Let's Encrypt certs for the hostname; if running
+# behind a load balancer that already terminates TLS, set SKIP_CADDY=1
+# in the bootstrap and route traffic directly to 8443/8444 with your
+# own TLS layer.
+
+@@RELAY_HOSTNAME@@ {
+    # WebSocket endpoints (operator + endpoint connect)
+    handle_path /v1/operator {
+        reverse_proxy 127.0.0.1:@@WS_PORT@@
+    }
+    handle_path /v1/endpoint/connect {
+        reverse_proxy 127.0.0.1:@@WS_PORT@@
+    }
+
+    # HTTP enrollment endpoints
+    handle /v1/endpoint/enroll {
+        reverse_proxy 127.0.0.1:@@HTTP_PORT@@
+    }
+    handle /v1/admin/endpoint/* {
+        reverse_proxy 127.0.0.1:@@HTTP_PORT@@
+    }
+
+    # Default: 404 on anything not whitelisted above
+    handle {
+        respond "Not Found" 404
+    }
+
+    log {
+        output file /var/log/caddy/brainstorm-relay.log
+        format json
+    }
+}

--- a/packages/relay/deploy/README.md
+++ b/packages/relay/deploy/README.md
@@ -1,0 +1,59 @@
+# Brainstorm relay deployment
+
+Single-host deployment of `@brainst0rm/relay` with TLS termination via Caddy + systemd lifecycle. Targets Ubuntu 22.04+ / Debian 12+ on x86_64.
+
+## What this deploys
+
+- Relay binary (Node 22) running as hardened systemd service under a dedicated `brainstorm-relay` user
+- Caddy as TLS-terminating reverse proxy on `:443`, auto-issuing Let's Encrypt certs
+- Generated tenant signing keypair (Ed25519) + admin token + operator HMAC key, in `/etc/brainstorm-relay/env` (mode 640)
+- Persistent state at `/var/lib/brainstorm-relay/`
+
+## What this doesn't deploy
+
+- An endpoint with a real CHV-backed executor — endpoints connect FROM other hosts
+- Cloud Hypervisor itself — relay host doesn't need it
+- Multi-tenant operator keys beyond the single bootstrapped tenant
+
+## Quick start
+
+```bash
+git clone https://github.com/justinjilg/brainstorm.git
+cd brainstorm
+sudo RELAY_HOSTNAME=relay.example.com bash packages/relay/deploy/bootstrap.sh
+```
+
+The bootstrap installs Node + Caddy, builds the relay, generates secrets, installs systemd unit + Caddyfile, starts the service, and prints the operator-side connection bundle.
+
+## Verification
+
+```bash
+systemctl status brainstorm-relay
+curl -fsS https://relay.example.com/v1/admin/endpoint/enroll \
+  -X POST -H "Authorization: Bearer <admin-token>" \
+  -H "Content-Type: application/json" \
+  -d '{"tenant_id":"tenant-local"}'
+# → { "bootstrap_token": "...", "endpoint_id": "..." }
+```
+
+## Files
+
+| Path                 | Purpose                                           |
+| -------------------- | ------------------------------------------------- |
+| `bootstrap.sh`       | Idempotent installer; safe to re-run for upgrades |
+| `relay.service`      | Hardened systemd unit                             |
+| `Caddyfile.template` | Caddy config with `@@`-placeholder substitution   |
+
+## Tear-down
+
+```bash
+systemctl stop brainstorm-relay
+systemctl disable brainstorm-relay
+rm -f /etc/systemd/system/brainstorm-relay.service
+rm -rf /etc/brainstorm-relay /var/lib/brainstorm-relay /var/log/brainstorm-relay /opt/brainstorm-relay
+userdel brainstorm-relay
+```
+
+## Validation
+
+Validated end-to-end on throwaway AWS Ubuntu 24.04 instance: install → service running → enrollment endpoint returning `bootstrap_token` over public TLS → tear-down clean.

--- a/packages/relay/deploy/bootstrap.sh
+++ b/packages/relay/deploy/bootstrap.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Brainstorm relay bootstrap installer.
+#
+# Targets: Ubuntu 22.04+, Debian 12+, x86_64.
+#
+# What this does:
+#   1. Installs Node.js 22+ (NodeSource), build essentials, Caddy
+#   2. Creates `brainstorm-relay` system user with restricted home
+#   3. Clones brainstorm repo, builds @brainst0rm/relay
+#   4. Generates Ed25519 tenant signing keypair + admin token + operator HMAC key
+#      (UNLESS pre-existing /etc/brainstorm-relay/env is present)
+#   5. Installs systemd unit + Caddyfile (TLS via Let's Encrypt)
+#   6. Starts brainstorm-relay.service
+#   7. Prints the operator-side connection bundle (relay URL, admin token,
+#      tenant pubkey, operator HMAC key) for paste into operator config
+#
+# What this does NOT do:
+#   - Open firewall ports (caller must allow 80/443 inbound)
+#   - Configure DNS (caller must point relay.<domain> at the host first)
+#   - Install Cloud Hypervisor (the relay doesn't need it; only endpoints do)
+#
+# Usage:
+#   curl -fsSL <repo-url>/packages/relay/deploy/bootstrap.sh | sudo bash
+#   OR (from a clone):
+#   sudo bash packages/relay/deploy/bootstrap.sh
+#
+# Required env (or interactive prompts):
+#   RELAY_HOSTNAME — public DNS name (e.g. relay.example.com); needed for Caddy TLS
+#
+# Optional env (all default-sensible):
+#   BRAINSTORM_REPO_URL  — default https://github.com/justinjilg/brainstorm.git
+#   BRAINSTORM_REPO_REF  — default main
+#   RELAY_BIND_PORT_WS   — default 8443
+#   RELAY_BIND_PORT_HTTP — default 8444
+#   SKIP_CADDY=1         — if you have your own TLS termination layer
+
+set -euo pipefail
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "ERROR: bootstrap must run as root (sudo)"
+  exit 2
+fi
+
+if [[ -z "${RELAY_HOSTNAME:-}" ]]; then
+  echo "ERROR: RELAY_HOSTNAME is required (e.g. relay.example.com)"
+  echo "       set it in env or via prompt when invoking bootstrap.sh"
+  exit 3
+fi
+
+REPO_URL="${BRAINSTORM_REPO_URL:-https://github.com/justinjilg/brainstorm.git}"
+REPO_REF="${BRAINSTORM_REPO_REF:-main}"
+WS_PORT="${RELAY_BIND_PORT_WS:-8443}"
+HTTP_PORT="${RELAY_BIND_PORT_HTTP:-8444}"
+
+INSTALL_DIR=/opt/brainstorm-relay
+ETC_DIR=/etc/brainstorm-relay
+DATA_DIR=/var/lib/brainstorm-relay
+LOG_DIR=/var/log/brainstorm-relay
+SVC_USER=brainstorm-relay
+SVC_GROUP=brainstorm-relay
+
+step() { echo; echo "== $* =="; }
+
+step "1. Installing system packages"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -qq -y curl ca-certificates gnupg git build-essential jq
+
+# Node.js 22.x via NodeSource
+if ! command -v node >/dev/null 2>&1 || \
+   [[ "$(node -v 2>/dev/null | sed 's/v//' | cut -d. -f1)" -lt 22 ]]; then
+  curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+  apt-get install -qq -y nodejs
+fi
+echo "  node: $(node -v)"
+echo "  npm:  $(npm -v)"
+
+# Caddy (only if not skipped)
+if [[ "${SKIP_CADDY:-0}" != "1" ]]; then
+  if ! command -v caddy >/dev/null 2>&1; then
+    apt-get install -qq -y debian-keyring debian-archive-keyring apt-transport-https
+    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \
+      | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \
+      | tee /etc/apt/sources.list.d/caddy-stable.list
+    apt-get update -qq
+    apt-get install -qq -y caddy
+  fi
+  echo "  caddy: $(caddy version | head -1)"
+fi
+
+step "2. Creating service user + directories"
+if ! id "$SVC_USER" >/dev/null 2>&1; then
+  useradd --system --create-home --home-dir "$INSTALL_DIR" \
+          --shell /usr/sbin/nologin --user-group "$SVC_USER"
+fi
+mkdir -p "$ETC_DIR" "$DATA_DIR" "$LOG_DIR"
+chown "$SVC_USER:$SVC_GROUP" "$DATA_DIR" "$LOG_DIR"
+chmod 700 "$ETC_DIR"
+
+step "3. Cloning + building brainstorm relay"
+if [[ ! -d "$INSTALL_DIR/.git" ]]; then
+  rm -rf "$INSTALL_DIR"
+  git clone --depth=1 --branch="$REPO_REF" "$REPO_URL" "$INSTALL_DIR"
+else
+  git -C "$INSTALL_DIR" fetch --depth=1 origin "$REPO_REF"
+  git -C "$INSTALL_DIR" checkout "$REPO_REF"
+  git -C "$INSTALL_DIR" reset --hard "origin/$REPO_REF"
+fi
+cd "$INSTALL_DIR"
+npm install --no-audit --no-fund
+npx turbo run build --filter='@brainst0rm/relay'
+chown -R "$SVC_USER:$SVC_GROUP" "$INSTALL_DIR"
+
+step "4. Provisioning secrets"
+ENV_FILE="$ETC_DIR/env"
+if [[ -f "$ENV_FILE" ]]; then
+  echo "  $ENV_FILE already present — reusing existing secrets"
+else
+  ADMIN_TOKEN=$(openssl rand -hex 32)
+  TENANT_KEY_HEX=$(openssl rand -hex 32)
+  OPERATOR_HMAC_KEY_HEX=$(openssl rand -hex 32)
+
+  cat > "$ENV_FILE" <<EOF
+# Brainstorm relay environment
+# Provisioned by bootstrap.sh on $(date -u +%Y-%m-%dT%H:%M:%SZ)
+BRAINSTORM_RELAY_HOST=127.0.0.1
+BRAINSTORM_RELAY_PORT_WS=$WS_PORT
+BRAINSTORM_RELAY_PORT_HTTP=$HTTP_PORT
+BRAINSTORM_RELAY_DATA_DIR=$DATA_DIR
+BRAINSTORM_RELAY_ADMIN_TOKEN=$ADMIN_TOKEN
+BRAINSTORM_RELAY_TENANT_KEY_HEX=$TENANT_KEY_HEX
+BRAINSTORM_RELAY_OPERATOR_HMAC_KEY_HEX=$OPERATOR_HMAC_KEY_HEX
+BRAINSTORM_RELAY_OPERATOR_ID=operator@local
+BRAINSTORM_RELAY_TENANT_ID=tenant-local
+EOF
+  chown root:"$SVC_GROUP" "$ENV_FILE"
+  chmod 640 "$ENV_FILE"
+  echo "  $ENV_FILE generated (mode 640)"
+fi
+
+step "5. Installing systemd unit"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+install -m 644 "$SCRIPT_DIR/relay.service" /etc/systemd/system/brainstorm-relay.service
+systemctl daemon-reload
+
+step "6. Installing Caddy config"
+if [[ "${SKIP_CADDY:-0}" != "1" ]]; then
+  CADDY_CFG=/etc/caddy/Caddyfile
+  install -m 644 "$SCRIPT_DIR/Caddyfile.template" "$CADDY_CFG.brainstorm-tmpl"
+  sed -e "s|@@RELAY_HOSTNAME@@|$RELAY_HOSTNAME|g" \
+      -e "s|@@WS_PORT@@|$WS_PORT|g" \
+      -e "s|@@HTTP_PORT@@|$HTTP_PORT|g" \
+      "$CADDY_CFG.brainstorm-tmpl" > "$CADDY_CFG"
+  systemctl reload caddy || systemctl restart caddy
+  echo "  caddy reloaded with TLS for $RELAY_HOSTNAME"
+fi
+
+step "7. Starting brainstorm-relay.service"
+systemctl enable brainstorm-relay.service
+systemctl restart brainstorm-relay.service
+sleep 2
+systemctl --no-pager status brainstorm-relay.service | head -12
+
+step "8. Connection bundle (paste into operator config)"
+TENANT_PUBKEY_HEX=$(grep BRAINSTORM_RELAY_TENANT_KEY_HEX "$ENV_FILE" | cut -d= -f2 \
+                   | xargs -I{} node -e "
+const ed = require('$INSTALL_DIR/node_modules/@noble/ed25519');
+ed.getPublicKeyAsync(Buffer.from('{}', 'hex')).then(p =>
+  console.log(Buffer.from(p).toString('hex')));")
+
+cat <<EOF
+
+# === Brainstorm relay connection bundle ===
+# Hostname:           $RELAY_HOSTNAME
+# WS endpoint:        wss://$RELAY_HOSTNAME/v1/operator
+# HTTP endpoint:      https://$RELAY_HOSTNAME/v1/admin/endpoint/enroll
+# Admin token:        $(grep BRAINSTORM_RELAY_ADMIN_TOKEN "$ENV_FILE" | cut -d= -f2)
+# Tenant pubkey hex:  $TENANT_PUBKEY_HEX
+# Operator HMAC key:  $(grep BRAINSTORM_RELAY_OPERATOR_HMAC_KEY_HEX "$ENV_FILE" | cut -d= -f2)
+# Operator id:        operator@local
+# Tenant id:          tenant-local
+#
+# Save these values to your operator-side vault. To rotate, edit
+# $ENV_FILE and 'systemctl restart brainstorm-relay'.
+# ===========================================
+EOF

--- a/packages/relay/deploy/relay.service
+++ b/packages/relay/deploy/relay.service
@@ -1,0 +1,38 @@
+[Unit]
+Description=Brainstorm endpoint-dispatch relay
+Documentation=https://github.com/justinjilg/brainstorm/tree/main/packages/relay
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=brainstorm-relay
+Group=brainstorm-relay
+WorkingDirectory=/opt/brainstorm-relay/packages/relay
+EnvironmentFile=/etc/brainstorm-relay/env
+ExecStart=/usr/bin/node /opt/brainstorm-relay/packages/relay/dist/bin.js
+Restart=on-failure
+RestartSec=5s
+LimitNOFILE=65536
+
+# Hardening
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=yes
+ReadWritePaths=/var/lib/brainstorm-relay /var/log/brainstorm-relay
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=yes
+LockPersonality=yes
+RestrictRealtime=yes
+SystemCallArchitectures=native
+
+# Logging
+StandardOutput=append:/var/log/brainstorm-relay/relay.log
+StandardError=append:/var/log/brainstorm-relay/relay.err
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/sandbox-redteam/src/probes/p-a4-resource-exhaust.ts
+++ b/packages/sandbox-redteam/src/probes/p-a4-resource-exhaust.ts
@@ -1,8 +1,22 @@
 // P-A4-resource-exhaust
-// Threat model class: A3 ("compromised tool") going for resource starvation.
-//                     We bin this as A4-class red-team because the failure
-//                     mode (host DoS via guest resource burn) is the same
-//                     space as a build-time-malicious image's behaviour.
+//
+// Tagging note (post-v0.1.0 honesty pass):
+//   This probe is filename-prefixed "A4" for continuity with the rest of the
+//   probe set, but its actual scope is sandbox-runtime resource enforcement,
+//   NOT threat-model class A4. Per docs/endpoint-agent-threat-model.md §3.1:
+//
+//     A4 = compromised IMAGE at BUILD-TIME (image-builder pipeline tamper);
+//          explicitly OUT OF MVP SCOPE. Defended via reproducible builds +
+//          signed images post-MVP.
+//     A5 = compromised host AGENT (code execution inside brainstorm-agent);
+//          also OUT OF MVP SCOPE.
+//
+//   What this probe actually exercises is closer to A3 (compromised tool
+//   inside the sandbox) hitting host-side resource ceilings — the failure
+//   mode under test is "does the sandbox's runtime cgroup-memory/pids limit
+//   contain the runaway", which is a sandbox-runtime concern rather than an
+//   attacker-class emulation. Re-tagging to a synthetic
+//   `"sandbox-runtime-limit"` class instead of falsely claiming A4 coverage.
 //
 // Mechanics: tool tries to allocate 100 GiB and/or fork-bomb. Real CHV
 // applies cgroup memory + pids limits. The probe passes iff the tool is
@@ -18,13 +32,14 @@ import type { Probe, ProbeOutcome } from "../types.js";
 
 export const pA4ResourceExhaust: Probe = {
   name: "P-A4-resource-exhaust",
-  attackerClass: "A4",
+  attackerClass: "sandbox-runtime-limit",
   expectation: "should-fail",
   validatedAgainst: "mock-only",
   description:
-    "Compromised tool allocates 100 GiB / fork-bombs. Sandbox cgroup limits " +
-    "MUST kill the runaway. Tool exit_code MUST be non-zero with an " +
-    "OOM/limit-style stderr signal.",
+    "Sandbox-runtime resource-limit probe (NOT threat-model A4 — see file " +
+    "header). Compromised tool allocates 100 GiB / fork-bombs. Sandbox " +
+    "cgroup limits MUST kill the runaway. Tool exit_code MUST be non-zero " +
+    "with an OOM/limit-style stderr signal.",
   async run(sandbox: Sandbox): Promise<ProbeOutcome> {
     const exec = await sandbox.executeTool({
       command_id: "redteam-A4-rss",

--- a/packages/sandbox-redteam/src/probes/p-a5-time-bomb.ts
+++ b/packages/sandbox-redteam/src/probes/p-a5-time-bomb.ts
@@ -1,9 +1,20 @@
 // P-A5-time-bomb
-// Threat model class: A5 (compromised host agent) — the surface a runaway
-//                     in-guest tool exercises in the host process is the
-//                     same as a buggy/malicious agent failing to enforce
-//                     deadline_ms. The defender posture (G2) is "hard
-//                     deadline kill". This probe asserts that posture.
+//
+// Tagging note (post-v0.1.0 honesty pass):
+//   This probe is filename-prefixed "A5" for continuity with the rest of the
+//   probe set, but its actual scope is sandbox-runtime deadline enforcement,
+//   NOT threat-model class A5. Per docs/endpoint-agent-threat-model.md §3.1:
+//
+//     A5 = compromised host AGENT (attacker has code execution inside the
+//          brainstorm-agent process). HIGH severity, OUT OF MVP SCOPE,
+//          defended post-MVP via hardware-rooted attestation.
+//
+//   What this probe actually exercises is the sandbox's `deadline_ms`
+//   enforcement path — the surface a runaway in-guest tool exercises is
+//   nominally an A3 ("compromised tool") concern, and the defender posture
+//   under test is the runtime-limit guarantee (G2 / hard-deadline kill),
+//   not an A5 host-agent compromise. Re-tagging to the synthetic
+//   `"sandbox-runtime-limit"` class instead of falsely claiming A5 coverage.
 //
 // Mechanics: the tool sleeps for longer than `deadline_ms`. The Sandbox
 // MUST throw `SandboxToolTimeoutError`. If the call returns a result, the
@@ -19,11 +30,12 @@ import type { Probe, ProbeOutcome } from "../types.js";
 
 export const pA5TimeBomb: Probe = {
   name: "P-A5-time-bomb",
-  attackerClass: "A5",
+  attackerClass: "sandbox-runtime-limit",
   expectation: "should-fail",
   validatedAgainst: "mock-only",
   description:
-    "Tool runs longer than deadline_ms. Sandbox MUST throw " +
+    "Sandbox-runtime deadline-enforcement probe (NOT threat-model A5 — see " +
+    "file header). Tool runs longer than deadline_ms. Sandbox MUST throw " +
     "SandboxToolTimeoutError, NOT return a delayed-but-successful result.",
   async run(sandbox: Sandbox): Promise<ProbeOutcome> {
     const deadlineMs = 50;

--- a/packages/sandbox-redteam/src/types.ts
+++ b/packages/sandbox-redteam/src/types.ts
@@ -31,7 +31,13 @@ export type AttackerClass =
   | "A8" // cross-endpoint replay
   | "A9" // cross-context replay
   | "A10" // replay after agent restart
-  | "LAT"; // synthetic class for latency-distribution probes
+  | "LAT" // synthetic class for latency-distribution probes
+  | "sandbox-runtime-limit"; // synthetic class — sandbox-runtime resource/deadline
+  // limits, NOT one of the formal A1..A10 attacker classes. Used by probes that
+  // exercise host-side enforcement (cgroup OOM kill, deadline_ms cancellation)
+  // rather than emulating an actual attacker. See p-a4-resource-exhaust.ts and
+  // p-a5-time-bomb.ts for the rationale (the names are kept for filename
+  // continuity but the tagging is honest about scope).
 
 export type ProbeExpectation = "should-pass" | "should-fail";
 

--- a/packages/sandbox-vz/helper/Sources/bsm-vz-helper/Preflight.swift
+++ b/packages/sandbox-vz/helper/Sources/bsm-vz-helper/Preflight.swift
@@ -20,8 +20,12 @@ import Virtualization
 enum Preflight {
     /// Build the preflight result and emit it as a single NDJSON line on
     /// stdout. Returns the exit code the caller should `exit(...)` with.
+    ///
+    /// The TS-side `PreflightResult` schema is frozen at protocol v1.0.0
+    /// (no `reason` field). Diagnostic text for `ok=false` cases is
+    /// written to stderr — operator-visible, but kept off the wire.
     static func run() -> Int32 {
-        let result = computeResult()
+        let (result, diagnostic) = computeResult()
         do {
             let line = try WireEncoding.line(result)
             FileHandle.standardOutput.write(Data(line.utf8))
@@ -33,12 +37,20 @@ enum Preflight {
             )
             return HelperExitCode.internalBug.rawValue
         }
+        if !result.ok, let diagnostic, !diagnostic.isEmpty {
+            FileHandle.standardError.write(
+                Data("preflight: \(diagnostic)\n".utf8)
+            )
+        }
         return result.ok
             ? HelperExitCode.ok.rawValue
             : HelperExitCode.preflightFail.rawValue
     }
 
-    static func computeResult() -> PreflightResult {
+    /// Compute the preflight verdict plus an optional human-readable
+    /// diagnostic. The diagnostic is NOT serialized on the wire — it is
+    /// only used by `run()` to emit stderr context on failure.
+    static func computeResult() -> (PreflightResult, String?) {
         let macVersion = currentMacOSVersion()
         let arch = currentArch()
         let entitled = entitlementPresent()
@@ -53,7 +65,7 @@ enum Preflight {
 
         let ok = archIsSupported && macOSIsSupported && entitled && frameworkAvailable
 
-        var reason: String? = nil
+        var diagnostic: String? = nil
         if !ok {
             var pieces: [String] = []
             if !macOSIsSupported {
@@ -68,17 +80,17 @@ enum Preflight {
             if !entitled {
                 pieces.append("missing com.apple.security.virtualization entitlement")
             }
-            reason = pieces.joined(separator: "; ")
+            diagnostic = pieces.joined(separator: "; ")
         }
 
-        return PreflightResult(
+        let result = PreflightResult(
             ok: ok,
             macos_version: macVersion.string,
             arch: arch,
             fast_snapshot_supported: fastSnapshot,
-            entitlement_present: entitled,
-            reason: reason
+            entitlement_present: entitled
         )
+        return (result, diagnostic)
     }
 
     // MARK: - Internals

--- a/packages/sandbox-vz/helper/Sources/bsm-vz-helper/Protocol.swift
+++ b/packages/sandbox-vz/helper/Sources/bsm-vz-helper/Protocol.swift
@@ -168,22 +168,24 @@ struct HelperErrorPayload: Encodable {
 
 // MARK: - Preflight
 
-/// Result of `bsm-vz-helper preflight` — exact shape from helper-protocol.ts:
+/// Result of `bsm-vz-helper preflight` — exact shape from helper-protocol.ts
+/// `PreflightResult`:
 ///   { ok: bool,
 ///     macos_version: "14.4.1",
 ///     arch: "arm64",
 ///     fast_snapshot_supported: bool,
 ///     entitlement_present: bool }
+///
+/// The TS schema (`packages/sandbox-vz/src/helper-protocol.ts`) is FROZEN at
+/// v1.0.0 of the endpoint-agent protocol. No extra fields permitted on the
+/// Swift side; adding fields belongs in v1.1.0. Diagnostic text on
+/// preflight failure is surfaced via stderr instead (see `Preflight.run`).
 struct PreflightResult: Encodable {
     let ok: Bool
     let macos_version: String
     let arch: String
     let fast_snapshot_supported: Bool
     let entitlement_present: Bool
-    /// Optional human-readable diagnostic. NOT part of the strict TS
-    /// shape, but TS will tolerate extra fields (JSON.parse doesn't
-    /// reject unknowns). Useful when ok=false to surface why.
-    let reason: String?
 }
 
 // MARK: - AnyCodable

--- a/packages/sandbox-vz/helper/Tests/bsm-vz-helperTests/NDJSONLoopTests.swift
+++ b/packages/sandbox-vz/helper/Tests/bsm-vz-helperTests/NDJSONLoopTests.swift
@@ -253,7 +253,7 @@ final class NDJSONLoopTests: XCTestCase {
 
 final class PreflightTests: XCTestCase {
     func testPreflightResultShape() {
-        let r = Preflight.computeResult()
+        let (r, _diagnostic) = Preflight.computeResult()
         // Shape required by helper-protocol.ts.
         XCTAssertFalse(r.macos_version.isEmpty)
         XCTAssertFalse(r.arch.isEmpty)
@@ -267,6 +267,25 @@ final class PreflightTests: XCTestCase {
         } else {
             XCTAssertFalse(r.fast_snapshot_supported)
         }
+    }
+
+    func testPreflightEncodingHasNoReasonField() throws {
+        // Protocol v1.0.0 freezes the wire schema. The Swift Encodable
+        // for PreflightResult MUST NOT emit a `reason` key — the TS side
+        // (helper-protocol.ts `PreflightResult`) doesn't model it and
+        // strict consumers would fail to parse.
+        let (r, _) = Preflight.computeResult()
+        let line = try WireEncoding.line(r)
+        let data = Data(line.dropLast().utf8)
+        let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertNotNil(obj)
+        XCTAssertNil(obj?["reason"], "PreflightResult must not emit a `reason` field — TS schema is frozen at v1.0.0")
+        // Spot-check the five fields the TS schema DOES expect.
+        XCTAssertNotNil(obj?["ok"])
+        XCTAssertNotNil(obj?["macos_version"])
+        XCTAssertNotNil(obj?["arch"])
+        XCTAssertNotNil(obj?["fast_snapshot_supported"])
+        XCTAssertNotNil(obj?["entitlement_present"])
     }
 }
 


### PR DESCRIPTION
## Summary

Operationalization scaffolding for `@brainst0rm/relay` v0.1.0. Single-host deploy with TLS via Caddy + systemd lifecycle. Targets Ubuntu 22.04+ / Debian 12+ on x86_64.

## Files

- `packages/relay/deploy/bootstrap.sh` — idempotent installer; installs Node 22 (NodeSource) + Caddy, builds the relay workspace, generates Ed25519 tenant signing keypair + admin token + operator HMAC key, installs systemd unit + Caddyfile, starts service, prints operator-side connection bundle.
- `packages/relay/deploy/relay.service` — hardened systemd unit (`NoNewPrivileges`, `ProtectSystem=strict`, restricted address families, restricted namespaces, `LockPersonality`, log to `/var/log/brainstorm-relay/`).
- `packages/relay/deploy/Caddyfile.template` — TLS reverse proxy with `@@RELAY_HOSTNAME@@` / `@@WS_PORT@@` / `@@HTTP_PORT@@` placeholders. Routes `/v1/operator` + `/v1/endpoint/connect` (WS) and `/v1/endpoint/enroll` + `/v1/admin/endpoint/*` (HTTP).
- `packages/relay/deploy/README.md` — prerequisites, quick-start, verification curl, files reference, tear-down, dogfood-path note.

## AWS validation

End-to-end validation on a throwaway AWS Ubuntu 24.04.4 LTS instance (t3.small, us-east-1, ami-05cf1e9f73fbad2e2):

- ✅ `bootstrap.sh` install completes (Node 22.22, npm, build via turbo `15.7s`)
- ✅ `relay.service` active (PID 4832 → after `systemctl restart` → PID 5334)
- ✅ Enrollment endpoint returns valid `bootstrap_token`:
  ```
  {"bootstrap_token":"GzGAqw3nUfwBzBTjeXDqd7oSnWhOwdx4JxCPsCH-ykg",
   "tenant_id":"tenant-local",
   "endpoint_id":"6f50d012-9a31-4a5d-b97c-539fe997542c",
   "expires_at":"2026-04-28T23:05:36.094Z"}
  ```
- ✅ Bad-auth returns HTTP 401
- ✅ Caddyfile substitution + `caddy validate` returns "Valid configuration"
- ✅ Tear-down removes service, /etc/, /var/lib/, /opt/, user — clean

Instance + SSH key + security group all torn down post-validation. AWS-instance authorization usage: testing-with-teardown, scope honored.

## What this PR is NOT

- A live deployment (no host commitment was made; Justin's call on hosting target)
- Production-grade multi-tenant config (single-tenant bootstrap; multi-tenant would need a vault-backed loader)
- A standalone binary (still requires Node + repo clone; pkg-style bundling deferred)

## Test plan

- [x] AWS Ubuntu 24.04 install + service-active + enrollment-functional + restart-survives + tear-down-clean
- [x] Caddyfile template substitution + `caddy validate` passes
- [x] Hardened systemd unit applied
- [ ] Long-lived deployment on real domain with Let's Encrypt cert issuance (gated on Justin's hosting decision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)