### PR TITLE
chore(security): clear 10 CodeQL alerts (unused-imports + polynomial-redos)

### DIFF
--- a/packages/cli/src/commands/harness.ts
+++ b/packages/cli/src/commands/harness.ts
@@ -23,7 +23,6 @@ import {
   walkHarnessDir,
   detectKind,
   extractIndexFields,
-  hashContent,
   materializeHarness,
 } from "@brainst0rm/harness-fs";
 import {

--- a/packages/endpoint-stub/src/index.ts
+++ b/packages/endpoint-stub/src/index.ts
@@ -32,9 +32,8 @@ export {
   type SandboxFactory,
 } from "./chv-executor.js";
 
-import { randomUUID, randomBytes } from "node:crypto";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { dirname } from "node:path";
 import WebSocket from "ws";
 import * as ed25519 from "@noble/ed25519";
 import { sha256 } from "@noble/hashes/sha256";

--- a/packages/harness-crypto/src/__tests__/recipient-bundle.test.ts
+++ b/packages/harness-crypto/src/__tests__/recipient-bundle.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { z } from "zod";

--- a/packages/harness-fs/src/init.ts
+++ b/packages/harness-fs/src/init.ts
@@ -63,11 +63,17 @@ export type MaterializeHarnessResult =
  * continue to land at the same paths.
  */
 export function toBusinessSlug(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9-]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 60);
+  // Bound input length BEFORE regex work so the slugify cost is constant
+  // even on adversarial input. CodeQL flags the trim-dashes regex below
+  // for polynomial-redos heuristics; capping at 256 chars upfront makes
+  // any backtracking irrelevant. Output is sliced again to 60 at the end.
+  const bounded = name.slice(0, 256).toLowerCase();
+  // Two single-anchored trims instead of an alternation: linear time
+  // and clearer intent than `/^-+|-+$/g`.
+  const collapsed = bounded.replace(/[^a-z0-9-]+/g, "-");
+  const trimmedLeft = collapsed.replace(/^-+/, "");
+  const trimmedRight = trimmedLeft.replace(/-+$/, "");
+  return trimmedRight.slice(0, 60);
 }
 
 export function materializeHarness(

--- a/packages/harness-index/src/queries.ts
+++ b/packages/harness-index/src/queries.ts
@@ -70,17 +70,8 @@ export interface TagSummary {
  * Reads via the index's tag table; returns an ordered list.
  */
 export function tagCloud(store: HarnessIndexStore): TagSummary[] {
-  // Pull all artifacts, count tags. Could push this to SQL with GROUP BY
-  // but the JS path is simpler and 20k artifacts × ~3 tags each is trivial.
-  const counts = new Map<string, number>();
-  for (const a of store.allArtifacts()) {
-    // Use the byTag path: each artifact in the loop, fetch its tags…
-    // Simpler approach: query directly. Since allArtifacts doesn't include
-    // tags, fall back to a scan via byTag for known tags. We scan the
-    // tags table directly via the underlying db.
-  }
-  // Direct query through the store's prepared statements — defensive
-  // bracket access avoids leaking internal handles in the .d.ts.
+  // Direct SQL aggregation through the store's prepared statements.
+  // Defensive bracket access avoids leaking internal handles in the .d.ts.
   const db = (
     store as unknown as {
       db: {
@@ -98,9 +89,6 @@ export function tagCloud(store: HarnessIndexStore): TagSummary[] {
        ORDER BY count DESC, tag ASC`,
     )
     .all();
-  // Suppress unused warning; counts map exists for future enhancement
-  // (e.g., merging with computed tags from external sources).
-  void counts;
   return rows;
 }
 

--- a/packages/relay/src/__tests__/canonical.test.ts
+++ b/packages/relay/src/__tests__/canonical.test.ts
@@ -68,9 +68,6 @@ describe("nfcNormalize", () => {
     const composed = "café"; // NFC: precomposed é (4 chars)
     expect(decomposed).not.toBe(composed); // sanity: different strings
     expect(decomposed.normalize("NFC")).toBe(composed); // collide on normalize
-    const colliding = JSON.parse(
-      JSON.stringify({ [decomposed]: 1, [composed]: 2 }),
-    );
     // We need to construct an object literal where both forms are keys
     // — use Object.assign with separate sources to force two distinct
     // own properties.

--- a/packages/relay/src/__tests__/nonce-store.test.ts
+++ b/packages/relay/src/__tests__/nonce-store.test.ts
@@ -56,8 +56,6 @@ describe("NonceStore", () => {
     // monkey-checking at the boundary: load up the store and verify
     // behavior at the limit.
     const store = makeStore({ capacity: 100_000 });
-    // Use an expires_at that's far in the future so eviction can't help.
-    const farFuture = new Date(Date.now() + 24 * 3600 * 1000).toISOString();
     // Loading 100k rows is expensive; instead verify the rejection logic
     // by inserting just under the limit and then poking at internals would
     // be invasive. Skip the load test; rely on capacity validation in

--- a/packages/relay/src/__tests__/result-router.test.ts
+++ b/packages/relay/src/__tests__/result-router.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";

--- a/packages/relay/src/dispatch.ts
+++ b/packages/relay/src/dispatch.ts
@@ -25,11 +25,7 @@ import type {
   ErrorEventRelayToOperator,
   Operator,
 } from "./types.js";
-import {
-  signEnvelope,
-  verifyEnvelope,
-  type SignableEnvelope,
-} from "./signing.js";
+import { signEnvelope, type SignableEnvelope } from "./signing.js";
 import { SIGN_CONTEXT, canonicalBytes } from "./canonical.js";
 import type { AuditLog } from "./audit.js";
 import type { NonceStore } from "./nonce-store.js";

--- a/packages/sandbox-redteam/src/mock-tools.ts
+++ b/packages/sandbox-redteam/src/mock-tools.ts
@@ -79,10 +79,11 @@ export function attackerToolBattery(): Record<string, MockToolHandler> {
     ok("", "");
   return {
     noop: noopFromCtx,
-    "stdout.echo": (inv): ToolExecution => {
+    "stdout.echo": (_inv): ToolExecution => {
       // This handler "leaks" by promoting stdout to a structured field.
-      const content =
-        typeof inv.params.content === "string" ? inv.params.content : "";
+      // Input is intentionally read-then-dropped to model a buggy
+      // tool that forgets to forward stdout — the test asserts the
+      // returned shape stays within ToolExecution.
       return {
         exit_code: 0,
         stdout: "", // forge dropped — bad


### PR DESCRIPTION
## Summary

Phase 0 Group F — CodeQL backlog triage. Closes 10 of 29 open alerts on main with genuine fixes; the remaining 19 are documented in the Phase-0 evidence doc as known false positives that deserve a separate hardening pass.

## Cleared (10 alerts)

**F1 — Unused imports/variables (9):** `harness-index/queries.ts`, `harness-crypto/recipient-bundle.test.ts`, `cli/harness.ts`, `relay/dispatch.ts`, `relay/result-router.test.ts`, `relay/nonce-store.test.ts`, `relay/canonical.test.ts`, `sandbox-redteam/mock-tools.ts`, `endpoint-stub/index.ts`.

**F2 — Polynomial redos (1):** `harness-fs/init.ts:66` `toBusinessSlug()` — bound input to 256 chars + replace alternation regex with two single-anchored trims.

## Documented as known FP (19 alerts, not in scope here)

- 7× `js/file-system-race` — single-process Electron + CLI; no concurrent attacker
- 3× `js/user-controlled-bypass` in `relay/enrollment.ts` — URL routing selectors, with `checkAdminAuth` immediately following each match
- 1× `js/insufficient-password-hash` in `broker/client.ts` — `fingerprintApiKey` is a tenant-boundary identifier, not a password verifier
- 4× `js/log-injection` + `js/http-to-file-access` + `js/file-access-to-http` in `endpoint-stub` — dev/test stub, not in production path
- 4× similar in `scripts/run-br-vs-cf-benchmark.mjs` — dev tool

These are tracked as a separate hardening backlog; no polish-grade fix exists without restructuring auth pathways (out of "no new features" scope).

## Verification

- typecheck across non-desktop workspaces: 71/71
- targeted tests: 14/14 across affected packages
- dep-cruiser + as-any unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)