### PR TITLE
chore(precommit): auto-regen tool catalog on builtin tool edits

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,9 @@
     ],
     "*.{json,md,yml,yaml}": [
       "prettier --write"
+    ],
+    "packages/tools/src/builtin/**/*.ts": [
+      "scripts/precommit-regen-catalog.sh"
     ]
   },
   "workspaces": [

--- a/scripts/precommit-regen-catalog.sh
+++ b/scripts/precommit-regen-catalog.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Pre-commit hook helper — invoked by lint-staged when files matching
+# packages/tools/src/builtin/**/*.ts are staged. Regenerates the exported
+# tool catalog and stages it alongside the source change so the CI
+# freshness check (`packages/tools` → `export-catalog:check`) can't fail
+# on a forgotten regen.
+#
+# lint-staged appends the matched file paths as args; we ignore them
+# because the export script reads the registry, not those files.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+npm --prefix packages/tools run --silent export-catalog >/dev/null
+git add docs/tool-catalog.json


### PR DESCRIPTION
## Summary

- PR #302 and PR #312 both broke CI's tool-catalog freshness check the same way — BR drift cleanup edited builtin tool source but skipped `npm run export-catalog`. CI catches it on push, but that's a ~4 min roundtrip.
- Adds `scripts/precommit-regen-catalog.sh` invoked by lint-staged whenever a file in `packages/tools/src/builtin/**/*.ts` is staged. Script regenerates and `git add`s the catalog (~0.7s).
- Lifts the same class of gotcha for all future PRs that edit tool descriptions/schemas.

## Test plan

- [x] Created a no-op probe edit on `packages/tools/src/builtin/br-intelligence.ts`, ran `npx lint-staged --concurrent false`, confirmed `docs/tool-catalog.json` was auto-staged alongside the source change
- [x] Reverted the probe; final commit contains only the script + lint-staged config

🤖 Generated with [Claude Code](https://claude.com/claude-code)