### PR TITLE
chore(harness): document ChangeSet payload immutability + session-lock posture

### DIFF
--- a/packages/harness-drift/src/types.ts
+++ b/packages/harness-drift/src/types.ts
@@ -80,7 +80,25 @@ export interface ChangeSet {
   readonly applied_at?: number;
   readonly reverted_at?: number;
 
-  /** Free-form payload the apply() routine reads. Persisted as JSON. */
+  /**
+   * Free-form payload the apply() routine reads. Persisted as JSON.
+   *
+   * Contract for implementers (important — easy to get wrong on revert):
+   *   - Treat `payload` as immutable after construction. apply() must
+   *     not mutate it, because revert() reads the same payload to roll
+   *     back. If apply() needs derived state, store it in a separate
+   *     field (see e.g. `prior_observed_value` on
+   *     ApplyIntentToRuntimeChangeSet).
+   *   - The shape is per-Kind, not per-instance. Concrete subclasses
+   *     should define an interface that their payload conforms to and
+   *     validate at the boundary (or rely on the constructor types).
+   *   - Schema typing is intentionally `Record<string, unknown>` here
+   *     so the engine can persist any ChangeSet without leaking each
+   *     subclass's internal shape into the engine's public types. A
+   *     fully-typed payload would require a generic on ChangeSet that
+   *     propagates through every store / persistor — deferred until
+   *     persistent ChangeSet drafts ship (PRD BH-CS-001).
+   */
   readonly payload: Record<string, unknown>;
 
   /** Describe what apply() would do. Pure; safe to call repeatedly. */

--- a/packages/harness-fs/src/write-through.ts
+++ b/packages/harness-fs/src/write-through.ts
@@ -21,6 +21,17 @@ import { WriteAheadLog } from "./wal.js";
  * be at intent_hash (atomic-write completed before crash) or not (atomic-
  * write hadn't started); either way the index update is the only thing to
  * re-issue. The hash verification in the index module decides what to do.
+ *
+ * Concurrent session note (advisory — not enforced):
+ *   v1 does NOT take a lockfile against concurrent writers on the same
+ *   harness root. If two desktops or two CLI invocations open the same
+ *   harness simultaneously, FS writes are uncoordinated and the last
+ *   `atomicWriteFile()` wins on any colliding path. The index is
+ *   per-user (Decision #11) so reads never collide; the WAL is also
+ *   per-user. The exposure is limited to the small window when two
+ *   operators are editing the same file in the same harness at the same
+ *   time. A `.harness/.session.lock` advisory file is a Phase-1+
+ *   candidate (PRD BH-SEC-* tier).
  */
 
 export interface HarnessWrite {


### PR DESCRIPTION
## Summary

Two narrow design-intent docstrings — no code changes. Closes 2 of 5 candidate items from the lighthouse Group-C cluster; the other 3 turned out not to be real bugs.

## Changes

- **C4** — `ChangeSet.payload` immutability contract (packages/harness-drift/src/types.ts)
- **C5** — Concurrent-session locking is advisory, not enforced (packages/harness-fs/src/write-through.ts HarnessWriter docstring)

## Skipped (not real bugs)

- C1 ratchet stolen → superseded: \"stolen\" is correctly terminal in v1
- C2 sensitive-glob minimatch: already uses minimatch
- C3 audit asymmetry: both encrypt + decrypt require AuditContext

## Test plan

- [x] typecheck 71/71
- [x] No source-level changes; docstrings only
- [x] dep-cruiser + as-any unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)