### PR TITLE
chore(security): mkdtempSync for predictable tmp paths (TOCTOU)

### DIFF
--- a/packages/code-graph/src/__tests__/cross-project.test.ts
+++ b/packages/code-graph/src/__tests__/cross-project.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { CodeGraph } from "../graph.js";
@@ -17,7 +17,7 @@ beforeAll(async () => {
   registerAdapter(createTypeScriptAdapter());
 
   // Project A — a backend API
-  const projectA = join(tmpdir(), `cross-a-${Date.now()}`);
+  const projectA = mkdtempSync(join(tmpdir(), `cross-a-`));
   mkdirSync(join(projectA, "src"), { recursive: true });
   writeFileSync(
     join(projectA, "src", "server.ts"),
@@ -54,7 +54,7 @@ export class User {
   );
 
   // Project B — a frontend that calls Project A
-  const projectB = join(tmpdir(), `cross-b-${Date.now()}`);
+  const projectB = mkdtempSync(join(tmpdir(), `cross-b-`));
   mkdirSync(join(projectB, "src"), { recursive: true });
   writeFileSync(
     join(projectB, "src", "client.ts"),
@@ -78,10 +78,8 @@ export function fetchCreateUser(data: any) {
   );
 
   // Build graphs
-  const dbDirA = join(tmpdir(), `cross-db-a-${Date.now()}`);
-  const dbDirB = join(tmpdir(), `cross-db-b-${Date.now()}`);
-  mkdirSync(dbDirA, { recursive: true });
-  mkdirSync(dbDirB, { recursive: true });
+  const dbDirA = mkdtempSync(join(tmpdir(), `cross-db-a-`));
+  const dbDirB = mkdtempSync(join(tmpdir(), `cross-db-b-`));
 
   graphA = new CodeGraph({ dbPath: join(dbDirA, "a.db") });
   graphB = new CodeGraph({ dbPath: join(dbDirB, "b.db") });
@@ -98,8 +96,7 @@ export function fetchCreateUser(data: any) {
   });
 
   // Create cross-project graph
-  const crossDbDir = join(tmpdir(), `cross-db-${Date.now()}`);
-  mkdirSync(crossDbDir, { recursive: true });
+  const crossDbDir = mkdtempSync(join(tmpdir(), `cross-db-`));
   crossGraph = new CrossProjectGraph(join(crossDbDir, "cross.db"));
   crossGraph.addProject("backend", graphA);
   crossGraph.addProject("frontend", graphB);

--- a/packages/code-graph/src/__tests__/languages.test.ts
+++ b/packages/code-graph/src/__tests__/languages.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from "vitest";
-import { writeFileSync, mkdirSync } from "node:fs";
+import { writeFileSync, mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -15,11 +15,7 @@ import { createJavaAdapter } from "../languages/java.js";
 import type { ParsedFile } from "../parser.js";
 
 function tmpFile(ext: string, content: string): string {
-  const dir = join(
-    tmpdir(),
-    `lang-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-  );
-  mkdirSync(dir, { recursive: true });
+  const dir = mkdtempSync(join(tmpdir(), `lang-test-`));
   const path = join(dir, `test${ext}`);
   writeFileSync(path, content, "utf-8");
   return path;

--- a/packages/code-graph/src/__tests__/mcp-tools.test.ts
+++ b/packages/code-graph/src/__tests__/mcp-tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { CodeGraph } from "../graph.js";
@@ -43,7 +43,7 @@ beforeAll(async () => {
   registerAdapter(createPythonAdapter());
 
   // Create fixture project
-  projectDir = join(tmpdir(), `mcp-test-${Date.now()}`);
+  projectDir = mkdtempSync(join(tmpdir(), `mcp-test-`));
   mkdirSync(join(projectDir, "src"), { recursive: true });
   mkdirSync(join(projectDir, "lib"), { recursive: true });
 
@@ -114,7 +114,7 @@ def transform(data):
   }
 
   // Build graph via pipeline
-  const dbDir = join(tmpdir(), `mcp-db-${Date.now()}`);
+  const dbDir = mkdtempSync(join(tmpdir(), `mcp-db-`));
   mkdirSync(dbDir, { recursive: true });
   graph = new CodeGraph({ dbPath: join(dbDir, "test.db") });
 

--- a/packages/code-graph/src/__tests__/pipeline.test.ts
+++ b/packages/code-graph/src/__tests__/pipeline.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterEach } from "vitest";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { CodeGraph } from "../graph.js";
@@ -138,8 +138,7 @@ describe("Pipeline DAG", () => {
 
     it("runs the full pipeline on a multi-language project", async () => {
       const projectDir = createFixtureProject();
-      const dbDir = join(tmpdir(), `pipeline-db-${Date.now()}`);
-      mkdirSync(dbDir, { recursive: true });
+      const dbDir = mkdtempSync(join(tmpdir(), `pipeline-db-`));
       graph = new CodeGraph({ dbPath: join(dbDir, "test.db") });
 
       const progressMessages: string[] = [];
@@ -177,8 +176,7 @@ describe("Pipeline DAG", () => {
 
     it("handles failed stages by skipping dependents", async () => {
       const projectDir = createFixtureProject();
-      const dbDir = join(tmpdir(), `pipeline-fail-${Date.now()}`);
-      mkdirSync(dbDir, { recursive: true });
+      const dbDir = mkdtempSync(join(tmpdir(), `pipeline-fail-`));
       graph = new CodeGraph({ dbPath: join(dbDir, "test.db") });
 
       const failingStage = {

--- a/packages/code-graph/src/__tests__/sectors.test.ts
+++ b/packages/code-graph/src/__tests__/sectors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { CodeGraph } from "../graph.js";
@@ -35,7 +35,7 @@ beforeAll(async () => {
   registerAdapter(createPythonAdapter());
 
   // Create a project with clear sector boundaries
-  projectDir = join(tmpdir(), `sectors-test-${Date.now()}`);
+  projectDir = mkdtempSync(join(tmpdir(), `sectors-test-`));
 
   // Auth sector — critical (crypto/auth keywords)
   mkdirSync(join(projectDir, "src", "auth"), { recursive: true });
@@ -113,8 +113,7 @@ def normalize(data):
   );
 
   // Build graph
-  const dbDir = join(tmpdir(), `sectors-db-${Date.now()}`);
-  mkdirSync(dbDir, { recursive: true });
+  const dbDir = mkdtempSync(join(tmpdir(), `sectors-db-`));
   graph = new CodeGraph({ dbPath: join(dbDir, "test.db") });
 
   await executePipeline(createDefaultPipeline(), {

--- a/packages/core/src/__tests__/curator-runner.test.ts
+++ b/packages/core/src/__tests__/curator-runner.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
-  mkdirSync,
+  mkdtempSync,
   writeFileSync,
   existsSync,
   unlinkSync,
@@ -25,12 +25,7 @@ vi.mock("../agent/subagent.js", () => ({
 }));
 
 function createTestDir(): string {
-  const dir = join(
-    tmpdir(),
-    `curator-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-  );
-  mkdirSync(dir, { recursive: true });
-  return dir;
+  return mkdtempSync(join(tmpdir(), `curator-test-`));
 }
 
 function writeMemoryFile(dir: string, name: string, content: string): void {

--- a/packages/core/src/__tests__/git-sync.test.ts
+++ b/packages/core/src/__tests__/git-sync.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { mkdirSync, existsSync } from "node:fs";
+import { mkdirSync, mkdtempSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
@@ -12,21 +12,13 @@ import {
 } from "../memory/git.js";
 
 function createTestRepo(): string {
-  const dir = join(
-    tmpdir(),
-    `git-sync-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-  );
-  mkdirSync(dir, { recursive: true });
+  const dir = mkdtempSync(join(tmpdir(), `git-sync-test-`));
   initMemoryRepo(dir);
   return dir;
 }
 
 function createBareRemote(): string {
-  const dir = join(
-    tmpdir(),
-    `git-remote-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-  );
-  mkdirSync(dir, { recursive: true });
+  const dir = mkdtempSync(join(tmpdir(), `git-remote-`));
   // Pin the initial branch so `git clone <remote>` checks out a branch
   // that actually exists once we push `main` to it. Without this, CI
   // Linux (no `init.defaultBranch` set) creates a bare repo with
@@ -109,10 +101,10 @@ describe("git-sync", () => {
       sync.syncAfterWrite();
 
       // Verify: clone remote and check file exists
-      const cloneDir = join(
-        tmpdir(),
-        `clone-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-      );
+      const cloneDir = mkdtempSync(join(tmpdir(), `clone-`));
+      // mkdtempSync created the dir; git clone needs it to NOT exist or
+      // be empty — the empty dir from mkdtempSync satisfies "empty," so
+      // clone happily fills it.
       execFileSync("git", ["clone", remote, cloneDir], { stdio: "ignore" });
       expect(existsSync(join(cloneDir, "test.md"))).toBe(true);
     });

--- a/packages/eval/src/runner.ts
+++ b/packages/eval/src/runner.ts
@@ -9,7 +9,13 @@ import {
   SessionManager,
 } from "@brainst0rm/core";
 import { createLogger } from "@brainst0rm/shared";
-import { mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+} from "node:fs";
 import { join, resolve, sep } from "node:path";
 import { tmpdir } from "node:os";
 import type { Probe, ProbeResult } from "./types.js";
@@ -41,11 +47,15 @@ export async function runProbe(
   // Sandbox directory for probe setup files AND for code-correctness runs.
   // Always created — scorer checks it for code_compiles — but the agent's
   // actual workspace depends on probe.workspace.
-  const sandboxDir = join(
-    tmpdir(),
-    `brainstorm-eval-${probe.id}-${Date.now()}`,
+  //
+  // mkdtempSync (rather than join + mkdirSync with a Date.now() suffix)
+  // closes the TOCTOU window CodeQL flagged: an attacker on the same
+  // machine could otherwise pre-create the predictable path as a
+  // symlink to a sensitive directory before our mkdir runs, causing
+  // the subsequent writeFileSync to land outside the intended sandbox.
+  const sandboxDir = mkdtempSync(
+    join(tmpdir(), `brainstorm-eval-${probe.id}-`),
   );
-  mkdirSync(sandboxDir, { recursive: true });
 
   try {
     // Write setup files. Probe definitions come from arbitrary JSONL


### PR DESCRIPTION
## Summary

Phase 0 Group I — closes ~18 of 24 \`js/insecure-temporary-file\` CodeQL alerts. Replaces the predictable \`join(tmpdir(), \`name-\${Date.now()}\`)\` + \`mkdirSync\` pattern with \`mkdtempSync(join(tmpdir(), \`name-\`))\`, which atomically creates a unique random-suffixed dir and closes the TOCTOU window.

## Production fix (real, not just polish)

\`packages/eval/src/runner.ts:44-48\` — sandbox directory for probe setup files was \`tmpdir + probe.id + Date.now()\`. An attacker on the same machine could pre-create that path as a symlink to a sensitive dir before our mkdir runs, causing the subsequent \`writeFileSync\` to land outside the intended sandbox.

## Test hygiene

7 test files swapped (sectors / cross-project / pipeline / mcp-tools / languages / git-sync / curator-runner). Same threat model is academic on dev machines, but the pattern is the right one and CodeQL pattern-matching will be quieter.

## Documented FPs (not fixed)

\`docgen/index.ts\`, \`code-graph/sectors/agent-assigner.ts\`, \`core/memory/curator-runner.ts\` — CodeQL traces flow through callers that don't actually hit os.tmpdir(). Detail in commit message.

## Verification

- typecheck 73/73, tests 16/16, dep-cruiser 0/0, as-any unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)