### PR TITLE
fix(ci): drop @brainst0rm/web filter — apps/web is gitignored

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm ci
 
       - name: Build all packages
-        run: npx turbo run build --filter='!@brainst0rm/desktop' --filter='!@brainst0rm/web' --filter='!@brainst0rm/image-builder'
+        run: npx turbo run build --filter='!@brainst0rm/desktop'
 
       - name: Run tests
         run: npx turbo run test --filter=@brainst0rm/core --filter=@brainst0rm/tools


### PR DESCRIPTION
apps/web is gitignored on the public repo (Vercel-linked marketing site source isn't checked in). On CI's fresh checkout the directory doesn't exist, so turbo errors with 'No package found' when given a filter for it. Only @brainst0rm/desktop needs the exclusion.