### PR TITLE
feat(db): downgrade-detection guard (P8d state-rollback, SQLite slice)

### DIFF
--- a/packages/db/src/__tests__/downgrade-guard.test.ts
+++ b/packages/db/src/__tests__/downgrade-guard.test.ts
@@ -1,0 +1,130 @@
+/**
+ * P8d downgrade guard — assertNoUnknownMigrations.
+ *
+ * Scenario: a 0.14 CLI applied migration "099_future_thing" to the
+ * shared ~/.brainstorm/brainstorm.db. The user then `npm install -g
+ * @brainst0rm/cli@0.13.0` to roll back. The 0.13 build's
+ * runMigrations() must NOT silently proceed — older code reading
+ * the new schema can mishandle NOT NULL columns it doesn't
+ * populate. Per docs/runbooks/rollback-published-version.md the
+ * expected behaviour is fail-fast with a pointer to the runbook.
+ *
+ * better-sqlite3 is sync so we use the in-process DB factory rather
+ * than file-on-disk to keep the test fast and isolated.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { assertNoUnknownMigrations, getTestDb } from "../client.js";
+
+function makeMigrationsTable(): Database.Database {
+  const db = new Database(":memory:");
+  // Create the _migrations table directly so we can seed the unknown
+  // row BEFORE the guard runs. getTestDb's :memory: shares no state
+  // across calls so we can't seed-then-reopen with it.
+  db.prepare(
+    "CREATE TABLE _migrations (id INTEGER PRIMARY KEY, name TEXT NOT NULL, applied_at INTEGER NOT NULL DEFAULT (unixepoch()))",
+  ).run();
+  return db;
+}
+
+describe("downgrade guard (P8d)", () => {
+  const originalEnv = process.env.BRAINSTORM_DB_ALLOW_UNKNOWN_MIGRATIONS;
+  beforeEach(() => {
+    delete process.env.BRAINSTORM_DB_ALLOW_UNKNOWN_MIGRATIONS;
+  });
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.BRAINSTORM_DB_ALLOW_UNKNOWN_MIGRATIONS;
+    } else {
+      process.env.BRAINSTORM_DB_ALLOW_UNKNOWN_MIGRATIONS = originalEnv;
+    }
+  });
+
+  it("no rows → returns without throwing (fresh install)", () => {
+    const db = makeMigrationsTable();
+    const known = new Set(["001_a", "002_b"]);
+    expect(() => assertNoUnknownMigrations(db, known)).not.toThrow();
+  });
+
+  it("all rows in known set → returns without throwing (matched CLI)", () => {
+    const db = makeMigrationsTable();
+    db.prepare("INSERT INTO _migrations (name) VALUES (?), (?)").run(
+      "001_a",
+      "002_b",
+    );
+    const known = new Set(["001_a", "002_b", "003_c"]);
+    expect(() => assertNoUnknownMigrations(db, known)).not.toThrow();
+  });
+
+  it("seeded unknown migration → throws with runbook pointer (downgrade detected)", () => {
+    const db = makeMigrationsTable();
+    db.prepare("INSERT INTO _migrations (name) VALUES (?), (?)").run(
+      "001_a",
+      "099_from_a_newer_cli",
+    );
+    const known = new Set(["001_a", "002_b"]);
+    let caught: unknown;
+    try {
+      assertNoUnknownMigrations(db, known);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    const msg = (caught as Error).message;
+    expect(msg).toContain("099_from_a_newer_cli");
+    expect(msg).toContain("rollback-published-version.md");
+    expect(msg).toContain("BRAINSTORM_DB_ALLOW_UNKNOWN_MIGRATIONS");
+  });
+
+  it("escape hatch BRAINSTORM_DB_ALLOW_UNKNOWN_MIGRATIONS=1 → no throw", () => {
+    const db = makeMigrationsTable();
+    db.prepare("INSERT INTO _migrations (name) VALUES (?)").run(
+      "099_future_with_hatch",
+    );
+    process.env.BRAINSTORM_DB_ALLOW_UNKNOWN_MIGRATIONS = "1";
+    const known = new Set(["001_a"]);
+    expect(() => assertNoUnknownMigrations(db, known)).not.toThrow();
+  });
+
+  it("any other env value does NOT trigger the escape hatch", () => {
+    const db = makeMigrationsTable();
+    db.prepare("INSERT INTO _migrations (name) VALUES (?)").run(
+      "099_future_strict",
+    );
+    process.env.BRAINSTORM_DB_ALLOW_UNKNOWN_MIGRATIONS = "true";
+    const known = new Set(["001_a"]);
+    expect(() => assertNoUnknownMigrations(db, known)).toThrow(
+      /099_future_strict/,
+    );
+  });
+
+  it("multiple unknown rows are all listed in the error message", () => {
+    const db = makeMigrationsTable();
+    db.prepare("INSERT INTO _migrations (name) VALUES (?), (?), (?)").run(
+      "098_a_future",
+      "099_b_future",
+      "100_c_future",
+    );
+    const known = new Set<string>();
+    let caught: unknown;
+    try {
+      assertNoUnknownMigrations(db, known);
+    } catch (err) {
+      caught = err;
+    }
+    const msg = (caught as Error).message;
+    expect(msg).toContain("098_a_future");
+    expect(msg).toContain("099_b_future");
+    expect(msg).toContain("100_c_future");
+  });
+
+  it("real production path: getTestDb works without unknown migrations", () => {
+    // Sanity that the guard doesn't break the happy path.
+    const db = getTestDb();
+    const count = db.prepare("SELECT COUNT(*) as n FROM _migrations").get() as {
+      n: number;
+    };
+    expect(count.n).toBeGreaterThan(0);
+  });
+});

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -91,6 +91,60 @@ export function cleanupOldRecords(db: Database.Database): void {
   }
 }
 
+/**
+ * Detects the "newer DB + older CLI" downgrade scenario.
+ *
+ * Migrations are forward-only by design. If a user runs 0.14 (which
+ * applies new migrations to ~/.brainstorm/brainstorm.db), then
+ * downgrades to 0.13, the older code sees a DB with rows in
+ * _migrations it doesn't recognise. Older code reading the new
+ * schema can silently mishandle NOT NULL columns it doesn't populate.
+ *
+ * Fail-fast at startup. Pointer to the rollback runbook.
+ * Escape hatch via BRAINSTORM_DB_ALLOW_UNKNOWN_MIGRATIONS=1 for
+ * operators restoring from a backup who know what they're doing.
+ */
+/** @internal — exported for testing. Production code should not call this
+ *  directly; runMigrations() invokes it at the right moment. */
+export function assertNoUnknownMigrations(
+  db: Database.Database,
+  knownNames: Set<string>,
+): void {
+  const rows = db.prepare("SELECT name FROM _migrations").all() as Array<{
+    name: string;
+  }>;
+  const unknown = rows.map((r) => r.name).filter((n) => !knownNames.has(n));
+  if (unknown.length === 0) return;
+
+  if (process.env.BRAINSTORM_DB_ALLOW_UNKNOWN_MIGRATIONS === "1") {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[db] BRAINSTORM_DB_ALLOW_UNKNOWN_MIGRATIONS=1 — proceeding with unknown migrations: ${unknown.join(", ")}`,
+    );
+    return;
+  }
+
+  throw new Error(
+    [
+      "Database has migrations this CLI doesn't recognise:",
+      `  ${unknown.join(", ")}`,
+      "",
+      "This usually means you downgraded the CLI from a newer version that",
+      "wrote schema changes to ~/.brainstorm/brainstorm.db. Older code",
+      "reading those tables can silently corrupt rows.",
+      "",
+      "Options:",
+      "  1. Upgrade back to the version that wrote the migration",
+      "     (or any newer version that has it).",
+      "  2. Restore the pre-upgrade DB backup; see",
+      "     docs/runbooks/rollback-published-version.md.",
+      "  3. Set BRAINSTORM_DB_ALLOW_UNKNOWN_MIGRATIONS=1 to proceed anyway",
+      "     (safe only when you've verified the migration was additive and",
+      "     your workflow doesn't touch the affected tables).",
+    ].join("\n"),
+  );
+}
+
 function runMigrations(db: Database.Database): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS _migrations (
@@ -99,6 +153,9 @@ function runMigrations(db: Database.Database): void {
       applied_at INTEGER NOT NULL DEFAULT (unixepoch())
     );
   `);
+
+  const knownNames = new Set(MIGRATIONS.map((m) => m.name));
+  assertNoUnknownMigrations(db, knownNames);
 
   const applied = new Set(
     db


### PR DESCRIPTION
## Summary

Closes the SQLite slice of the v15 carry-forward **state rollback** named in \`docs/assessment-audit-v15.md\`.

**Scenario**: user runs 0.14 (which applies new migrations to \`~/.brainstorm/brainstorm.db\`), then \`npm install -g @brainst0rm/cli@0.13\` to roll back. Older code reading the new schema can silently mishandle NOT NULL columns it doesn't populate. Until now there was no guard — older CLI silently proceeded.

## Implementation

\`assertNoUnknownMigrations()\` runs as the first step of \`runMigrations()\` and throws if \`_migrations\` contains any name not in the compiled-in \`MIGRATIONS\` list. Error message:
- Lists the unknown migrations
- Points to \`docs/runbooks/rollback-published-version.md\`
- Documents the escape hatch (\`BRAINSTORM_DB_ALLOW_UNKNOWN_MIGRATIONS=1\` for operators restoring from a backup)

## Tests

7 in \`downgrade-guard.test.ts\` — fresh install, matched CLI, unknown row (verifies error message content), escape hatch on/off (strict literal "1" only), multiple unknowns, production path sanity via \`getTestDb\`.

## Carry-forward

Vault state rollback remains as a separate piece of P8d (different package, different blast radius).

## Test plan

- [x] \`npx turbo run test --filter=@brainst0rm/db\` — all tests pass
- [x] Guard exits cleanly on the happy path (\`getTestDb\` works)
- [x] Error message contains the actual unknown migration names + runbook pointer
- [x] Escape hatch only accepts literal "1", not "true"/"yes"

🤖 Generated with [Claude Code](https://claude.com/claude-code)