### PR TITLE
fix(cli): declare archetype-* deps + Phase-0 CI quality audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19690,6 +19690,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@brainst0rm/agents": "0.13.0",
+        "@brainst0rm/archetype-msp": "0.13.0",
+        "@brainst0rm/archetype-saas-platform": "0.13.0",
         "@brainst0rm/broker": "0.13.0",
         "@brainst0rm/code-graph": "0.13.0",
         "@brainst0rm/config": "0.13.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,6 +35,8 @@
   },
   "dependencies": {
     "@brainst0rm/agents": "0.13.0",
+    "@brainst0rm/archetype-msp": "0.13.0",
+    "@brainst0rm/archetype-saas-platform": "0.13.0",
     "@brainst0rm/code-graph": "0.13.0",
     "@brainst0rm/config": "0.13.0",
     "@brainst0rm/broker": "0.13.0",


### PR DESCRIPTION
## Summary

Phase 0 Group E — CI/package quality audit. Two real gaps surfaced; one fixed here.

## Findings

**E1 — `--passWithNoTests` audit.** Scanned all 27 packages with bare \`vitest run\`. All have ≥1 test file today. The two archetype packages were already fixed in PR #291 (commit 56f9a10). **No new gaps.**

**E2 — Undeclared `@brainst0rm/*` imports.** Scanned all packages for runtime imports of workspace packages not listed in dependencies. **One real gap:** cli imports `@brainst0rm/archetype-msp` + `@brainst0rm/archetype-saas-platform` from `harness-templates.ts` but never declared them. Same shape as the router→gateway fix from PR #291.

## Fix

- packages/cli/package.json: add the two archetype dependencies at \`0.13.0\`
- package-lock.json: refreshed

## Verification

- \`npx turbo run build --filter=@brainst0rm/cli --force\` succeeds (29 tasks, was 27 — archetypes now in topological chain)
- dep-cruiser + as-any unchanged

## Test plan

- [x] cli builds clean
- [x] No new ratchet violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)