### PR TITLE
fix(changesets): correct repo owner from justinpbarnett to justinjilg

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.3/schema.json",
   "changelog": [
     "@changesets/changelog-github",
-    { "repo": "justinpbarnett/brainstorm" }
+    { "repo": "justinjilg/brainstorm" }
   ],
   "commit": false,
   "fixed": [],


### PR DESCRIPTION
## Summary

One-character fix to `.changeset/config.json`. The Release (Changesets) workflow has been failing on every push to main since the queued changesets from PRs #341, #342, #343 hit it — `@changesets/changelog-github` tries to fetch PR/issue metadata from `justinpbarnett/brainstorm` to render the changelog, that repo doesn't exist, and the workflow dies before the Release PR can be opened.

The real repo is `justinjilg/brainstorm` (matches `package.json` `repository.url` and `git remote`).

## Test plan

- [x] Diff is a single identifier; safe to merge with admin
- [ ] After merge: next push to main triggers the Release workflow, "Create Release PR or Publish" step should succeed and open a versioned Release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)