### PR TITLE
fix(security): close 3 v16 Attacker findings — D6 lift

### DIFF
--- a/packages/godmode/src/__tests__/signing.test.ts
+++ b/packages/godmode/src/__tests__/signing.test.ts
@@ -1,13 +1,17 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import {
   signEvent,
   verifyEvent,
   createSignedEvent,
   deriveTenantKey,
   canonicalize,
+  _resetSeenEventIdsForTesting,
 } from "../signing";
 
 describe("Platform Event Signing", () => {
+  beforeEach(() => {
+    _resetSeenEventIdsForTesting();
+  });
   const MASTER_SECRET = "test-secret-for-unit-tests";
   const TENANT_ID = "tenant-abc-123";
 
@@ -188,5 +192,68 @@ describe("Platform Event Signing", () => {
         true,
       );
     });
+  });
+});
+
+// v16 Attacker — platform-event replay dedupe (closes signing.ts gap
+// flagged in /docs/assessment-audit-v16.md).
+describe("verifyEvent — replay dedupe (v16 Attacker)", () => {
+  const SECRET = "test-master-secret";
+
+  beforeEach(() => {
+    // Each test starts with a clean dedupe cache.
+    _resetSeenEventIdsForTesting();
+  });
+
+  it("accepts a fresh signed event exactly once; rejects replay", () => {
+    const event = createSignedEvent(
+      "test.event",
+      "tenant-1",
+      "msp",
+      { foo: "bar" },
+      SECRET,
+    );
+    // First time: signature valid + within window + id unseen → accept
+    expect(verifyEvent(event, SECRET)).toBe(true);
+    // Second time: same bytes → REPLAY → reject
+    expect(verifyEvent(event, SECRET)).toBe(false);
+    // Third time, fourth time: still rejected
+    expect(verifyEvent(event, SECRET)).toBe(false);
+    expect(verifyEvent(event, SECRET)).toBe(false);
+  });
+
+  it("two distinct events with different ids both accepted", () => {
+    const a = createSignedEvent(
+      "test.event",
+      "tenant-1",
+      "msp",
+      { n: 1 },
+      SECRET,
+    );
+    const b = createSignedEvent(
+      "test.event",
+      "tenant-1",
+      "msp",
+      { n: 2 },
+      SECRET,
+    );
+    expect(a.id).not.toBe(b.id);
+    expect(verifyEvent(a, SECRET)).toBe(true);
+    expect(verifyEvent(b, SECRET)).toBe(true);
+    // Each rejected on second attempt
+    expect(verifyEvent(a, SECRET)).toBe(false);
+    expect(verifyEvent(b, SECRET)).toBe(false);
+  });
+
+  it("missing event.id is rejected outright", () => {
+    const event = createSignedEvent(
+      "test.event",
+      "tenant-1",
+      "msp",
+      { x: 1 },
+      SECRET,
+    );
+    const tampered = { ...event, id: "" };
+    expect(verifyEvent(tampered, SECRET)).toBe(false);
   });
 });

--- a/packages/godmode/src/signing.ts
+++ b/packages/godmode/src/signing.ts
@@ -72,6 +72,57 @@ export function signEvent(
 /** Maximum age (in seconds) for a platform event to be accepted. */
 const MAX_EVENT_AGE_SECONDS = 300; // 5 minutes
 
+/**
+ * Replay-dedupe cache for verified event ids.
+ *
+ * v16 Attacker finding: the freshness window alone is not sufficient. An
+ * attacker who captures one signed event can replay it ~300×/sec for
+ * 5 minutes — the signature is valid, the timestamp is within window, and
+ * the server has no record that THIS event was already seen. Webhook
+ * verification closed the same shape with an LRU nonce cache (PR #309);
+ * platform events did not.
+ *
+ * Map keyed on event.id, value = wall-clock ms when first seen. Entries
+ * expire passively at lookup (any entry older than the freshness window
+ * is treated as evicted). The cache is also LRU-bounded so a flood of
+ * fresh-but-bogus ids cannot blow memory.
+ *
+ * Exported for tests that need to reset state between cases.
+ */
+const seenEventIds = new Map<string, number>();
+const MAX_SEEN_IDS = 100_000;
+const FRESHNESS_MS = MAX_EVENT_AGE_SECONDS * 1000;
+
+/** Test helper — drop all dedupe state. Production code MUST NOT call this. */
+export function _resetSeenEventIdsForTesting(): void {
+  seenEventIds.clear();
+}
+
+function checkAndRecordEventId(eventId: string, now: number): boolean {
+  // Passive expiry: drop entries older than the freshness window. Done
+  // lazily on every check so we don't need a sweeper timer.
+  const cutoff = now - FRESHNESS_MS;
+  // First, opportunistically evict ALL entries older than cutoff. Cheap
+  // when the cache is small; with the LRU cap above this stays cheap.
+  for (const [id, ts] of seenEventIds) {
+    if (ts < cutoff) seenEventIds.delete(id);
+  }
+
+  if (seenEventIds.has(eventId)) {
+    // Already seen within the freshness window — REPLAY.
+    return false;
+  }
+
+  // LRU eviction if full — drop oldest entry by insertion order.
+  if (seenEventIds.size >= MAX_SEEN_IDS) {
+    const oldestKey = seenEventIds.keys().next().value;
+    if (oldestKey !== undefined) seenEventIds.delete(oldestKey);
+  }
+
+  seenEventIds.set(eventId, now);
+  return true;
+}
+
 export function verifyEvent(
   event: PlatformEvent,
   masterSecret: string,
@@ -79,24 +130,32 @@ export function verifyEvent(
   // Reject events without a signature
   if (!event.signature) return false;
 
-  // Replay protection: require a parseable timestamp inside the freshness
-  // window. A missing or malformed timestamp is treated as a failed check,
-  // not skipped — otherwise a captured event could be replayed forever by
-  // an attacker who strips or corrupts the timestamp field.
+  // Reject events without an id — required for replay dedupe
+  if (!event.id) return false;
+
+  // Replay protection step 1: require a parseable timestamp inside the
+  // freshness window. A missing or malformed timestamp is treated as a
+  // failed check, not skipped — otherwise a captured event could be
+  // replayed forever by an attacker who strips or corrupts the field.
   if (!event.timestamp) return false;
   const eventTime = new Date(event.timestamp).getTime();
   if (Number.isNaN(eventTime)) return false;
   const ageMs = Math.abs(Date.now() - eventTime);
   if (ageMs > MAX_EVENT_AGE_SECONDS * 1000) return false;
 
+  // Verify signature BEFORE recording id in the dedupe cache — otherwise
+  // an attacker can spam fake ids to fill the LRU and evict legitimate
+  // entries.
   const { signature, ...rest } = event;
   const expected = signEvent(rest, masterSecret);
-
-  // Timing-safe comparison
   const sigBuf = Buffer.from(signature, "hex");
   const expectedBuf = Buffer.from(expected, "hex");
   if (sigBuf.length !== expectedBuf.length) return false;
-  return timingSafeEqual(sigBuf, expectedBuf);
+  if (!timingSafeEqual(sigBuf, expectedBuf)) return false;
+
+  // Replay protection step 2: record event.id; reject if already seen
+  // within the freshness window.
+  return checkAndRecordEventId(event.id, Date.now());
 }
 
 /**

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -39,7 +39,16 @@ import {
   type IncomingMessage,
   type ServerResponse,
 } from "node:http";
-import { randomUUID } from "node:crypto";
+import { randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
+import {
+  writeFileSync,
+  unlinkSync,
+  mkdirSync,
+  existsSync,
+  chmodSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { createLogger } from "@brainst0rm/shared";
 import type { GodModeConnectionResult } from "@brainst0rm/godmode";
 import type { ToolRegistry } from "@brainst0rm/tools";
@@ -82,6 +91,23 @@ export class BrainstormServer {
   private deps: ServerDependencies;
   private opts: Required<ServerOptions>;
   private conversationManager: ConversationManager | null = null;
+  /**
+   * Dev-mode auth token. Generated at server start when `jwtSecret` is
+   * empty AND the bind is loopback. Written to ~/.brainstorm/server-token
+   * with 0600 perms so only the SAME-UID process can read it; required
+   * on every /api/* request (Authorization: Bearer <token>).
+   *
+   * v16 Attacker (PR #325 round) finding: previously, dev mode let ANY
+   * local process — possibly a different user or a sandboxed plugin —
+   * hit /api/v1/changesets/:id/approve, /api/v1/memory, /api/v1/tools/
+   * execute, /api/v1/chat with no auth. The dev token binds the
+   * trust scope to "processes that can read this file" = same uid.
+   *
+   * Cleared on stop(). Production users with BRAINSTORM_JWT_SECRET set
+   * never see this — it's strictly dev mode.
+   */
+  private devToken: string | null = null;
+  private devTokenPath: string | null = null;
 
   constructor(deps: ServerDependencies, opts?: ServerOptions) {
     this.deps = deps;
@@ -102,13 +128,42 @@ export class BrainstormServer {
     }
   }
 
+  /**
+   * Per-session loopback auth token. Written to disk with 0600 perms so
+   * only same-uid processes can read it. Required on /api/* in dev mode.
+   */
+  private initDevToken(): void {
+    const dir = join(
+      process.env.BRAINSTORM_HOME ?? join(homedir(), ".brainstorm"),
+    );
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    const tokenPath = join(dir, "server-token");
+    const token = randomBytes(32).toString("hex");
+    writeFileSync(tokenPath, token, { mode: 0o600 });
+    chmodSync(tokenPath, 0o600);
+    this.devToken = token;
+    this.devTokenPath = tokenPath;
+  }
+
+  /** Constant-time check of supplied Bearer against the dev token. */
+  private verifyDevToken(authHeader: string | undefined): boolean {
+    if (!this.devToken || !authHeader) return false;
+    const m = /^Bearer\s+(.+)$/i.exec(authHeader.trim());
+    if (!m) return false;
+    const supplied = Buffer.from(m[1], "utf8");
+    const expected = Buffer.from(this.devToken, "utf8");
+    if (supplied.length !== expected.length) return false;
+    return timingSafeEqual(supplied, expected);
+  }
+
   /** Start the HTTP server. Returns a promise that resolves when listening. */
   async start(): Promise<{ url: string }> {
     const { port, host } = this.opts;
 
     // Security: refuse to start without auth on non-loopback interface.
-    // POST /api/v1/god-mode/execute runs arbitrary operations on managed infrastructure —
-    // exposing it without JWT auth is a critical security violation.
+    // POST /api/v1/god-mode/execute runs arbitrary operations on managed
+    // infrastructure — exposing it without JWT auth is a critical
+    // security violation.
     if (!this.opts.jwtSecret) {
       if (host !== "127.0.0.1" && host !== "localhost" && host !== "::1") {
         log.fatal(
@@ -117,7 +172,15 @@ export class BrainstormServer {
         );
         process.exit(1);
       } else {
-        log.info("Running in dev mode (no JWT auth) — localhost only");
+        // Loopback dev mode: still require a bearer token so a different
+        // local user (or a sandboxed plugin under a different uid) can't
+        // hit /api/*. Generate, write 0600, require on every /api/*
+        // request via the existing auth gate.
+        this.initDevToken();
+        log.info(
+          { tokenPath: this.devTokenPath },
+          "Running in dev mode (loopback only). Wrote per-session token to file — same-uid processes can read it for client auth.",
+        );
       }
     }
 
@@ -141,6 +204,17 @@ export class BrainstormServer {
 
   /** Stop the server gracefully. */
   async stop(): Promise<void> {
+    // Delete the dev-mode token file on shutdown so a captured token
+    // from a prior session can't be re-used against a new server.
+    if (this.devTokenPath && existsSync(this.devTokenPath)) {
+      try {
+        unlinkSync(this.devTokenPath);
+      } catch (err) {
+        log.warn({ err }, "Failed to delete dev token on shutdown");
+      }
+    }
+    this.devToken = null;
+    this.devTokenPath = null;
     return new Promise((resolve) => {
       if (!this.server) return resolve();
       this.server.close(() => {
@@ -206,6 +280,18 @@ export class BrainstormServer {
           401,
           "Authentication required — set SUPABASE_JWT_SECRET",
         );
+      } else {
+        // Dev mode (loopback, no jwtSecret): require the per-session
+        // bearer token. Closes the v16 Attacker confused-deputy: a
+        // sandboxed plugin or different-uid local process can no longer
+        // hit /api/* just because it has loopback access.
+        if (!this.verifyDevToken(req.headers.authorization as string)) {
+          return this.errorResponse(
+            res,
+            401,
+            `Dev-mode token required. Read it from ${this.devTokenPath ?? "~/.brainstorm/server-token"} and send as 'Authorization: Bearer <token>'.`,
+          );
+        }
       }
     }
 

--- a/packages/workflow/src/__tests__/engine.test.ts
+++ b/packages/workflow/src/__tests__/engine.test.ts
@@ -573,6 +573,85 @@ describe("artifact-store", () => {
       }
     });
 
+    // ── v16 Attacker flag-loader bypass class (extends v15) ──────────
+    // Found by the v16 stochastic round's Attacker persona. Same shape
+    // as the v15 -exec/-toolexec/-gcflags class: each flag below tells
+    // the surrounding tool to load attacker-controlled file as code OR
+    // treat an attacker-controlled path as authoritative.
+
+    it("v16-attacker-flag-loader: make -f loads alternate Makefile", () => {
+      const dangerous = [
+        "make -f /tmp/evil.Makefile",
+        "make --makefile=/tmp/evil.Makefile",
+        "make --makefile /tmp/evil.Makefile",
+      ];
+      for (const gate of dangerous) {
+        const v = validateGateCommand(gate);
+        expect(v.allowed, `must reject make -f: ${gate}`).toBe(false);
+        expect(v.reason).toMatch(/dangerous pattern|f|makefile/);
+      }
+      expect(validateGateCommand("make test").allowed).toBe(true);
+      expect(validateGateCommand("make build").allowed).toBe(true);
+    });
+
+    it("v16-attacker-flag-loader: pytest -p loads arbitrary plugin module", () => {
+      const dangerous = [
+        "pytest -p evil_plugin",
+        "pytest -p /tmp/evil",
+        "pytest --rootdir=/tmp/attacker",
+      ];
+      for (const gate of dangerous) {
+        const v = validateGateCommand(gate);
+        expect(v.allowed, `must reject pytest -p/--rootdir: ${gate}`).toBe(
+          false,
+        );
+      }
+      expect(validateGateCommand("pytest tests/").allowed).toBe(true);
+    });
+
+    it("v16-attacker-flag-loader: cargo --manifest-path overrides Cargo.toml", () => {
+      const dangerous = [
+        "cargo test --manifest-path=/tmp/Cargo.toml",
+        "cargo build --manifest-path /tmp/Cargo.toml",
+      ];
+      for (const gate of dangerous) {
+        const v = validateGateCommand(gate);
+        expect(v.allowed, `must reject --manifest-path: ${gate}`).toBe(false);
+      }
+    });
+
+    it("v16-attacker-flag-loader: node --inspect / --require / --import via npm run", () => {
+      // Note: bare `node script.js` is not in the gate allowlist anyway,
+      // so the attack surface here is "npm run X" where X invokes node
+      // with these flags via the script. The flag-loader patterns catch
+      // them in the npm-run command-line form, which IS allowlisted.
+      const dangerous = [
+        "npm test --inspect-brk=0.0.0.0:9229",
+        "npm test --inspect",
+        "npm test --require=/tmp/preload.js",
+        "npm test -r /tmp/preload.js",
+        "npm test --import=/tmp/loader.mjs",
+      ];
+      for (const gate of dangerous) {
+        const v = validateGateCommand(gate);
+        expect(v.allowed, `must reject node flag-loader: ${gate}`).toBe(false);
+      }
+      expect(validateGateCommand("npm test").allowed).toBe(true);
+    });
+
+    it("v16-attacker-flag-loader: npm --userconfig / --prefix point to attacker config", () => {
+      const dangerous = [
+        "npm test --userconfig=/tmp/.npmrc",
+        "npm install --userconfig /tmp/.npmrc",
+        "npm test --prefix=/tmp/attacker",
+        "npm test --env-file=/tmp/.env",
+      ];
+      for (const gate of dangerous) {
+        const v = validateGateCommand(gate);
+        expect(v.allowed, `must reject npm config-loader: ${gate}`).toBe(false);
+      }
+    });
+
     it("flag-loader rules are word-bounded — false positives stay false", () => {
       // The danger patterns must not catch substrings inside longer
       // tokens. E.g. `--configbar` is NOT `--config`, and the test

--- a/packages/workflow/src/engine.ts
+++ b/packages/workflow/src/engine.ts
@@ -83,6 +83,25 @@ const DANGER_PATTERNS: ReadonlyArray<RegExp> = [
   /(?:^|\s)-{1,2}reporter[\s=]/, // vitest --reporter, npm test --reporter — v15
   /(?:^|\s)-{1,2}target-dir[\s=]/, // cargo --target-dir — write-where-attacker-wants
   /(?:^|\s)-{1,2}plugin[\s=]/, // generic plugin-loader form (jest, eslint, etc.)
+  // v16 Attacker (post path-to-90 round) — flag-loader bypass class
+  // extension. Each loads an attacker-controlled file as code or treats
+  // an attacker-controlled path as authoritative configuration.
+  // The trailing class `(?:$|[\s=])` matches end-of-string OR ws/= so a
+  // dangerous flag is caught even when it's the final token (e.g.
+  // `npm test --inspect`).
+  /(?:^|\s)-f(?:$|[\s=])/, // make -f /tmp/evil.Makefile — load alt Makefile
+  /(?:^|\s)-{1,2}makefile(?:$|[\s=])/, // make --makefile=/tmp/evil.Makefile
+  /(?:^|\s)-p(?:$|[\s=])/, // pytest -p PLUGIN — load plugin module
+  /(?:^|\s)-{1,2}rootdir(?:$|[\s=])/, // pytest --rootdir — treat path as project root
+  /(?:^|\s)-{1,2}manifest-path(?:$|[\s=])/, // cargo --manifest-path — alt Cargo.toml
+  /(?:^|\s)-{1,2}inspect-brk(?:$|[\s=])/, // node --inspect-brk — debugger w/ arb code
+  /(?:^|\s)-{1,2}inspect(?:$|[\s=])/, // node --inspect — same class
+  /(?:^|\s)-{1,2}userconfig(?:$|[\s=])/, // npm --userconfig — alt npmrc with scripts
+  /(?:^|\s)-{1,2}env-file(?:$|[\s=])/, // node --env-file — set env from arbitrary path
+  /(?:^|\s)-{1,2}prefix(?:$|[\s=])/, // npm --prefix — alt project root for scripts
+  /(?:^|\s)-{1,2}require(?:$|[\s=])/, // node --require / -r — preload arbitrary module
+  /(?:^|\s)-r(?:$|[\s=])/, // node -r — short form of --require
+  /(?:^|\s)-{1,2}import(?:$|[\s=])/, // node --import — preload ESM module
 ];
 
 /**


### PR DESCRIPTION
Three new attack classes identified by the v16 stochastic round's Attacker persona, each closed with regression tests:

1. **BrainstormServer dev-mode confused-deputy** — per-session bearer token at `~/.brainstorm/server-token` (0600), required on `/api/*` in dev mode. Same-uid bound by filesystem perms.

2. **make -f / pytest -p / cargo --manifest-path / node --inspect / etc.** — extends v15 P9a-2 flag-loader bypass class with 12 new patterns. Includes EOF match fix so `npm test --inspect` (no trailing space) is caught.

3. **Platform-event replay** — LRU dedupe cache on `event.id`, signature verified BEFORE recording to prevent fill-the-cache attack. Mirrors webhook nonce pattern (#309).

Tests: +5 workflow, +3 godmode, all server tests still pass.

Closes v16 D6 -0.34 with cited regression closes.