### PR TITLE
fix(workflow): close 3 v13 Attacker kill-gate bypasses (path-to-90 P9a)

### DIFF
--- a/packages/workflow/src/__tests__/engine.test.ts
+++ b/packages/workflow/src/__tests__/engine.test.ts
@@ -413,8 +413,86 @@ describe("artifact-store", () => {
       for (const gate of dangerous) {
         const verdict = validateGateCommand(gate);
         expect(verdict.allowed, `must reject: ${gate}`).toBe(false);
-        expect(verdict.reason).toMatch(/metacharacters|not in allowlist/);
+        expect(verdict.reason).toMatch(
+          /metacharacters|not in allowlist|expansion/,
+        );
       }
+    });
+
+    // ── v13 Attacker bypasses — closed in P9a (2026-05-15) ─────────
+    //
+    // The v13 stochastic-assessment Attacker (re-verified in v14 evidence)
+    // identified three specific bypasses that survived the v12 fix:
+    //   1. Word-boundary gap on prefix match — "npx vitest-pwn"
+    //   2. Per-command danger flag — "go test -exec=/tmp/wrapper"
+    //   3. Brace expansion + glob — now also caught by expanded metachar set
+    //
+    // Each test below names the bypass it closes and asserts the rejection
+    // includes a reason that points the operator at the failing rule.
+
+    it("v13-attacker-bypass-1: word-boundary on prefix match (npx vitest-pwn)", () => {
+      const verdicts = [
+        validateGateCommand("npx vitest-pwn"),
+        validateGateCommand("go test-x"),
+        validateGateCommand("cargo testxxx"),
+        validateGateCommand("npm testimony"),
+        validateGateCommand("pytestpwn"),
+        validateGateCommand("makeevil"),
+      ];
+      for (const v of verdicts) {
+        expect(v.allowed, "must reject mid-token prefix collision").toBe(false);
+        expect(v.reason).toMatch(/word-boundary|not in allowlist/);
+      }
+      // The legitimate exact-match must STILL pass.
+      expect(validateGateCommand("npx vitest").allowed).toBe(true);
+      expect(validateGateCommand("npx vitest run").allowed).toBe(true);
+      expect(validateGateCommand("go test").allowed).toBe(true);
+      expect(validateGateCommand("go test ./...").allowed).toBe(true);
+    });
+
+    it("v13-attacker-bypass-2: go/cargo -exec wrapper-binary execution", () => {
+      const dangerous = [
+        "go test -exec=/tmp/wrapper ./...",
+        "go test -exec /tmp/wrapper ./...",
+        "go test --exec=evil-binary ./pkg",
+        "cargo test -exec=/tmp/pwn",
+        "go test ./pkg/foo -exec=/abs/path/evil",
+        "go test -exec=evil -v",
+      ];
+      for (const gate of dangerous) {
+        const v = validateGateCommand(gate);
+        expect(v.allowed, `must reject -exec form: ${gate}`).toBe(false);
+        expect(v.reason).toMatch(/exec|dangerous pattern/);
+      }
+      // Innocuous -exec-adjacent strings must still pass (flag is not the
+      // word "exec"; rule matches `-exec` or `--exec` only).
+      expect(validateGateCommand("go test ./executor").allowed).toBe(true);
+      expect(validateGateCommand("cargo test executive").allowed).toBe(true);
+    });
+
+    it("v13-attacker-bypass-3: brace expansion and glob in arguments", () => {
+      // Brace expansion {a,b} and glob * are shell-evaluated before the
+      // command sees its args. Even if the resulting expansion is
+      // 'harmless', the shape attack is enough — operator intent is
+      // unclear when shell expansion is in play. Reject categorically.
+      const dangerous = [
+        "npm test {a,b}",
+        "npm run {build,deploy}",
+        "go test ./...*",
+        "make test ~user/script",
+        "pytest test_?.py",
+      ];
+      for (const gate of dangerous) {
+        const v = validateGateCommand(gate);
+        expect(v.allowed, `must reject expansion form: ${gate}`).toBe(false);
+        expect(v.reason).toMatch(/metacharacters|expansion/);
+      }
+    });
+
+    it("rejects empty/whitespace-only commands", () => {
+      expect(validateGateCommand("").allowed).toBe(false);
+      expect(validateGateCommand("   ").allowed).toBe(false);
+      expect(validateGateCommand("\t\n").allowed).toBe(false);
     });
   });
 });

--- a/packages/workflow/src/engine.ts
+++ b/packages/workflow/src/engine.ts
@@ -29,9 +29,10 @@ import {
 
 /**
  * Shell commands that may run as a workflow kill-gate. Each entry is a
- * prefix; the gate is accepted only if it starts with one of these AND
- * contains no shell metacharacters. Exported so tests can assert the
- * surface directly without spinning up a full workflow run.
+ * prefix; the gate is accepted only if it matches one of these with a
+ * word boundary AND contains no shell metacharacters AND contains no
+ * per-command danger patterns. Exported so tests can assert the surface
+ * directly without spinning up a full workflow run.
  */
 export const ALLOWED_GATE_PREFIXES = [
   "npm test",
@@ -48,34 +49,93 @@ export const ALLOWED_GATE_PREFIXES = [
 ] as const;
 
 /**
+ * Per-allowed-prefix danger patterns. If the gate string passes prefix +
+ * metachar checks but matches any pattern here, it is still rejected.
+ *
+ * `go test -exec=PROGRAM` and `go test -exec PROGRAM` cause `go` to run
+ * PROGRAM as the test binary wrapper — direct arbitrary command execution
+ * without any shell metacharacter. v13 Attacker bypass #2; closed here.
+ *
+ * `cargo test` has a similar `--exec`-shape flag risk; pre-emptively block.
+ */
+const DANGER_PATTERNS: ReadonlyArray<RegExp> = [
+  /(?:^|\s)-{1,2}exec[\s=]/, // -exec / -exec= / --exec / --exec=
+];
+
+/**
  * Validate a kill-gate command string before execution. Gates run via
  * /bin/sh -c, so a prefix match alone is not safe — "npm test; rm -rf /"
- * starts with "npm test" but chains a second command. This helper also
- * rejects any shell metacharacter that could chain, pipe, redirect, or
- * substitute ( `;`, `&`, `|`, backtick, `$`, `<`, `>`, parens, newlines ).
- * Plain whitespace-delimited arguments such as "npm run build --if-present"
- * still pass.
+ * starts with "npm test" but chains a second command. Defenses, in order:
+ *
+ *   1. **Word-bounded prefix match.** Accept either exact equality with
+ *      a prefix OR prefix followed by whitespace. Closes v13 Attacker
+ *      bypass #1: `validateGateCommand("npx vitest-pwn")` no longer
+ *      passes by starting with "npx vitest". The trailing character
+ *      after the prefix MUST be whitespace (or end-of-string).
+ *
+ *   2. **Shell metacharacter deny.** Rejects any character that could
+ *      chain, pipe, redirect, substitute, or expand
+ *      ( `;`, `&`, `|`, backtick, `$`, `<`, `>`, parens, newlines, `{}`,
+ *      `*`, `?`, `~` ). Plain whitespace-delimited arguments such as
+ *      "npm run build --if-present" still pass.
+ *
+ *   3. **Per-command danger pattern deny** (post-metachar). The `-exec`
+ *      flag on `go test` / `cargo test` runs an arbitrary wrapper binary
+ *      directly, bypassing shell metachar checks entirely. Closes v13
+ *      Attacker bypass #2.
+ *
+ * Returns `{allowed: true}` on accept, or `{allowed: false, reason}` on
+ * reject. The reason string is operator-readable; callers should surface
+ * it as-is.
  */
 export function validateGateCommand(gate: string): {
   allowed: boolean;
   reason?: string;
 } {
   const trimmed = gate.trimStart();
-  const prefixOk = ALLOWED_GATE_PREFIXES.some((prefix) =>
-    trimmed.startsWith(prefix),
-  );
+
+  // 1. Word-bounded prefix match.
+  const prefixOk = ALLOWED_GATE_PREFIXES.some((prefix) => {
+    if (trimmed === prefix) return true; // exact match
+    if (!trimmed.startsWith(prefix)) return false;
+    // If the prefix already ends with whitespace ("npm run ",
+    // "npx turbo run ", "make "), the word boundary is baked in by
+    // startsWith — and the next char IS the start of an argument,
+    // which is fine. Only enforce next-char whitespace for prefixes
+    // that DON'T end with whitespace ("npm test", "npx vitest",
+    // "go test", "cargo test", "pytest", etc.) — those would
+    // otherwise collide on shapes like "npx vitest-pwn".
+    if (/\s$/.test(prefix)) return true;
+    const nextChar = trimmed.charAt(prefix.length);
+    return nextChar === " " || nextChar === "\t";
+  });
   if (!prefixOk) {
     return {
       allowed: false,
-      reason: `Gate rejected: command not in allowlist. Allowed prefixes: ${ALLOWED_GATE_PREFIXES.join(", ")}`,
+      reason: `Gate rejected: command not in allowlist or fails word-boundary check. Allowed prefixes: ${ALLOWED_GATE_PREFIXES.join(", ")}`,
     };
   }
-  if (/[;&|`$<>\n\r()]/.test(trimmed)) {
+
+  // 2. Shell metacharacter deny (expanded vs v12 to include {}, *, ?, ~).
+  //    `{a,b}` brace expansion + `*` glob + `~` home expansion are all
+  //    shell-evaluated before arguments reach the command and could
+  //    expand into unexpected forms.
+  if (/[;&|`$<>\n\r(){}*?~]/.test(trimmed)) {
     return {
       allowed: false,
       reason:
-        "Gate rejected: command contains shell metacharacters that would allow chaining or substitution",
+        "Gate rejected: command contains shell metacharacters or expansion forms that would allow chaining, substitution, or argument-shape attack",
     };
+  }
+
+  // 3. Per-command danger patterns.
+  for (const pattern of DANGER_PATTERNS) {
+    if (pattern.test(trimmed)) {
+      return {
+        allowed: false,
+        reason: `Gate rejected: command matches a known dangerous pattern (${pattern.source}) — e.g., go/cargo -exec runs an arbitrary wrapper binary`,
+      };
+    }
   }
   return { allowed: true };
 }


### PR DESCRIPTION
## Summary

**Path-to-90 Phase 9a.** Closes the 3 specific kill-gate bypasses the v13 stochastic-assessment Attacker named and the v14 Attacker re-verified as still open at HEAD. Real **D6 SecurityPosture +0.4** lift.

## What was broken

The v14 Attacker's evidence (synthesis.md lines naming `packages/workflow/src/engine.ts`):

1. `validateGateCommand("npx vitest-pwn")` returned `allowed=true` — prefix `"npx vitest"` had no word-boundary check, so any npm typosquat passed.
2. `validateGateCommand("go test -exec=/tmp/wrapper ./...")` returned `allowed=true` — the metachar regex didn't catch `-exec=`, and `go test -exec` runs an arbitrary wrapper binary directly.
3. Brace expansion `{a,b}`, glob `*`/`?`, home `~` were not in the metachar deny — `npm test {a,b}` and similar passed.

## What changed

### `packages/workflow/src/engine.ts`

1. **Word-bounded prefix match.** Exact equality OR prefix-followed-by-whitespace. Prefixes that already end with whitespace (`"npm run "`, `"make "`) keep working; prefixes without (`"npx vitest"`, `"go test"`) now reject mid-token collisions.
2. **Expanded metachar deny.** Added `{}`, `*`, `?`, `~` to the regex.
3. **New `DANGER_PATTERNS` list.** Matches `-exec`/`--exec` shapes after prefix + metachar. Catches the `go test -exec` class.

### Tests (`engine.test.ts`)

- 4 new test groups asserting each bypass is now rejected:
  - `v13-attacker-bypass-1`: 6 word-boundary collisions reject; 4 legitimate exact/word-bounded inputs still pass.
  - `v13-attacker-bypass-2`: 6 `-exec`-shape inputs reject; 2 innocuous `-exec`-adjacent inputs (`go test ./executor`, `cargo test executive`) still pass.
  - `v13-attacker-bypass-3`: 5 brace/glob/home expansion inputs reject.
  - `empty-command`: empty/whitespace-only inputs reject.
- Existing tests still pass (11/11 legitimate commands, 10/10 chaining attempts).

## Verification

- `npx turbo run build typecheck --filter=@brainst0rm/workflow` → green
- `npx vitest run engine.test.ts` → **19/19 tests pass** (15 prior + 4 new)

## Per no-cheating

Each fix has a regression test that asserts the EXACT bypass string from the v14 Attacker evidence is now rejected, AND that legitimate commands still pass. Lift is measurable, not aspirational. v15 Attacker will need to find NEW bypasses to score the same -0.4 critique.

## Carry-forward (NOT in this PR)

- **Webhook nonce-cache replay** in `packages/server/src/github-webhook.ts:137` (`MAX_NONCE_CACHE=1000`, in-memory, evict-only-on-age) → P9b
- **Curator-lock release without PID check** in `packages/core/src/memory/curator-runner.ts:121` → P9c

## Path-to-90 lift estimate

- **D6 SecurityPosture +0.4** (3 cited bypasses closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)