### PR TITLE
feat(P0): brainstorm status — ecosystem-wide health view

### DIFF
--- a/packages/cli/src/__tests__/status.test.ts
+++ b/packages/cli/src/__tests__/status.test.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { __test } from "../commands/status.js";
+import {
+  PRODUCTS,
+  fetchEcosystemStatuses,
+  renderEcosystemTable,
+  __test,
+} from "../commands/status.js";
 
-const { fetchProductStatus, formatStatusBadge, PRODUCTS } = __test;
+const { fetchProductStatus, formatStatusBadge } = __test;
 
-describe("brainstorm status", () => {
+describe("brainstorm ecosystem/status helpers", () => {
   let originalFetch: typeof globalThis.fetch;
   let originalEnv: Record<string, string | undefined>;
 
@@ -83,7 +88,7 @@ describe("brainstorm status", () => {
     expect(status.product).toBe("msp");
     expect(status.version).toBe("1.0.0");
     expect(status.toolCount).toBe(1);
-    expect(status.edgeProtocolImplemented).toBe(true); // 400 != 404 → route exists
+    expect(status.edgeProtocolImplemented).toBe(true);
   });
 
   it("flags edge protocol as missing when probe returns 404", async () => {
@@ -111,6 +116,27 @@ describe("brainstorm status", () => {
     expect(status.edgeProtocolImplemented).toBe(false);
   });
 
+  it("respects tool_count when server provides it instead of tools array", async () => {
+    process.env.BRAINSTORM_GTM_API_KEY = "k";
+    globalThis.fetch = vi.fn((url: string | URL | Request) => {
+      const u = String(url);
+      if (u.endsWith("/health")) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ status: "ok" }), { status: 200 }),
+        );
+      }
+      if (u.endsWith("/api/v1/god-mode/tools")) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ tool_count: 42 }), { status: 200 }),
+        );
+      }
+      return Promise.resolve(new Response("{}", { status: 404 }));
+    }) as typeof globalThis.fetch;
+    const target = PRODUCTS.find((p) => p.id === "gtm")!;
+    const status = await fetchProductStatus(target);
+    expect(status.toolCount).toBe(42);
+  });
+
   it("skips tools fetch when API key is unset", async () => {
     delete process.env.BRAINSTORM_GTM_API_KEY;
     const fetchSpy = vi.fn((url: string | URL | Request) => {
@@ -127,10 +153,50 @@ describe("brainstorm status", () => {
     const status = await fetchProductStatus(target);
     expect(status.apiKeyConfigured).toBe(false);
     expect(status.toolCount).toBe(null);
-    // /health was called; god-mode/tools was NOT
     const calls = fetchSpy.mock.calls.map((c) => String(c[0]));
     expect(calls.some((c) => c.endsWith("/health"))).toBe(true);
     expect(calls.some((c) => c.endsWith("/api/v1/god-mode/tools"))).toBe(false);
+  });
+
+  it("fetchEcosystemStatuses honors --product filter", async () => {
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ status: "ok" }), { status: 200 }),
+      ),
+    ) as typeof globalThis.fetch;
+    const single = await fetchEcosystemStatuses("br");
+    expect(single).toBeDefined();
+    expect(single!.length).toBe(1);
+    expect(single![0]!.id).toBe("br");
+  });
+
+  it("fetchEcosystemStatuses returns undefined for unknown product id", async () => {
+    globalThis.fetch = vi.fn() as typeof globalThis.fetch;
+    const result = await fetchEcosystemStatuses("nonexistent");
+    expect(result).toBeUndefined();
+  });
+
+  it("renderEcosystemTable produces tabular output", () => {
+    const rendered = renderEcosystemTable([
+      {
+        id: "msp",
+        displayName: "BrainstormMSP",
+        baseUrl: "https://example.com",
+        apiKeyConfigured: true,
+        reachable: true,
+        healthStatus: "healthy",
+        product: null,
+        version: null,
+        toolCount: 5,
+        edgeProtocolImplemented: true,
+        latencyMs: 42,
+        error: null,
+      },
+    ]);
+    expect(rendered).toContain("BrainstormMSP");
+    expect(rendered).toContain("✓ ok");
+    expect(rendered).toContain("42ms");
+    expect(rendered).toContain("yes");
   });
 
   it("status badge formats correctly", () => {

--- a/packages/cli/src/__tests__/status.test.ts
+++ b/packages/cli/src/__tests__/status.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { __test } from "../commands/status.js";
+
+const { fetchProductStatus, formatStatusBadge, PRODUCTS } = __test;
+
+describe("brainstorm status", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let originalEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    process.env = { ...originalEnv } as NodeJS.ProcessEnv;
+  });
+
+  it("known products array covers all 5", () => {
+    expect(PRODUCTS.map((p) => p.id).sort()).toEqual([
+      "br",
+      "gtm",
+      "msp",
+      "shield",
+      "vm",
+    ]);
+  });
+
+  it("MSP and VM declare hasEdgeProtocol; others do not", () => {
+    expect(PRODUCTS.find((p) => p.id === "msp")?.hasEdgeProtocol).toBe(true);
+    expect(PRODUCTS.find((p) => p.id === "vm")?.hasEdgeProtocol).toBe(true);
+    expect(PRODUCTS.find((p) => p.id === "br")?.hasEdgeProtocol).toBe(false);
+    expect(PRODUCTS.find((p) => p.id === "gtm")?.hasEdgeProtocol).toBe(false);
+    expect(PRODUCTS.find((p) => p.id === "shield")?.hasEdgeProtocol).toBe(
+      false,
+    );
+  });
+
+  it("reports unreachable when fetch fails", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    const target = PRODUCTS[0]!;
+    const status = await fetchProductStatus(target);
+    expect(status.reachable).toBe(false);
+    expect(status.error).toContain("ECONNREFUSED");
+    expect(status.latencyMs).toBe(null);
+  });
+
+  it("parses healthy /health response", async () => {
+    process.env.BRAINSTORM_MSP_API_KEY = "br_live_test";
+    globalThis.fetch = vi.fn((url: string | URL | Request) => {
+      const u = String(url);
+      if (u.endsWith("/health")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              status: "healthy",
+              product: "msp",
+              version: "1.0.0",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      if (u.endsWith("/api/v1/god-mode/tools")) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ tools: [{ name: "msp.foo" }] }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (u.endsWith("/api/v1/edge/heartbeat")) {
+        return Promise.resolve(new Response("{}", { status: 400 }));
+      }
+      return Promise.resolve(new Response("{}", { status: 404 }));
+    }) as typeof globalThis.fetch;
+
+    const target = PRODUCTS.find((p) => p.id === "msp")!;
+    const status = await fetchProductStatus(target);
+    expect(status.reachable).toBe(true);
+    expect(status.healthStatus).toBe("healthy");
+    expect(status.product).toBe("msp");
+    expect(status.version).toBe("1.0.0");
+    expect(status.toolCount).toBe(1);
+    expect(status.edgeProtocolImplemented).toBe(true); // 400 != 404 → route exists
+  });
+
+  it("flags edge protocol as missing when probe returns 404", async () => {
+    process.env.BRAINSTORM_VM_API_KEY = "k";
+    globalThis.fetch = vi.fn((url: string | URL | Request) => {
+      const u = String(url);
+      if (u.endsWith("/health")) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ status: "healthy" }), { status: 200 }),
+        );
+      }
+      if (u.endsWith("/api/v1/edge/heartbeat")) {
+        return Promise.resolve(new Response("not found", { status: 404 }));
+      }
+      if (u.endsWith("/api/v1/god-mode/tools")) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ tools: [] }), { status: 200 }),
+        );
+      }
+      return Promise.resolve(new Response("{}", { status: 404 }));
+    }) as typeof globalThis.fetch;
+
+    const target = PRODUCTS.find((p) => p.id === "vm")!;
+    const status = await fetchProductStatus(target);
+    expect(status.edgeProtocolImplemented).toBe(false);
+  });
+
+  it("skips tools fetch when API key is unset", async () => {
+    delete process.env.BRAINSTORM_GTM_API_KEY;
+    const fetchSpy = vi.fn((url: string | URL | Request) => {
+      const u = String(url);
+      if (u.endsWith("/health")) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ status: "ok" }), { status: 200 }),
+        );
+      }
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    });
+    globalThis.fetch = fetchSpy as typeof globalThis.fetch;
+    const target = PRODUCTS.find((p) => p.id === "gtm")!;
+    const status = await fetchProductStatus(target);
+    expect(status.apiKeyConfigured).toBe(false);
+    expect(status.toolCount).toBe(null);
+    // /health was called; god-mode/tools was NOT
+    const calls = fetchSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((c) => c.endsWith("/health"))).toBe(true);
+    expect(calls.some((c) => c.endsWith("/api/v1/god-mode/tools"))).toBe(false);
+  });
+
+  it("status badge formats correctly", () => {
+    expect(
+      formatStatusBadge({
+        id: "x",
+        displayName: "X",
+        baseUrl: "",
+        apiKeyConfigured: true,
+        reachable: true,
+        healthStatus: "healthy",
+        product: null,
+        version: null,
+        toolCount: null,
+        edgeProtocolImplemented: null,
+        latencyMs: 10,
+        error: null,
+      }),
+    ).toBe("✓ ok");
+    expect(
+      formatStatusBadge({
+        id: "x",
+        displayName: "X",
+        baseUrl: "",
+        apiKeyConfigured: true,
+        reachable: false,
+        healthStatus: null,
+        product: null,
+        version: null,
+        toolCount: null,
+        edgeProtocolImplemented: null,
+        latencyMs: null,
+        error: "boom",
+      }),
+    ).toBe("✗ unreachable");
+  });
+});

--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -401,6 +401,11 @@ program
 import { registerHarnessCommands } from "../commands/harness.js";
 registerHarnessCommands(program);
 
+// `brainstorm status` — ecosystem-wide health across MSP, BR, GTM, VM, Shield.
+// See packages/cli/src/commands/status.ts; P0/Wk1 #59 of radiant-petting-kitten.
+import { registerStatusCommand } from "../commands/status.js";
+registerStatusCommand(program);
+
 program
   .command("eval")
   .description("Run capability evaluation probes against a model")

--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -401,10 +401,12 @@ program
 import { registerHarnessCommands } from "../commands/harness.js";
 registerHarnessCommands(program);
 
-// `brainstorm status` — ecosystem-wide health across MSP, BR, GTM, VM, Shield.
-// See packages/cli/src/commands/status.ts; P0/Wk1 #59 of radiant-petting-kitten.
-import { registerStatusCommand } from "../commands/status.js";
-registerStatusCommand(program);
+// Per-product status fetcher used by the `ecosystem` / `status` command below.
+// Lives in commands/status.ts so the rendering + fetch logic stays unit-testable.
+import {
+  fetchEcosystemStatuses,
+  renderEcosystemTable,
+} from "../commands/status.js";
 
 program
   .command("eval")
@@ -6710,7 +6712,30 @@ program
   .description(
     "Show full ecosystem status — all products, tools, auth, connectivity",
   )
-  .action(async () => {
+  .option("--json", "Output as JSON (skips auth / MCP narrative)")
+  .option("--product <id>", "Limit to one product id (msp|br|gtm|vm|shield)")
+  .action(async (opts: { json?: boolean; product?: string }) => {
+    // --json or --product paths use the new structured fetcher
+    // (P0/Wk1 #59 of radiant-petting-kitten rev 2 — adds Edge Protocol probe
+    // and machine-readable output to the existing ecosystem command).
+    if (opts.json || opts.product) {
+      const statuses = await fetchEcosystemStatuses(opts.product);
+      if (!statuses) {
+        console.error(
+          `  Unknown --product ${opts.product}. Known: msp, br, gtm, vm, shield`,
+        );
+        process.exitCode = 2;
+        return;
+      }
+      if (opts.json) {
+        console.log(JSON.stringify(statuses, null, 2));
+      } else {
+        console.log(renderEcosystemTable(statuses));
+      }
+      return;
+    }
+
+    // Default path: legacy human-readable rendering with auth + MCP narrative
     console.log(`\n  Brainstorm Ecosystem Status`);
     console.log(`  ───────────────────────────\n`);
 

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,19 +1,15 @@
-import { Command } from "commander";
-
 /**
- * `brainstorm status` — ecosystem-wide health view.
- *
- * Pulls /health from each known product (MSP, BR, GTM, VM, Shield) plus the
- * Edge surface where available. Concise human-readable output by default;
- * --json emits machine-parseable summary for scripting.
+ * Ecosystem-status helpers for `brainstorm ecosystem` / `brainstorm status`
+ * (alias). Pulls /health from each known product plus an Edge Protocol
+ * existence probe (for products that serve it). Output rendering is split
+ * from fetching so the bin entrypoint stays focused on Commander glue.
  *
  * Plan reference: P0/Wk1 #59 of radiant-petting-kitten rev 2 (Primitive 4).
- * The pre-existing `brainstorm router status` stays under its own subcommand
- * for backwards compat; this top-level command is the operator's single-pane
- * view of the unified ecosystem.
+ * The legacy `program.command("ecosystem").alias("status")` in bin/brainstorm.ts
+ * stays as the operator-facing command; this module is the engine.
  */
 
-interface ProductTarget {
+export interface ProductTarget {
   id: string;
   displayName: string;
   baseUrl: string;
@@ -21,10 +17,10 @@ interface ProductTarget {
   hasEdgeProtocol: boolean; // true for MSP + VM in the unified architecture
 }
 
-const PRODUCTS: ProductTarget[] = [
+export const PRODUCTS: ProductTarget[] = [
   {
     id: "msp",
-    displayName: "brainstormMSP",
+    displayName: "BrainstormMSP",
     baseUrl: process.env.BRAINSTORM_MSP_URL ?? "https://brainstormmsp.ai",
     apiKeyEnv: "BRAINSTORM_MSP_API_KEY",
     hasEdgeProtocol: true,
@@ -39,21 +35,21 @@ const PRODUCTS: ProductTarget[] = [
   },
   {
     id: "gtm",
-    displayName: "brainstorm-gtm",
+    displayName: "BrainstormGTM",
     baseUrl: process.env.BRAINSTORM_GTM_URL ?? "https://catsfeet.com",
     apiKeyEnv: "BRAINSTORM_GTM_API_KEY",
     hasEdgeProtocol: false,
   },
   {
     id: "vm",
-    displayName: "brainstormVM",
+    displayName: "BrainstormVM",
     baseUrl: process.env.BRAINSTORM_VM_URL ?? "https://app.brainstormvm.com",
     apiKeyEnv: "BRAINSTORM_VM_API_KEY",
     hasEdgeProtocol: true,
   },
   {
     id: "shield",
-    displayName: "brainstorm-shield",
+    displayName: "BrainstormShield",
     baseUrl:
       process.env.BRAINSTORM_SHIELD_URL ?? "https://shield.brainstorm.co",
     apiKeyEnv: "BRAINSTORM_SHIELD_API_KEY",
@@ -61,17 +57,17 @@ const PRODUCTS: ProductTarget[] = [
   },
 ];
 
-interface ProductStatus {
+export interface ProductStatus {
   id: string;
   displayName: string;
   baseUrl: string;
   apiKeyConfigured: boolean;
   reachable: boolean;
-  healthStatus: string | null; // "healthy" | "ok" | "degraded" | null when unreachable
-  product: string | null; // self-reported product id from /health body
+  healthStatus: string | null;
+  product: string | null;
   version: string | null;
   toolCount: number | null;
-  edgeProtocolImplemented: boolean | null; // null when not applicable
+  edgeProtocolImplemented: boolean | null;
   latencyMs: number | null;
   error: string | null;
 }
@@ -128,8 +124,13 @@ async function fetchProductStatus(p: ProductTarget): Promise<ProductStatus> {
         signal: AbortSignal.timeout(TOOLS_TIMEOUT_MS),
       });
       if (toolsRes.ok) {
-        const data = (await toolsRes.json()) as { tools?: unknown[] };
-        status.toolCount = Array.isArray(data.tools) ? data.tools.length : 0;
+        const data = (await toolsRes.json()) as {
+          tools?: unknown[];
+          tool_count?: number;
+        };
+        status.toolCount =
+          (typeof data.tool_count === "number" ? data.tool_count : null) ??
+          (Array.isArray(data.tools) ? data.tools.length : 0);
       }
     } catch {
       // Tools fetch failure is non-fatal — keep health status from above.
@@ -138,7 +139,7 @@ async function fetchProductStatus(p: ProductTarget): Promise<ProductStatus> {
 
   if (p.hasEdgeProtocol) {
     // Cheap probe: does /api/v1/edge/heartbeat exist? Any non-404 means the
-    // route is mounted (likely 400/401 for an empty request without auth).
+    // route is mounted (likely 400/401 for an empty unsigned request).
     try {
       const probe = await fetch(`${p.baseUrl}/api/v1/edge/heartbeat`, {
         method: "POST",
@@ -155,6 +156,20 @@ async function fetchProductStatus(p: ProductTarget): Promise<ProductStatus> {
   return status;
 }
 
+/**
+ * Fetch status for every known product, optionally filtered to a single id.
+ * Returns undefined when productId is provided and unknown.
+ */
+export async function fetchEcosystemStatuses(
+  productId?: string,
+): Promise<ProductStatus[] | undefined> {
+  const targets = productId
+    ? PRODUCTS.filter((p) => p.id === productId)
+    : PRODUCTS;
+  if (targets.length === 0) return undefined;
+  return Promise.all(targets.map(fetchProductStatus));
+}
+
 function formatStatusBadge(s: ProductStatus): string {
   if (!s.reachable) return "✗ unreachable";
   if (s.healthStatus === "healthy" || s.healthStatus === "ok") return "✓ ok";
@@ -162,7 +177,7 @@ function formatStatusBadge(s: ProductStatus): string {
   return `△ ${s.healthStatus ?? "unknown"}`;
 }
 
-function renderTable(statuses: ProductStatus[]): string {
+export function renderEcosystemTable(statuses: ProductStatus[]): string {
   const lines: string[] = [];
   lines.push("");
   lines.push("  Brainstorm Ecosystem Status");
@@ -207,14 +222,13 @@ function renderTable(statuses: ProductStatus[]): string {
     );
   }
   lines.push("");
-  // Print configuration hints for any unreachable / unconfigured products.
   const issues = statuses.filter((s) => !s.reachable || !s.apiKeyConfigured);
   if (issues.length > 0) {
     lines.push("  Notes:");
     for (const s of issues) {
       if (!s.apiKeyConfigured) {
         lines.push(
-          `    ${s.displayName}: set ${envHintFor(s.id)} to query tools`,
+          `    ${s.displayName}: set ${s.id === "br" ? "BRAINSTORM_API_KEY" : `BRAINSTORM_${s.id.toUpperCase()}_API_KEY`} to query tools`,
         );
       }
       if (!s.reachable && s.error) {
@@ -226,45 +240,5 @@ function renderTable(statuses: ProductStatus[]): string {
   return lines.join("\n");
 }
 
-function envHintFor(productId: string): string {
-  const map: Record<string, string> = {
-    msp: "BRAINSTORM_MSP_API_KEY",
-    br: "BRAINSTORM_API_KEY",
-    gtm: "BRAINSTORM_GTM_API_KEY",
-    vm: "BRAINSTORM_VM_API_KEY",
-    shield: "BRAINSTORM_SHIELD_API_KEY",
-  };
-  return map[productId] ?? "BRAINSTORM_*_API_KEY";
-}
-
-/**
- * Register the top-level `status` command on the given Commander program.
- */
-export function registerStatusCommand(program: Command): void {
-  program
-    .command("status")
-    .description("Show ecosystem-wide health across all known products")
-    .option("--json", "Output as JSON")
-    .option("--product <id>", "Limit to one product id (msp|br|gtm|vm|shield)")
-    .action(async (opts: { json?: boolean; product?: string }) => {
-      const targets = opts.product
-        ? PRODUCTS.filter((p) => p.id === opts.product)
-        : PRODUCTS;
-      if (targets.length === 0) {
-        console.error(
-          `  Unknown --product ${opts.product}. Known: ${PRODUCTS.map((p) => p.id).join(", ")}`,
-        );
-        process.exitCode = 2;
-        return;
-      }
-      const results = await Promise.all(targets.map(fetchProductStatus));
-      if (opts.json) {
-        console.log(JSON.stringify(results, null, 2));
-        return;
-      }
-      console.log(renderTable(results));
-    });
-}
-
-// Exported for testing.
-export const __test = { fetchProductStatus, formatStatusBadge, PRODUCTS };
+// Exported for unit testing.
+export const __test = { fetchProductStatus, formatStatusBadge };

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,0 +1,270 @@
+import { Command } from "commander";
+
+/**
+ * `brainstorm status` — ecosystem-wide health view.
+ *
+ * Pulls /health from each known product (MSP, BR, GTM, VM, Shield) plus the
+ * Edge surface where available. Concise human-readable output by default;
+ * --json emits machine-parseable summary for scripting.
+ *
+ * Plan reference: P0/Wk1 #59 of radiant-petting-kitten rev 2 (Primitive 4).
+ * The pre-existing `brainstorm router status` stays under its own subcommand
+ * for backwards compat; this top-level command is the operator's single-pane
+ * view of the unified ecosystem.
+ */
+
+interface ProductTarget {
+  id: string;
+  displayName: string;
+  baseUrl: string;
+  apiKeyEnv: string;
+  hasEdgeProtocol: boolean; // true for MSP + VM in the unified architecture
+}
+
+const PRODUCTS: ProductTarget[] = [
+  {
+    id: "msp",
+    displayName: "brainstormMSP",
+    baseUrl: process.env.BRAINSTORM_MSP_URL ?? "https://brainstormmsp.ai",
+    apiKeyEnv: "BRAINSTORM_MSP_API_KEY",
+    hasEdgeProtocol: true,
+  },
+  {
+    id: "br",
+    displayName: "BrainstormRouter",
+    baseUrl:
+      process.env.BRAINSTORM_BR_URL ?? "https://api.brainstormrouter.com",
+    apiKeyEnv: "BRAINSTORM_API_KEY",
+    hasEdgeProtocol: false,
+  },
+  {
+    id: "gtm",
+    displayName: "brainstorm-gtm",
+    baseUrl: process.env.BRAINSTORM_GTM_URL ?? "https://catsfeet.com",
+    apiKeyEnv: "BRAINSTORM_GTM_API_KEY",
+    hasEdgeProtocol: false,
+  },
+  {
+    id: "vm",
+    displayName: "brainstormVM",
+    baseUrl: process.env.BRAINSTORM_VM_URL ?? "https://app.brainstormvm.com",
+    apiKeyEnv: "BRAINSTORM_VM_API_KEY",
+    hasEdgeProtocol: true,
+  },
+  {
+    id: "shield",
+    displayName: "brainstorm-shield",
+    baseUrl:
+      process.env.BRAINSTORM_SHIELD_URL ?? "https://shield.brainstorm.co",
+    apiKeyEnv: "BRAINSTORM_SHIELD_API_KEY",
+    hasEdgeProtocol: false,
+  },
+];
+
+interface ProductStatus {
+  id: string;
+  displayName: string;
+  baseUrl: string;
+  apiKeyConfigured: boolean;
+  reachable: boolean;
+  healthStatus: string | null; // "healthy" | "ok" | "degraded" | null when unreachable
+  product: string | null; // self-reported product id from /health body
+  version: string | null;
+  toolCount: number | null;
+  edgeProtocolImplemented: boolean | null; // null when not applicable
+  latencyMs: number | null;
+  error: string | null;
+}
+
+const HEALTH_TIMEOUT_MS = 8000;
+const TOOLS_TIMEOUT_MS = 8000;
+
+async function fetchProductStatus(p: ProductTarget): Promise<ProductStatus> {
+  const apiKey = process.env[p.apiKeyEnv];
+  const status: ProductStatus = {
+    id: p.id,
+    displayName: p.displayName,
+    baseUrl: p.baseUrl,
+    apiKeyConfigured: Boolean(apiKey),
+    reachable: false,
+    healthStatus: null,
+    product: null,
+    version: null,
+    toolCount: null,
+    edgeProtocolImplemented: p.hasEdgeProtocol ? false : null,
+    latencyMs: null,
+    error: null,
+  };
+
+  const start = Date.now();
+  try {
+    const healthRes = await fetch(`${p.baseUrl}/health`, {
+      signal: AbortSignal.timeout(HEALTH_TIMEOUT_MS),
+    });
+    status.latencyMs = Date.now() - start;
+    status.reachable = true;
+    if (healthRes.ok) {
+      try {
+        const body = (await healthRes.json()) as Record<string, unknown>;
+        status.healthStatus =
+          (body.status as string) ?? (body.health as string) ?? "unknown";
+        status.product = (body.product as string) ?? null;
+        status.version = (body.version as string) ?? null;
+      } catch {
+        status.healthStatus = `http-${healthRes.status}`;
+      }
+    } else {
+      status.healthStatus = `http-${healthRes.status}`;
+    }
+  } catch (err) {
+    status.error = err instanceof Error ? err.message : String(err);
+    return status;
+  }
+
+  if (apiKey) {
+    try {
+      const toolsRes = await fetch(`${p.baseUrl}/api/v1/god-mode/tools`, {
+        headers: { Authorization: `Bearer ${apiKey}` },
+        signal: AbortSignal.timeout(TOOLS_TIMEOUT_MS),
+      });
+      if (toolsRes.ok) {
+        const data = (await toolsRes.json()) as { tools?: unknown[] };
+        status.toolCount = Array.isArray(data.tools) ? data.tools.length : 0;
+      }
+    } catch {
+      // Tools fetch failure is non-fatal — keep health status from above.
+    }
+  }
+
+  if (p.hasEdgeProtocol) {
+    // Cheap probe: does /api/v1/edge/heartbeat exist? Any non-404 means the
+    // route is mounted (likely 400/401 for an empty request without auth).
+    try {
+      const probe = await fetch(`${p.baseUrl}/api/v1/edge/heartbeat`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+        signal: AbortSignal.timeout(HEALTH_TIMEOUT_MS),
+      });
+      status.edgeProtocolImplemented = probe.status !== 404;
+    } catch {
+      status.edgeProtocolImplemented = false;
+    }
+  }
+
+  return status;
+}
+
+function formatStatusBadge(s: ProductStatus): string {
+  if (!s.reachable) return "✗ unreachable";
+  if (s.healthStatus === "healthy" || s.healthStatus === "ok") return "✓ ok";
+  if (s.healthStatus?.startsWith("http-")) return `△ ${s.healthStatus}`;
+  return `△ ${s.healthStatus ?? "unknown"}`;
+}
+
+function renderTable(statuses: ProductStatus[]): string {
+  const lines: string[] = [];
+  lines.push("");
+  lines.push("  Brainstorm Ecosystem Status");
+  lines.push("");
+  lines.push(
+    "  " +
+      "Product".padEnd(18) +
+      "Status".padEnd(20) +
+      "Latency".padEnd(10) +
+      "Tools".padEnd(8) +
+      "Edge",
+  );
+  lines.push(
+    "  " +
+      "─".repeat(18) +
+      "─".repeat(20) +
+      "─".repeat(10) +
+      "─".repeat(8) +
+      "────",
+  );
+  for (const s of statuses) {
+    const tools =
+      s.toolCount === null
+        ? s.apiKeyConfigured
+          ? "?"
+          : "(no key)"
+        : String(s.toolCount);
+    const edge =
+      s.edgeProtocolImplemented === null
+        ? "n/a"
+        : s.edgeProtocolImplemented
+          ? "yes"
+          : "no";
+    const latency = s.latencyMs === null ? "—" : `${s.latencyMs}ms`;
+    lines.push(
+      "  " +
+        s.displayName.padEnd(18) +
+        formatStatusBadge(s).padEnd(20) +
+        latency.padEnd(10) +
+        tools.padEnd(8) +
+        edge,
+    );
+  }
+  lines.push("");
+  // Print configuration hints for any unreachable / unconfigured products.
+  const issues = statuses.filter((s) => !s.reachable || !s.apiKeyConfigured);
+  if (issues.length > 0) {
+    lines.push("  Notes:");
+    for (const s of issues) {
+      if (!s.apiKeyConfigured) {
+        lines.push(
+          `    ${s.displayName}: set ${envHintFor(s.id)} to query tools`,
+        );
+      }
+      if (!s.reachable && s.error) {
+        lines.push(`    ${s.displayName}: ${s.error}`);
+      }
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+function envHintFor(productId: string): string {
+  const map: Record<string, string> = {
+    msp: "BRAINSTORM_MSP_API_KEY",
+    br: "BRAINSTORM_API_KEY",
+    gtm: "BRAINSTORM_GTM_API_KEY",
+    vm: "BRAINSTORM_VM_API_KEY",
+    shield: "BRAINSTORM_SHIELD_API_KEY",
+  };
+  return map[productId] ?? "BRAINSTORM_*_API_KEY";
+}
+
+/**
+ * Register the top-level `status` command on the given Commander program.
+ */
+export function registerStatusCommand(program: Command): void {
+  program
+    .command("status")
+    .description("Show ecosystem-wide health across all known products")
+    .option("--json", "Output as JSON")
+    .option("--product <id>", "Limit to one product id (msp|br|gtm|vm|shield)")
+    .action(async (opts: { json?: boolean; product?: string }) => {
+      const targets = opts.product
+        ? PRODUCTS.filter((p) => p.id === opts.product)
+        : PRODUCTS;
+      if (targets.length === 0) {
+        console.error(
+          `  Unknown --product ${opts.product}. Known: ${PRODUCTS.map((p) => p.id).join(", ")}`,
+        );
+        process.exitCode = 2;
+        return;
+      }
+      const results = await Promise.all(targets.map(fetchProductStatus));
+      if (opts.json) {
+        console.log(JSON.stringify(results, null, 2));
+        return;
+      }
+      console.log(renderTable(results));
+    });
+}
+
+// Exported for testing.
+export const __test = { fetchProductStatus, formatStatusBadge, PRODUCTS };

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -43,7 +43,12 @@ export const PRODUCTS: ProductTarget[] = [
   {
     id: "vm",
     displayName: "BrainstormVM",
-    baseUrl: process.env.BRAINSTORM_VM_URL ?? "https://app.brainstormvm.com",
+    // Codex round-2 fix on PR #345: align default with the rest of the CLI
+    // (MCP server + setup + legacy ecosystem command all use
+    // https://vm.brainstorm.co). The unified-architecture canonical CP URL
+    // becomes https://app.brainstormvm.com when DNS migration completes;
+    // until then BRAINSTORM_VM_URL is the operator override.
+    baseUrl: process.env.BRAINSTORM_VM_URL ?? "https://vm.brainstorm.co",
     apiKeyEnv: "BRAINSTORM_VM_API_KEY",
     hasEdgeProtocol: true,
   },


### PR DESCRIPTION
## Summary

P0/Wk1 #59 of [radiant-petting-kitten rev 2](file:///Users/justin/.claude/plans/radiant-petting-kitten.md). New top-level \`brainstorm status\` command surfacing per-product health across the unified ecosystem (MSP / BR / GTM / VM / Shield).

Pulled forward from Wk-11 to Wk-1 per GPT-5.5's plan-review feedback — single biggest sequencing improvement was \"give the operator visibility while the platform is being built, not after.\"

## What it does

For each known product:
1. \`GET /health\` — required, gives status + product + version
2. \`GET /api/v1/god-mode/tools\` (Bearer auth) — optional, gives tool count
3. \`POST /api/v1/edge/heartbeat\` (no auth, empty body) — only for products that declare \`hasEdgeProtocol\` (MSP + VM). Status != 404 means the route is mounted.

Output:
- Default: aligned-column table with badges (✓ ok / △ http-503 / ✗ unreachable)
- \`--json\`: machine-readable summary for scripting
- \`--product <id>\`: limit to one of msp|br|gtm|vm|shield
- Notes section flags products missing API keys + unreachable products with error

## Test plan

- [x] 7 vitest unit tests covering known-products array, edge protocol wiring, unreachable handling, healthy response parsing, edge probe detection, API-key-absent path, status badge formatting
- [x] \`npx tsc --noEmit\` clean

## Backwards compat

The pre-existing \`brainstorm router status\` subcommand stays as-is. This is a new top-level command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)