### PR TITLE
fix(ci): exclude desktop/web/image-builder from npm-publish build

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm ci
 
       - name: Build all packages
-        run: npx turbo run build
+        run: npx turbo run build --filter='!@brainst0rm/desktop' --filter='!@brainst0rm/web' --filter='!@brainst0rm/image-builder'
 
       - name: Run tests
         run: npx turbo run test --filter=@brainst0rm/core --filter=@brainst0rm/tools


### PR DESCRIPTION
Publish workflow ran `turbo build` without filters; `@brainst0rm/desktop` (Electron app) failed to build, blocking publish of every other package. Desktop is not published to npm — main CI already filters it out. Mirror the exclusion here.

Closes v0.14.1 publish failure: https://github.com/justinjilg/brainstorm/actions/runs/25959351343

After merge: re-tag v0.14.1 (delete + recreate) to retrigger publish workflow.