### PR TITLE
feat(P2): BrainstormRouter mesh-auth Phase 2 — A2A Protocol v0.1 broker

### DIFF
--- a/packages/godmode/src/__tests__/mesh.test.ts
+++ b/packages/godmode/src/__tests__/mesh.test.ts
@@ -1,0 +1,373 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  InMemorySeenStore,
+  InMemoryTaskStore,
+  MeshBroker,
+  formatTraceparent,
+  newRootTraceparent,
+  nextSpan,
+  parseTraceparent,
+  type AgentJWTClaims,
+  type CapabilityResolver,
+  type Dispatcher,
+  type DispatchOutcome,
+  type JWTVerifier,
+  type MeshBrokerConfig,
+  type MeshInvokeInput,
+} from "../mesh/index.js";
+
+function buildBroker(overrides?: Partial<MeshBrokerConfig>): MeshBroker {
+  const cfg: MeshBrokerConfig = {
+    seenStore: new InMemorySeenStore(),
+    taskStore: new InMemoryTaskStore(),
+    resolver: stubResolver({ status: "active", tenantId: "tenant-1" }),
+    dispatcher: stubDispatcher({
+      kind: "sync",
+      output: { ok: true },
+      evidence_envelope_hash: "deadbeef",
+      completed_at: new Date().toISOString(),
+    }),
+    jwt: stubJWT({
+      sub: "did:bvm:tenant-1:caller",
+      tenant_id: "tenant-1",
+      capabilities: ["agent.summarize_text"],
+    }),
+    statusUrlPrefix: "/v1/mesh/task",
+    ...overrides,
+  };
+  return new MeshBroker(cfg);
+}
+
+function validInput(overrides?: Partial<MeshInvokeInput>): MeshInvokeInput {
+  return {
+    targetDID: "did:bvm:tenant-1:writer",
+    authorizationHeader: "Bearer fake.jwt.token",
+    traceparentHeader: formatTraceparent(newRootTraceparent()),
+    tracestateHeader: null,
+    idempotencyKeyHeader: "11111111-1111-1111-1111-000000000001",
+    body: {
+      task_id: "22222222-2222-2222-2222-000000000002",
+      capability: "agent.summarize_text",
+      input: { text: "hello" },
+    },
+    ...overrides,
+  };
+}
+
+function stubResolver(
+  result: {
+    status: "active" | "deprecated" | "removed";
+    tenantId: string;
+  } | null,
+): CapabilityResolver {
+  return {
+    async resolve() {
+      return result;
+    },
+  };
+}
+
+function stubDispatcher(outcome: DispatchOutcome): Dispatcher {
+  return {
+    async dispatch() {
+      return outcome;
+    },
+  };
+}
+
+function stubJWT(claims: AgentJWTClaims | null): JWTVerifier {
+  return {
+    async verify() {
+      return claims;
+    },
+  };
+}
+
+describe("MeshBroker.invoke happy paths", () => {
+  it("returns 200 sync response when dispatcher resolves synchronously", async () => {
+    const broker = buildBroker();
+    const result = await broker.invoke(validInput());
+    expect(result.status).toBe(200);
+    expect((result.body as any).task_id).toBe(
+      "22222222-2222-2222-2222-000000000002",
+    );
+    expect((result.body as any).traceparent).toBeTruthy();
+  });
+
+  it("returns 202 + status_url when dispatcher reports async", async () => {
+    const broker = buildBroker({
+      dispatcher: stubDispatcher({ kind: "async" }),
+    });
+    const result = await broker.invoke(validInput());
+    expect(result.status).toBe(202);
+    expect((result.body as any).status_url).toContain("/v1/mesh/task/");
+  });
+
+  it("propagates trace_id while assigning a new span_id downstream", async () => {
+    const root = newRootTraceparent();
+    const broker = buildBroker();
+    const result = await broker.invoke(
+      validInput({ traceparentHeader: formatTraceparent(root) }),
+    );
+    expect(result.status).toBe(200);
+    const downstream = parseTraceparent((result.body as any).traceparent);
+    expect(downstream).not.toBeNull();
+    expect(downstream!.trace_id).toBe(root.trace_id);
+    expect(downstream!.span_id).not.toBe(root.span_id);
+  });
+});
+
+describe("MeshBroker.invoke validation", () => {
+  it("rejects missing traceparent with 400 VALIDATION", async () => {
+    const broker = buildBroker();
+    const result = await broker.invoke(validInput({ traceparentHeader: null }));
+    expect(result.status).toBe(400);
+    expect((result.body as any).code).toBe("VALIDATION");
+  });
+
+  it("rejects malformed traceparent with 400 VALIDATION", async () => {
+    const broker = buildBroker();
+    const result = await broker.invoke(
+      validInput({ traceparentHeader: "not-a-traceparent" }),
+    );
+    expect(result.status).toBe(400);
+  });
+
+  it("rejects missing Idempotency-Key with 400 VALIDATION", async () => {
+    const broker = buildBroker();
+    const result = await broker.invoke(
+      validInput({ idempotencyKeyHeader: null }),
+    );
+    expect(result.status).toBe(400);
+  });
+
+  it("rejects missing Bearer auth with 401 UNAUTHORIZED", async () => {
+    const broker = buildBroker();
+    const result = await broker.invoke(
+      validInput({ authorizationHeader: null }),
+    );
+    expect(result.status).toBe(401);
+  });
+
+  it("rejects malformed auth header with 401 UNAUTHORIZED", async () => {
+    const broker = buildBroker();
+    const result = await broker.invoke(
+      validInput({ authorizationHeader: "Basic abc" }),
+    );
+    expect(result.status).toBe(401);
+  });
+
+  it("rejects non-agent capability with 400 VALIDATION", async () => {
+    const broker = buildBroker();
+    const result = await broker.invoke(
+      validInput({
+        body: {
+          task_id: "x",
+          capability: "vm.create_instance",
+          input: {},
+        },
+      }),
+    );
+    expect(result.status).toBe(400);
+  });
+
+  it("rejects missing input with 400 VALIDATION", async () => {
+    const broker = buildBroker();
+    const result = await broker.invoke(
+      validInput({
+        body: {
+          task_id: "x",
+          capability: "agent.summarize_text",
+        } as any,
+      }),
+    );
+    expect(result.status).toBe(400);
+  });
+});
+
+describe("MeshBroker.invoke replay protection", () => {
+  let seen: InMemorySeenStore;
+  beforeEach(() => {
+    seen = new InMemorySeenStore();
+  });
+
+  it("first call with a key succeeds; duplicate returns 409 with original task_id", async () => {
+    const broker = buildBroker({ seenStore: seen });
+    const first = await broker.invoke(validInput());
+    expect(first.status).toBe(200);
+
+    // Same idempotency key, different task_id → must 409.
+    const dup = await broker.invoke(
+      validInput({
+        body: {
+          task_id: "33333333-3333-3333-3333-000000000003",
+          capability: "agent.summarize_text",
+          input: { text: "different" },
+        },
+      }),
+    );
+    expect(dup.status).toBe(409);
+    expect((dup.body as any).code).toBe("CONFLICT");
+    expect((dup.body as any).task_id).toBe(
+      "22222222-2222-2222-2222-000000000002",
+    );
+  });
+
+  it("different idempotency keys do not collide", async () => {
+    const broker = buildBroker({ seenStore: seen });
+    const r1 = await broker.invoke(validInput());
+    const r2 = await broker.invoke(
+      validInput({
+        idempotencyKeyHeader: "44444444-4444-4444-4444-000000000004",
+      }),
+    );
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+  });
+});
+
+describe("MeshBroker.invoke authorization", () => {
+  it("rejects when JWT capabilities[] does not include requested capability (403)", async () => {
+    const broker = buildBroker({
+      jwt: stubJWT({
+        sub: "did:bvm:tenant-1:caller",
+        tenant_id: "tenant-1",
+        capabilities: ["agent.something_else"],
+      }),
+    });
+    const result = await broker.invoke(validInput());
+    expect(result.status).toBe(403);
+    expect((result.body as any).code).toBe("FORBIDDEN");
+  });
+
+  it("rejects when caller tenant differs from target tenant (403)", async () => {
+    const broker = buildBroker({
+      jwt: stubJWT({
+        sub: "did:bvm:other-tenant:caller",
+        tenant_id: "other-tenant",
+        capabilities: ["agent.summarize_text"],
+      }),
+    });
+    const result = await broker.invoke(validInput());
+    expect(result.status).toBe(403);
+  });
+
+  it("rejects when JWT verification fails (401)", async () => {
+    const broker = buildBroker({ jwt: stubJWT(null) });
+    const result = await broker.invoke(validInput());
+    expect(result.status).toBe(401);
+  });
+});
+
+describe("MeshBroker.invoke capability resolution", () => {
+  it("404 NOT_FOUND when target has no such capability", async () => {
+    const broker = buildBroker({ resolver: stubResolver(null) });
+    const result = await broker.invoke(validInput());
+    expect(result.status).toBe(404);
+  });
+
+  it("404 NOT_FOUND when target capability is deprecated", async () => {
+    const broker = buildBroker({
+      resolver: stubResolver({ status: "deprecated", tenantId: "tenant-1" }),
+    });
+    const result = await broker.invoke(validInput());
+    expect(result.status).toBe(404);
+  });
+
+  it("404 NOT_FOUND when target capability is removed", async () => {
+    const broker = buildBroker({
+      resolver: stubResolver({ status: "removed", tenantId: "tenant-1" }),
+    });
+    const result = await broker.invoke(validInput());
+    expect(result.status).toBe(404);
+  });
+});
+
+describe("MeshBroker.getTask", () => {
+  it("returns 404 for unknown task_id", async () => {
+    const broker = buildBroker();
+    const r = await broker.getTask("nonexistent");
+    expect(r.status).toBe(404);
+  });
+
+  it("returns 200 with sync result after completion", async () => {
+    const broker = buildBroker({
+      dispatcher: stubDispatcher({ kind: "async" }),
+    });
+    const accept = await broker.invoke(validInput());
+    expect(accept.status).toBe(202);
+    const taskId = (accept.body as any).task_id;
+
+    // Simulate the dispatcher completing the task.
+    const { taskStore } = broker as any;
+    // Reach into the underlying store via the broker config — we kept it
+    // private but test code reaches in to simulate the completion.
+    // (Production dispatchers would call completeTask directly.)
+    const cfg = (broker as any).cfg as MeshBrokerConfig;
+    const completion = {
+      task_id: taskId,
+      output: { done: true },
+      evidence_envelope_hash: "abcd1234",
+      completed_at: new Date().toISOString(),
+      traceparent: (accept.body as any).traceparent,
+    };
+    await cfg.taskStore.transition(taskId, "completed", { result: completion });
+
+    const final = await broker.getTask(taskId);
+    expect(final.status).toBe(200);
+    expect((final.body as any).output).toEqual({ done: true });
+    void taskStore;
+  });
+});
+
+describe("trace-context helpers", () => {
+  it("parseTraceparent rejects all-zero trace_id", () => {
+    const bad = "00-00000000000000000000000000000000-0000000000000001-01";
+    expect(parseTraceparent(bad)).toBeNull();
+  });
+
+  it("parseTraceparent rejects all-zero span_id", () => {
+    const bad = "00-00000000000000000000000000000001-0000000000000000-01";
+    expect(parseTraceparent(bad)).toBeNull();
+  });
+
+  it("nextSpan keeps trace_id but assigns fresh span_id", () => {
+    const root = newRootTraceparent();
+    const next = nextSpan(root);
+    expect(next.trace_id).toBe(root.trace_id);
+    expect(next.span_id).not.toBe(root.span_id);
+  });
+
+  it("formatTraceparent + parseTraceparent roundtrip", () => {
+    const root = newRootTraceparent();
+    const s = formatTraceparent(root);
+    const parsed = parseTraceparent(s);
+    expect(parsed).toEqual(root);
+  });
+});
+
+describe("InMemorySeenStore", () => {
+  it("first call returns firstTime=true", async () => {
+    const store = new InMemorySeenStore();
+    const r = await store.seeOrFetch("k1", "task-1");
+    expect(r.firstTime).toBe(true);
+  });
+
+  it("duplicate within TTL returns the original task id", async () => {
+    const store = new InMemorySeenStore();
+    await store.seeOrFetch("k1", "task-1");
+    const r = await store.seeOrFetch("k1", "task-2");
+    expect(r.firstTime).toBe(false);
+    expect(
+      (r as { firstTime: false; existingTaskId: string }).existingTaskId,
+    ).toBe("task-1");
+  });
+
+  it("evicts entries older than TTL", async () => {
+    const store = new InMemorySeenStore({ ttlMs: 10 });
+    await store.seeOrFetch("k1", "task-1");
+    await new Promise((r) => setTimeout(r, 30));
+    const r = await store.seeOrFetch("k1", "task-2");
+    expect(r.firstTime).toBe(true);
+  });
+});

--- a/packages/godmode/src/__tests__/mesh.test.ts
+++ b/packages/godmode/src/__tests__/mesh.test.ts
@@ -122,7 +122,7 @@ describe("MeshBroker.invoke validation", () => {
     const broker = buildBroker();
     const result = await broker.invoke(validInput({ traceparentHeader: null }));
     expect(result.status).toBe(400);
-    expect((result.body as any).code).toBe("VALIDATION");
+    expect((result.body as any).error.code).toBe("VALIDATION");
   });
 
   it("rejects malformed traceparent with 400 VALIDATION", async () => {
@@ -207,7 +207,7 @@ describe("MeshBroker.invoke replay protection", () => {
       }),
     );
     expect(dup.status).toBe(409);
-    expect((dup.body as any).code).toBe("CONFLICT");
+    expect((dup.body as any).error.code).toBe("CONFLICT");
     expect((dup.body as any).task_id).toBe(
       "22222222-2222-2222-2222-000000000002",
     );
@@ -237,7 +237,7 @@ describe("MeshBroker.invoke authorization", () => {
     });
     const result = await broker.invoke(validInput());
     expect(result.status).toBe(403);
-    expect((result.body as any).code).toBe("FORBIDDEN");
+    expect((result.body as any).error.code).toBe("FORBIDDEN");
   });
 
   it("rejects when caller tenant differs from target tenant (403)", async () => {

--- a/packages/godmode/src/mesh/handler.ts
+++ b/packages/godmode/src/mesh/handler.ts
@@ -181,8 +181,11 @@ export class MeshBroker {
       return {
         status: 409,
         body: {
-          error: "duplicate Idempotency-Key",
-          code: "CONFLICT",
+          success: false,
+          error: {
+            code: "CONFLICT",
+            message: "duplicate Idempotency-Key",
+          },
           task_id: seen.existingTaskId,
         },
       };
@@ -301,11 +304,14 @@ function err(
   status: number,
   code: A2AErrorCode,
   message: string,
-  detail?: string,
+  _detail?: string,
 ): MeshInvokeOutcome {
   return {
     status,
-    body: { error: message, code, detail },
+    body: {
+      success: false,
+      error: { code, message },
+    },
   };
 }
 

--- a/packages/godmode/src/mesh/handler.ts
+++ b/packages/godmode/src/mesh/handler.ts
@@ -225,6 +225,28 @@ export class MeshBroker {
     const downstreamTrace: TraceContext = nextSpan(trace);
     const downstreamTraceparent = formatTraceparent(downstreamTrace);
 
+    // Codex round-1 fix: record the task BEFORE dispatching. Fast async
+    // dispatchers (queue workers, sub-millisecond in-memory shortcuts) can
+    // call completeTask() before our accept() lands, losing the completion
+    // entirely. Pre-recording makes completeTask()/transition() race-safe.
+    //
+    // The record's state is "accepted" until either:
+    //   (a) sync dispatcher returns a result → we transition to "completed"
+    //       before returning the 200 response
+    //   (b) async dispatcher returns "async" → completion arrives via
+    //       a later completeTask() call (race-safe now)
+    //   (c) dispatcher returns "error" → we never advance the record;
+    //       sweepExpired() reclaims it at the 30-min ttl
+    const acceptedRecord = buildAcceptedRecord({
+      taskId: reqBody!.task_id,
+      callerDID,
+      targetDID: input.targetDID,
+      capability: reqBody!.capability,
+      traceparent: downstreamTraceparent,
+      tracestate: input.tracestateHeader ?? undefined,
+    });
+    await this.cfg.taskStore.accept(acceptedRecord);
+
     const outcome = await this.cfg.dispatcher.dispatch({
       targetDID: input.targetDID,
       capability: reqBody!.capability,
@@ -235,6 +257,10 @@ export class MeshBroker {
     });
 
     if (outcome.kind === "error") {
+      // Pre-recorded task stays accepted until ttl expiry. Could be
+      // optimized later by transitioning to "failed" here; leaving as-is
+      // because the error is the broker's, not the target's, and we don't
+      // have a clean way to distinguish in the dispatcher contract yet.
       return { status: outcome.status, body: outcome.envelope };
     }
 
@@ -246,25 +272,21 @@ export class MeshBroker {
         completed_at: outcome.completed_at,
         traceparent: downstreamTraceparent,
       };
+      // Transition the pre-recorded task to completed so subsequent
+      // status_url polling reflects reality. transition() is idempotent on
+      // terminal state so any concurrent completeTask() from a racy
+      // dispatcher is safe.
+      await this.cfg.taskStore.transition(reqBody!.task_id, "completed", {
+        result: response,
+        completedAt: outcome.completed_at,
+      });
       return { status: 200, body: response };
     }
 
-    // Async path: record task in store and return 202 + status_url.
-    const record = buildAcceptedRecord({
-      taskId: reqBody!.task_id,
-      callerDID,
-      targetDID: input.targetDID,
-      capability: reqBody!.capability,
-      traceparent: downstreamTraceparent,
-      tracestate: input.tracestateHeader ?? undefined,
-    });
-    await this.cfg.taskStore.accept(record);
-
+    // Async path: task is already recorded above. Just emit the 202.
     const response: A2AInvokeAsyncResponse = {
       task_id: reqBody!.task_id,
-      status_url: `${this.cfg.statusUrlPrefix.replace(/\/$/, "")}/${encodeURIComponent(
-        reqBody!.task_id,
-      )}`,
+      status_url: buildStatusUrl(this.cfg.statusUrlPrefix, reqBody!.task_id),
       traceparent: downstreamTraceparent,
     };
     return { status: 202, body: response };
@@ -285,13 +307,15 @@ export class MeshBroker {
     if (r.state === "failed" && r.failure) {
       return { status: 500, body: r.failure };
     }
-    // Still accepted/running — return 202 with the same status_url shape
-    // so pollers see a consistent payload.
+    // Still accepted/running — return 202 with the configured status_url
+    // prefix (codex round-1 fix: previously hard-coded /v1/mesh/task/...,
+    // which broke clients in non-default deployments) so pollers see a
+    // consistent payload across the initial 202 and subsequent polls.
     return {
       status: 202,
       body: {
         task_id: r.task_id,
-        status_url: `/v1/mesh/task/${encodeURIComponent(r.task_id)}`,
+        status_url: buildStatusUrl(this.cfg.statusUrlPrefix, r.task_id),
         traceparent: r.traceparent,
       },
     };
@@ -299,6 +323,16 @@ export class MeshBroker {
 }
 
 // ── Helpers ──────────────────────────────────────────────────────
+
+/**
+ * Build a status_url for an async task, honoring the broker's configured
+ * prefix. Codex round-1 fix on PR #348: previously the initial 202 used
+ * the prefix but subsequent polls hard-coded /v1/mesh/task/..., breaking
+ * non-default deployments.
+ */
+function buildStatusUrl(prefix: string, taskId: string): string {
+  return `${prefix.replace(/\/$/, "")}/${encodeURIComponent(taskId)}`;
+}
 
 function err(
   status: number,

--- a/packages/godmode/src/mesh/handler.ts
+++ b/packages/godmode/src/mesh/handler.ts
@@ -1,0 +1,352 @@
+/**
+ * BrainstormRouter mesh-auth Phase 2 — the broker for A2A Protocol v0.1.
+ *
+ * Implements POST /v1/mesh/invoke/{target_did}:
+ *   1. Parse + validate request body, headers (Authorization, traceparent,
+ *      Idempotency-Key).
+ *   2. Verify the per-agent JWT.
+ *   3. Check the distributed replay store; reject duplicates with 409.
+ *   4. Resolve the capability against the Agent Capability Registry; reject
+ *      unknown/inactive with 404.
+ *   5. Enforce tenant isolation (caller.tenant_id == target tenant).
+ *   6. Dispatch to the target. The dispatcher contract is pluggable so the
+ *      broker can route to brainstormVM CP, brainstormMSP cloud, or any
+ *      future host without taking a dep on a specific HTTP client here.
+ *
+ * Synchronous targets return a sync result; long-running targets cause a
+ * 202 Accepted with a status_url. The companion task store tracks async
+ * state until completion or expiry.
+ */
+
+import { randomUUID } from "node:crypto";
+import type {
+  A2AErrorCode,
+  A2AErrorEnvelope,
+  A2AInvokeAsyncResponse,
+  A2AInvokeRequest,
+  A2AInvokeSyncResponse,
+  AgentJWTClaims,
+  TraceContext,
+} from "./types.js";
+import type { SeenStore } from "./replay-store.js";
+import type { TaskStore } from "./task-store.js";
+import { buildAcceptedRecord } from "./task-store.js";
+import {
+  formatTraceparent,
+  nextSpan,
+  parseTraceparent,
+} from "./trace-context.js";
+
+/** Outcome the dispatcher returns when it accepts and forwards a request. */
+export type DispatchOutcome =
+  | {
+      kind: "sync";
+      output: unknown;
+      evidence_envelope_hash: string;
+      completed_at: string;
+    }
+  | { kind: "async" }
+  | { kind: "error"; status: number; envelope: A2AErrorEnvelope };
+
+/**
+ * Resolve a capability on a target. Returns null when the capability is
+ * not registered (or removed); returns the active record otherwise.
+ *
+ * Implementations call the Agent Capability Registry — either via direct
+ * package import (when the broker shares process with the registry) or via
+ * HTTP (when the registry runs in a separate service).
+ */
+export interface CapabilityResolver {
+  resolve(
+    targetDID: string,
+    capability: string,
+  ): Promise<{
+    status: "active" | "deprecated" | "removed";
+    tenantId: string;
+  } | null>;
+}
+
+/**
+ * Dispatch the invocation to the target. The dispatcher is the only place
+ * that knows how to actually reach a particular agent (HTTP push, queue
+ * enqueue, WS frame, etc.).
+ */
+export interface Dispatcher {
+  dispatch(input: {
+    targetDID: string;
+    capability: string;
+    request: A2AInvokeRequest;
+    callerDID: string;
+    traceparent: string;
+    tracestate?: string;
+  }): Promise<DispatchOutcome>;
+}
+
+/**
+ * Verify a per-agent JWT and return the claims. Implementations consult the
+ * BR signing-key store (rotated independently of agent enrollment).
+ */
+export interface JWTVerifier {
+  verify(token: string): Promise<AgentJWTClaims | null>;
+}
+
+/** Configuration carried by the broker. */
+export interface MeshBrokerConfig {
+  seenStore: SeenStore;
+  taskStore: TaskStore;
+  resolver: CapabilityResolver;
+  dispatcher: Dispatcher;
+  jwt: JWTVerifier;
+  /** URL prefix the broker uses to construct status_url responses. */
+  statusUrlPrefix: string;
+}
+
+/** Inputs to the broker — abstracted away from any specific HTTP framework. */
+export interface MeshInvokeInput {
+  targetDID: string;
+  authorizationHeader: string | null;
+  traceparentHeader: string | null;
+  tracestateHeader: string | null;
+  idempotencyKeyHeader: string | null;
+  body: unknown;
+}
+
+/** Outcome the broker hands back to whatever HTTP layer is in front. */
+export type MeshInvokeOutcome =
+  | { status: 200; body: A2AInvokeSyncResponse }
+  | { status: 202; body: A2AInvokeAsyncResponse }
+  | { status: number; body: A2AErrorEnvelope };
+
+/**
+ * The broker. Stateless aside from injected stores; safe under concurrent
+ * invocation from one process.
+ */
+export class MeshBroker {
+  constructor(private readonly cfg: MeshBrokerConfig) {}
+
+  async invoke(input: MeshInvokeInput): Promise<MeshInvokeOutcome> {
+    // --- Step 1: parse + structural validation ---
+    const trace = parseTraceparent(input.traceparentHeader);
+    if (!trace) {
+      return err(400, "VALIDATION", "missing or malformed traceparent");
+    }
+    if (!input.idempotencyKeyHeader) {
+      return err(400, "VALIDATION", "Idempotency-Key header is required");
+    }
+    if (
+      !input.authorizationHeader ||
+      !input.authorizationHeader.startsWith("Bearer ")
+    ) {
+      return err(
+        401,
+        "UNAUTHORIZED",
+        "missing or malformed Authorization header",
+      );
+    }
+    const token = input.authorizationHeader.slice("Bearer ".length).trim();
+
+    const reqBody = input.body as A2AInvokeRequest | null;
+    const bodyErr = validateBody(reqBody);
+    if (bodyErr) {
+      return err(400, "VALIDATION", bodyErr);
+    }
+
+    // --- Step 2: verify the JWT ---
+    const claims = await this.cfg.jwt.verify(token);
+    if (!claims) {
+      return err(401, "UNAUTHORIZED", "JWT verification failed");
+    }
+    const callerDID = claims.sub;
+    if (!callerDID) {
+      return err(401, "UNAUTHORIZED", "JWT missing sub (caller DID)");
+    }
+
+    // The caller's JWT capabilities[] is the list of capabilities the agent
+    // is AUTHORIZED to invoke on peers. Reject early if the requested
+    // capability isn't in that list.
+    if (!claims.capabilities.includes(reqBody!.capability)) {
+      return err(
+        403,
+        "FORBIDDEN",
+        `caller JWT does not include capability ${reqBody!.capability}`,
+      );
+    }
+
+    // --- Step 3: distributed replay protection ---
+    const seen = await this.cfg.seenStore.seeOrFetch(
+      input.idempotencyKeyHeader,
+      reqBody!.task_id,
+    );
+    if (!seen.firstTime) {
+      return {
+        status: 409,
+        body: {
+          error: "duplicate Idempotency-Key",
+          code: "CONFLICT",
+          task_id: seen.existingTaskId,
+        },
+      };
+    }
+
+    // --- Step 4: resolve capability on target ---
+    const cap = await this.cfg.resolver.resolve(
+      input.targetDID,
+      reqBody!.capability,
+    );
+    if (!cap) {
+      return err(
+        404,
+        "NOT_FOUND",
+        `capability ${reqBody!.capability} not registered for ${input.targetDID}`,
+      );
+    }
+    if (cap.status !== "active") {
+      return err(
+        404,
+        "NOT_FOUND",
+        `capability ${reqBody!.capability} is ${cap.status} on ${input.targetDID}`,
+      );
+    }
+
+    // --- Step 5: tenant isolation ---
+    if (claims.tenant_id !== cap.tenantId) {
+      return err(
+        403,
+        "FORBIDDEN",
+        `caller tenant ${claims.tenant_id} != target tenant ${cap.tenantId}`,
+      );
+    }
+
+    // --- Step 6: dispatch ---
+    // Build the downstream traceparent: same trace_id, fresh span_id.
+    const downstreamTrace: TraceContext = nextSpan(trace);
+    const downstreamTraceparent = formatTraceparent(downstreamTrace);
+
+    const outcome = await this.cfg.dispatcher.dispatch({
+      targetDID: input.targetDID,
+      capability: reqBody!.capability,
+      request: reqBody!,
+      callerDID,
+      traceparent: downstreamTraceparent,
+      tracestate: input.tracestateHeader ?? undefined,
+    });
+
+    if (outcome.kind === "error") {
+      return { status: outcome.status, body: outcome.envelope };
+    }
+
+    if (outcome.kind === "sync") {
+      const response: A2AInvokeSyncResponse = {
+        task_id: reqBody!.task_id,
+        output: outcome.output,
+        evidence_envelope_hash: outcome.evidence_envelope_hash,
+        completed_at: outcome.completed_at,
+        traceparent: downstreamTraceparent,
+      };
+      return { status: 200, body: response };
+    }
+
+    // Async path: record task in store and return 202 + status_url.
+    const record = buildAcceptedRecord({
+      taskId: reqBody!.task_id,
+      callerDID,
+      targetDID: input.targetDID,
+      capability: reqBody!.capability,
+      traceparent: downstreamTraceparent,
+      tracestate: input.tracestateHeader ?? undefined,
+    });
+    await this.cfg.taskStore.accept(record);
+
+    const response: A2AInvokeAsyncResponse = {
+      task_id: reqBody!.task_id,
+      status_url: `${this.cfg.statusUrlPrefix.replace(/\/$/, "")}/${encodeURIComponent(
+        reqBody!.task_id,
+      )}`,
+      traceparent: downstreamTraceparent,
+    };
+    return { status: 202, body: response };
+  }
+
+  /** GET /v1/mesh/task/{task_id} — read current state of an async task. */
+  async getTask(taskId: string): Promise<MeshInvokeOutcome> {
+    const r = await this.cfg.taskStore.get(taskId);
+    if (!r) {
+      return err(404, "NOT_FOUND", `unknown task_id ${taskId}`);
+    }
+    if (r.state === "expired") {
+      return err(410, "GONE", `task ${taskId} expired without completion`);
+    }
+    if (r.state === "completed" && r.result) {
+      return { status: 200, body: r.result };
+    }
+    if (r.state === "failed" && r.failure) {
+      return { status: 500, body: r.failure };
+    }
+    // Still accepted/running — return 202 with the same status_url shape
+    // so pollers see a consistent payload.
+    return {
+      status: 202,
+      body: {
+        task_id: r.task_id,
+        status_url: `/v1/mesh/task/${encodeURIComponent(r.task_id)}`,
+        traceparent: r.traceparent,
+      },
+    };
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function err(
+  status: number,
+  code: A2AErrorCode,
+  message: string,
+  detail?: string,
+): MeshInvokeOutcome {
+  return {
+    status,
+    body: { error: message, code, detail },
+  };
+}
+
+function validateBody(body: A2AInvokeRequest | null): string | null {
+  if (!body || typeof body !== "object") return "request body is required";
+  if (typeof body.task_id !== "string" || body.task_id.length === 0) {
+    return "task_id is required";
+  }
+  if (typeof body.capability !== "string" || body.capability.length === 0) {
+    return "capability is required";
+  }
+  if (!body.capability.startsWith("agent.")) {
+    return `capability must be in the agent.* namespace (got ${body.capability})`;
+  }
+  if (body.input === undefined) {
+    return "input is required (use {} for no-arg capabilities)";
+  }
+  return null;
+}
+
+/** Convenience helper to record a sync completion against the task store —
+ *  the dispatcher calls this when its async path resolves. */
+export async function completeTask(
+  store: TaskStore,
+  taskId: string,
+  result: A2AInvokeSyncResponse,
+): Promise<void> {
+  await store.transition(taskId, "completed", {
+    result,
+    completedAt: new Date().toISOString(),
+  });
+}
+
+/** Record a failure against the task store. */
+export async function failTask(
+  store: TaskStore,
+  taskId: string,
+  failure: A2AErrorEnvelope,
+): Promise<void> {
+  await store.transition(taskId, "failed", {
+    failure,
+    completedAt: new Date().toISOString(),
+  });
+}

--- a/packages/godmode/src/mesh/index.ts
+++ b/packages/godmode/src/mesh/index.ts
@@ -1,0 +1,46 @@
+/**
+ * Brainstorm A2A Protocol v0.1 — BrainstormRouter mesh-auth Phase 2.
+ *
+ * Public surface of the mesh-auth implementation. See ./types.ts for wire
+ * shapes, ./handler.ts for the broker, ./replay-store.ts for distributed
+ * replay protection, ./task-store.ts for async state, and
+ * ./trace-context.ts for W3C trace propagation.
+ *
+ * Plan reference: P2/Wk5 #66 of radiant-petting-kitten rev 2.
+ * Spec: brainstorm/docs/a2a-protocol-v01.md (#347, merged).
+ */
+
+export * from "./types.js";
+export {
+  MeshBroker,
+  completeTask,
+  failTask,
+  type CapabilityResolver,
+  type Dispatcher,
+  type DispatchOutcome,
+  type JWTVerifier,
+  type MeshBrokerConfig,
+  type MeshInvokeInput,
+  type MeshInvokeOutcome,
+} from "./handler.js";
+export {
+  InMemorySeenStore,
+  RedisSeenStore,
+  type MinimalRedisClient,
+  type SeenResult,
+  type SeenStore,
+} from "./replay-store.js";
+export {
+  InMemoryTaskStore,
+  buildAcceptedRecord,
+  type TaskStore,
+} from "./task-store.js";
+export {
+  formatTraceparent,
+  isSampled,
+  newRootTraceparent,
+  newSpanId,
+  newTraceId,
+  nextSpan,
+  parseTraceparent,
+} from "./trace-context.js";

--- a/packages/godmode/src/mesh/replay-store.ts
+++ b/packages/godmode/src/mesh/replay-store.ts
@@ -1,0 +1,153 @@
+/**
+ * Distributed replay protection for A2A Idempotency-Key.
+ *
+ * The store is keyed on (Idempotency-Key → task_id) with a 10-minute TTL.
+ * BrainstormRouter runs on multi-instance ECS, so an in-memory LRU is NOT
+ * sufficient: a replay can route to a different task whose memory has
+ * never seen the key. This is the most-flagged hardening from the rev-2
+ * multi-model plan review.
+ *
+ * Two implementations:
+ *   - InMemorySeenStore: for tests + single-process dev. NOT for production.
+ *   - RedisSeenStore: backed by Upstash Redis (or any Redis-compatible
+ *     SET NX EX implementation). The production path.
+ *
+ * Callers select via NewSeenStore(opts) based on env. The contract is the
+ * same: first call with a given key wins; subsequent calls within TTL
+ * return the original task_id and the caller MUST reject with 409 CONFLICT.
+ */
+
+/** Result of a check-and-set against the replay store. */
+export type SeenResult =
+  | { firstTime: true }
+  | { firstTime: false; existingTaskId: string };
+
+/**
+ * Replay store contract. Implementations MUST be safe under concurrent
+ * SeeOrFetch calls — exactly one caller for a given key gets firstTime=true.
+ */
+export interface SeenStore {
+  /**
+   * Atomically: if `key` has not been seen within TTL, record it with the
+   * supplied taskId and return firstTime=true. Otherwise return
+   * firstTime=false and the originally-recorded taskId.
+   */
+  seeOrFetch(key: string, taskId: string): Promise<SeenResult>;
+
+  /** Maximum entry lifetime in milliseconds. */
+  readonly ttlMs: number;
+}
+
+const DEFAULT_TTL_MS = 10 * 60 * 1000; // 10 minutes — matches the A2A spec
+
+/**
+ * In-process implementation. Each entry expires lazily on lookup.
+ * Hard cap on size prevents unbounded growth under attack.
+ *
+ * Safe under concurrent calls from the SAME process but NOT cross-process.
+ * Use only in tests + single-instance dev runs.
+ */
+export class InMemorySeenStore implements SeenStore {
+  readonly ttlMs: number;
+  private readonly maxSize: number;
+  private readonly map = new Map<
+    string,
+    { taskId: string; recordedAt: number }
+  >();
+
+  constructor(opts?: { ttlMs?: number; maxSize?: number }) {
+    this.ttlMs = opts?.ttlMs ?? DEFAULT_TTL_MS;
+    this.maxSize = opts?.maxSize ?? 100_000;
+  }
+
+  async seeOrFetch(key: string, taskId: string): Promise<SeenResult> {
+    const now = Date.now();
+    const cutoff = now - this.ttlMs;
+
+    // Passive expiry: evict any entry older than the TTL.
+    for (const [k, v] of this.map) {
+      if (v.recordedAt < cutoff) {
+        this.map.delete(k);
+      }
+    }
+
+    const existing = this.map.get(key);
+    if (existing && existing.recordedAt >= cutoff) {
+      return { firstTime: false, existingTaskId: existing.taskId };
+    }
+
+    // LRU eviction if we hit the cap.
+    if (this.map.size >= this.maxSize) {
+      const oldest = this.map.keys().next().value;
+      if (oldest !== undefined) this.map.delete(oldest);
+    }
+
+    this.map.set(key, { taskId, recordedAt: now });
+    return { firstTime: true };
+  }
+
+  /** Test helper. Production code MUST NOT call this. */
+  _clear(): void {
+    this.map.clear();
+  }
+}
+
+/**
+ * Redis-backed implementation. Uses SET NX EX semantics so the first call
+ * for a key wins atomically across processes/instances.
+ *
+ * Constructor takes a minimal redis-client adapter so we don't lock the
+ * concrete library (ioredis vs @upstash/redis vs node-redis) at this layer.
+ * Production wiring picks whichever the deployment uses.
+ */
+export interface MinimalRedisClient {
+  /**
+   * SET key value [NX] [EX seconds] — returns the previous value when NX
+   * fails, or undefined/null when NX succeeds (key did not exist).
+   *
+   * Semantically:
+   *   - On success (firstTime): returns ok-marker (e.g. "OK")
+   *   - On NX fail: returns null
+   * Implementations MUST use atomic SET NX EX; emulating via GET+SET is unsafe.
+   */
+  setNxEx(
+    key: string,
+    value: string,
+    ttlSeconds: number,
+  ): Promise<string | null>;
+
+  /** Read the value for a key (used to fetch the original taskId on conflict). */
+  get(key: string): Promise<string | null>;
+}
+
+export class RedisSeenStore implements SeenStore {
+  readonly ttlMs: number;
+  private readonly client: MinimalRedisClient;
+  private readonly prefix: string;
+
+  constructor(
+    client: MinimalRedisClient,
+    opts?: { ttlMs?: number; prefix?: string },
+  ) {
+    this.client = client;
+    this.ttlMs = opts?.ttlMs ?? DEFAULT_TTL_MS;
+    this.prefix = opts?.prefix ?? "a2a:seen:";
+  }
+
+  async seeOrFetch(key: string, taskId: string): Promise<SeenResult> {
+    const fullKey = this.prefix + key;
+    const ttlSeconds = Math.max(1, Math.floor(this.ttlMs / 1000));
+    const result = await this.client.setNxEx(fullKey, taskId, ttlSeconds);
+    if (result !== null) {
+      return { firstTime: true };
+    }
+    // SET NX failed → key already exists. Fetch the recorded taskId.
+    const existing = await this.client.get(fullKey);
+    return {
+      firstTime: false,
+      // If the key disappears between SETNX and GET (TTL boundary race),
+      // we still report a conflict but the existingTaskId is unknown.
+      existingTaskId: existing ?? "<unknown>",
+    };
+  }
+}

--- a/packages/godmode/src/mesh/task-store.ts
+++ b/packages/godmode/src/mesh/task-store.ts
@@ -1,0 +1,157 @@
+/**
+ * Async task state machine for A2A invocations that don't complete
+ * synchronously.
+ *
+ * When a target accepts an invocation but doesn't have an answer within
+ * ~30s, the broker returns 202 Accepted with a status_url. This module
+ * tracks the task's lifecycle so GET /v1/mesh/task/{task_id} can answer.
+ *
+ * In-memory implementation only for v0.1. Multi-instance production will
+ * need a Redis-backed implementation; the interface is shaped to make
+ * substitution easy.
+ */
+
+import type {
+  A2AErrorEnvelope,
+  A2AInvokeSyncResponse,
+  TaskRecord,
+  TaskState,
+} from "./types.js";
+
+export interface TaskStore {
+  /** Record a freshly-accepted task. */
+  accept(record: TaskRecord): Promise<void>;
+
+  /** Read the current state of a task. Returns null if unknown. */
+  get(taskId: string): Promise<TaskRecord | null>;
+
+  /** Transition state. completedAt is set when state is terminal. */
+  transition(
+    taskId: string,
+    state: TaskState,
+    opts?: {
+      result?: A2AInvokeSyncResponse;
+      failure?: A2AErrorEnvelope;
+      completedAt?: string;
+    },
+  ): Promise<TaskRecord | null>;
+
+  /** Expire any tasks whose expires_at < now. Returns the count. */
+  sweepExpired(now: Date): Promise<number>;
+}
+
+const DEFAULT_EXPIRY_MS = 30 * 60 * 1000; // 30 minutes per spec
+
+/**
+ * In-memory implementation. Safe under concurrent access from one process;
+ * production multi-instance deployment needs Redis or similar.
+ */
+export class InMemoryTaskStore implements TaskStore {
+  private readonly records = new Map<string, TaskRecord>();
+
+  async accept(record: TaskRecord): Promise<void> {
+    this.records.set(record.task_id, record);
+  }
+
+  async get(taskId: string): Promise<TaskRecord | null> {
+    const r = this.records.get(taskId);
+    if (!r) return null;
+    // Lazy expiry: if past expires_at and still non-terminal, mark expired.
+    if (new Date(r.expires_at).getTime() < Date.now()) {
+      if (
+        r.state !== "completed" &&
+        r.state !== "failed" &&
+        r.state !== "expired"
+      ) {
+        const expired: TaskRecord = {
+          ...r,
+          state: "expired",
+          completed_at: new Date().toISOString(),
+        };
+        this.records.set(taskId, expired);
+        return expired;
+      }
+    }
+    return r;
+  }
+
+  async transition(
+    taskId: string,
+    state: TaskState,
+    opts?: {
+      result?: A2AInvokeSyncResponse;
+      failure?: A2AErrorEnvelope;
+      completedAt?: string;
+    },
+  ): Promise<TaskRecord | null> {
+    const r = this.records.get(taskId);
+    if (!r) return null;
+    if (isTerminal(r.state)) {
+      // Don't overwrite a terminal state — caller racing.
+      return r;
+    }
+    const updated: TaskRecord = {
+      ...r,
+      state,
+      result: opts?.result ?? r.result,
+      failure: opts?.failure ?? r.failure,
+      completed_at:
+        opts?.completedAt ??
+        (isTerminal(state) ? new Date().toISOString() : r.completed_at),
+    };
+    this.records.set(taskId, updated);
+    return updated;
+  }
+
+  async sweepExpired(now: Date): Promise<number> {
+    let count = 0;
+    for (const [k, r] of this.records) {
+      if (
+        !isTerminal(r.state) &&
+        new Date(r.expires_at).getTime() < now.getTime()
+      ) {
+        this.records.set(k, {
+          ...r,
+          state: "expired",
+          completed_at: now.toISOString(),
+        });
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /** Test helper. */
+  _clear(): void {
+    this.records.clear();
+  }
+}
+
+function isTerminal(s: TaskState): boolean {
+  return s === "completed" || s === "failed" || s === "expired";
+}
+
+/** Build an accepted TaskRecord with sensible defaults. */
+export function buildAcceptedRecord(opts: {
+  taskId: string;
+  callerDID: string;
+  targetDID: string;
+  capability: string;
+  traceparent: string;
+  tracestate?: string;
+  ttlMs?: number;
+}): TaskRecord {
+  const now = new Date();
+  const ttl = opts.ttlMs ?? DEFAULT_EXPIRY_MS;
+  return {
+    task_id: opts.taskId,
+    state: "accepted",
+    caller_did: opts.callerDID,
+    target_did: opts.targetDID,
+    capability: opts.capability,
+    traceparent: opts.traceparent,
+    tracestate: opts.tracestate,
+    accepted_at: now.toISOString(),
+    expires_at: new Date(now.getTime() + ttl).toISOString(),
+  };
+}

--- a/packages/godmode/src/mesh/trace-context.ts
+++ b/packages/godmode/src/mesh/trace-context.ts
@@ -1,0 +1,75 @@
+/**
+ * W3C Trace Context parsing + propagation.
+ *
+ * https://www.w3.org/TR/trace-context/
+ *
+ * The traceparent header carries a 4-part value:
+ *   <version>-<trace_id>-<span_id>-<flags>
+ *
+ * For A2A receivers, the contract is:
+ *   1. Parse incoming traceparent (REQUIRED — reject if missing/malformed)
+ *   2. Generate a new span_id for local work, keep the trace_id
+ *   3. Echo the updated traceparent in synchronous responses
+ *   4. Stamp the (incoming) traceparent on every evidence + ChangeSet produced
+ *   5. Forward the updated traceparent on any downstream A2A invocations
+ */
+
+import { randomBytes } from "node:crypto";
+import type { TraceContext } from "./types.js";
+
+const VERSION = "00";
+const FLAG_SAMPLED = 0x01;
+const TRACEPARENT_RE =
+  /^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/;
+
+export function parseTraceparent(
+  value: string | undefined | null,
+): TraceContext | null {
+  if (!value) return null;
+  const m = TRACEPARENT_RE.exec(value.trim());
+  if (!m) return null;
+  const version = m[1] as string;
+  const trace_id = m[2] as string;
+  const span_id = m[3] as string;
+  const flags = m[4] as string;
+  if (version === "ff") return null;
+  if (trace_id === "0".repeat(32)) return null;
+  if (span_id === "0".repeat(16)) return null;
+  return { version, trace_id, span_id, flags };
+}
+
+export function formatTraceparent(tc: TraceContext): string {
+  return `${tc.version}-${tc.trace_id}-${tc.span_id}-${tc.flags}`;
+}
+
+export function newSpanId(): string {
+  return randomBytes(8).toString("hex");
+}
+
+export function newTraceId(): string {
+  return randomBytes(16).toString("hex");
+}
+
+export function nextSpan(parent: TraceContext): TraceContext {
+  return {
+    version: VERSION,
+    trace_id: parent.trace_id,
+    span_id: newSpanId(),
+    flags: parent.flags,
+  };
+}
+
+export function newRootTraceparent(opts?: { sampled?: boolean }): TraceContext {
+  const sampled = opts?.sampled ?? true;
+  return {
+    version: VERSION,
+    trace_id: newTraceId(),
+    span_id: newSpanId(),
+    flags: sampled ? FLAG_SAMPLED.toString(16).padStart(2, "0") : "00",
+  };
+}
+
+export function isSampled(tc: TraceContext): boolean {
+  const f = parseInt(tc.flags, 16);
+  return (f & FLAG_SAMPLED) === FLAG_SAMPLED;
+}

--- a/packages/godmode/src/mesh/types.ts
+++ b/packages/godmode/src/mesh/types.ts
@@ -1,0 +1,112 @@
+/**
+ * Brainstorm A2A Protocol v0.1 — wire types.
+ *
+ * Implements the canonical spec at /docs/a2a-protocol-v01.md. Agents invoke
+ * each other through BrainstormRouter mesh-auth via POST /v1/mesh/invoke/{target_did}.
+ *
+ * Three response shapes:
+ *   - 200 OK    — synchronous completion
+ *   - 202 Accepted — async, caller polls status_url
+ *   - 4xx/5xx   — typed error envelope aligned with Platform Contract v1 codes
+ */
+
+/** Request body for POST /v1/mesh/invoke/{target_did}. */
+export interface A2AInvokeRequest {
+  /** Caller-generated UUID, unique per logical task. */
+  task_id: string;
+  /** Capability name in the agent.<verb>_<noun> namespace. */
+  capability: string;
+  /** Payload validated against the registered input_schema. */
+  input: unknown;
+  /** Caller's deadline (ISO 8601). Receivers SHOULD reject if they can't meet it. */
+  deadline_iso?: string;
+}
+
+/** Successful synchronous response body. */
+export interface A2AInvokeSyncResponse {
+  task_id: string;
+  output: unknown;
+  evidence_envelope_hash: string;
+  completed_at: string;
+  /** W3C traceparent propagated unchanged from request. */
+  traceparent: string;
+}
+
+/** Successful async response body (202 Accepted). */
+export interface A2AInvokeAsyncResponse {
+  task_id: string;
+  status_url: string;
+  traceparent: string;
+}
+
+/** Canonical error envelope. */
+export interface A2AErrorEnvelope {
+  error: string;
+  code: A2AErrorCode;
+  detail?: string;
+  retry_after_seconds?: number;
+  /** When code=CONFLICT and the request was a duplicate Idempotency-Key,
+   *  this carries the original task_id from the first acceptance. */
+  task_id?: string;
+}
+
+/** Closed enum of A2A error codes — aligned with Platform Contract v1. */
+export type A2AErrorCode =
+  | "VALIDATION"
+  | "UNAUTHORIZED"
+  | "FORBIDDEN"
+  | "NOT_FOUND"
+  | "RATE_LIMITED"
+  | "CONFLICT"
+  | "GONE"
+  | "INVARIANT"
+  | "INTERNAL"
+  | "UNAVAILABLE";
+
+/** Async task lifecycle states. */
+export type TaskState =
+  | "accepted"
+  | "running"
+  | "completed"
+  | "failed"
+  | "expired";
+
+/** Persistence shape for async tasks (status_url responses). */
+export interface TaskRecord {
+  task_id: string;
+  state: TaskState;
+  caller_did: string;
+  target_did: string;
+  capability: string;
+  traceparent: string;
+  tracestate?: string;
+  accepted_at: string;
+  completed_at?: string;
+  /** Set when state is completed/failed. */
+  result?: A2AInvokeSyncResponse;
+  /** Set when state is failed. */
+  failure?: A2AErrorEnvelope;
+  /** Hard expiry — task is GONE after this even if not completed. */
+  expires_at: string;
+}
+
+/** Decoded W3C traceparent header. */
+export interface TraceContext {
+  version: string; // "00"
+  trace_id: string; // 32-hex
+  span_id: string; // 16-hex
+  flags: string; // 2-hex
+}
+
+/** Per-agent JWT claims (issued by /v1/agent/bootstrap). */
+export interface AgentJWTClaims {
+  /** Caller's lineage DID — did:bvm:<tenant>:<agent>. */
+  sub: string;
+  tenant_id: string;
+  /** Capability names this agent is authorized to INVOKE on peers. */
+  capabilities: string[];
+  /** Optional signing-key identifier for rotation. */
+  key_id?: string;
+  iat?: number;
+  exp?: number;
+}

--- a/packages/godmode/src/mesh/types.ts
+++ b/packages/godmode/src/mesh/types.ts
@@ -39,15 +39,25 @@ export interface A2AInvokeAsyncResponse {
   traceparent: string;
 }
 
-/** Canonical error envelope. */
+/**
+ * Canonical Platform Contract v1 error envelope.
+ *
+ * Spec at /docs/platform-contract-v1.md mandates {success:false, error:{code, message}}.
+ * A2A-specific top-level extensions (e.g. task_id on CONFLICT, retry_after_seconds
+ * on RATE_LIMITED) ride alongside; callers route on error.code only.
+ */
 export interface A2AErrorEnvelope {
-  error: string;
-  code: A2AErrorCode;
-  detail?: string;
-  retry_after_seconds?: number;
-  /** When code=CONFLICT and the request was a duplicate Idempotency-Key,
-   *  this carries the original task_id from the first acceptance. */
+  success: false;
+  error: {
+    code: A2AErrorCode;
+    message: string;
+  };
+  /** Original task_id from first acceptance, populated when code=CONFLICT
+   *  (duplicate Idempotency-Key). */
   task_id?: string;
+  /** Seconds until the caller may retry, set when code=RATE_LIMITED.
+   *  The HTTP `Retry-After` response header carries the same value. */
+  retry_after_seconds?: number;
 }
 
 /** Closed enum of A2A error codes — aligned with Platform Contract v1. */


### PR DESCRIPTION
## Summary

P2/Wk5 #66 of [radiant-petting-kitten rev 2](file:///Users/justin/.claude/plans/radiant-petting-kitten.md). Ships the BrainstormRouter implementation of A2A Protocol v0.1 (spec doc at #347).

**Unblocks brainstorm-gtm's 70 agents** whose MeshClient has been blocked on Phase 2 mesh-auth since rev-1 — the single biggest cross-product win in this plan.

## Layout: \`packages/godmode/src/mesh/\`

- \`types.ts\` — Wire shapes (A2AInvokeRequest, sync/async response, error envelope, TaskRecord, TraceContext, AgentJWTClaims)
- \`replay-store.ts\` — **InMemorySeenStore** (tests + dev) + **RedisSeenStore** (production via \`SET NX EX\`). Solves the multi-model plan review's biggest hardening callout: in-memory LRU is unsafe on multi-instance ECS.
- \`trace-context.ts\` — W3C Trace Context parsing + propagation. Receivers keep \`trace_id\`, assign fresh \`span_id\`, echo downstream.
- \`task-store.ts\` — Async task state machine (accepted → running → completed|failed|expired) with lazy expiry.
- \`handler.ts\` — \`MeshBroker\`: 6-step validation pipeline + \`getTask\`. Pluggable \`CapabilityResolver\`, \`Dispatcher\`, \`JWTVerifier\` interfaces.
- \`index.ts\` — Public surface.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`vitest run src/__tests__/mesh.test.ts\` — 27/27 PASS
- [x] Coverage: happy sync + async paths, trace propagation, full validation matrix, replay protection (first vs duplicate vs different key), authorization (capabilities + tenant + verify failure), capability resolution (none/deprecated/removed), getTask lifecycle, trace-context edge cases, in-memory store TTL

## Companion PRs

- brainstorm#347 — A2A Protocol v0.1 canonical spec (the wire contract this implements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)