### PR TITLE
feat(P5/Wk12): brainstorm evidence verify --format human

### DIFF
--- a/packages/cli/src/__tests__/evidence.test.ts
+++ b/packages/cli/src/__tests__/evidence.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { __test } from "../commands/evidence.js";
+
+const { renderHuman, SECTIONS, fetchReport } = __test;
+
+function passingReport() {
+  const base = {
+    lineage_did: "did:bvm:acme:researcher",
+    generated_at: "2026-05-17T00:00:00Z",
+  };
+  const ok = (summary: string) => ({ ok: true, summary });
+  return {
+    ...base,
+    chain: ok("12 envelopes, 0 sig failures, prev_hash intact"),
+    lineage: ok("2 instances, 1 signed replacement event"),
+    manifest: ok("autonomy=L2, 3 capabilities registered"),
+    quota: ok("417 brokered, 0 rejected"),
+    policy: ok("2 high-risk ChangeSets held pending_approval"),
+    lifecycle: ok("boot→running→killed→replaced"),
+    intent: ok("8 A2A invocations linked via traceparent"),
+    replace: ok("DID continuity verified across instance replacement"),
+  };
+}
+
+describe("brainstorm evidence verify — human render", () => {
+  it("renders every section line in pass state", () => {
+    const out = renderHuman(passingReport() as any);
+    for (const s of SECTIONS) {
+      expect(out).toContain(`[${s.label}]`);
+    }
+    expect(out).toMatch(/Overall:\s+✓ PASS/);
+  });
+
+  it("flags overall FAIL if any section is not ok", () => {
+    const r = passingReport() as any;
+    r.chain = { ok: false, summary: "1 hash mismatch at envelope 7" };
+    const out = renderHuman(r);
+    expect(out).toMatch(/Overall:.*FAIL/);
+    expect(out).toMatch(/\[CHAIN\] ✗ 1 hash mismatch/);
+  });
+
+  it("handles missing sections gracefully", () => {
+    const r = passingReport() as any;
+    delete r.replace;
+    const out = renderHuman(r);
+    expect(out).toMatch(/\[REPLACE\].*missing section/);
+    expect(out).toMatch(/Overall:.*FAIL/);
+  });
+});
+
+describe("brainstorm evidence verify — fetchReport", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("calls /api/v1/evidence/lineage/<encoded did> with bearer auth", async () => {
+    const captured: { url: string; auth: string } = { url: "", auth: "" };
+    globalThis.fetch = (async (url: any, init: any) => {
+      captured.url = String(url);
+      captured.auth =
+        (init?.headers as Record<string, string>)?.Authorization ?? "";
+      return new Response(JSON.stringify(passingReport()), { status: 200 });
+    }) as typeof globalThis.fetch;
+
+    const { status, body } = await fetchReport(
+      "https://vm.example",
+      "tok",
+      "did:bvm:acme:researcher",
+    );
+    expect(status).toBe(200);
+    expect((body as any).lineage_did).toBe("did:bvm:acme:researcher");
+    expect(captured.url).toBe(
+      "https://vm.example/api/v1/evidence/lineage/did%3Abvm%3Aacme%3Aresearcher",
+    );
+    expect(captured.auth).toBe("Bearer tok");
+  });
+
+  it("surfaces a 404 with null body cleanly (no JSON parse throw)", async () => {
+    globalThis.fetch = (async () =>
+      new Response("lineage not found", {
+        status: 404,
+      })) as typeof globalThis.fetch;
+    const { status, body } = await fetchReport(
+      "https://vm.example",
+      "tok",
+      "did:bvm:acme:researcher",
+    );
+    expect(status).toBe(404);
+    expect(body).toBeNull();
+  });
+});

--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -417,6 +417,11 @@ registerA2ACommand(program);
 import { registerTraceCommand } from "../commands/trace.js";
 registerTraceCommand(program);
 
+// `brainstorm evidence verify --lineage <did>` — Phase G ratification
+// surface. See packages/cli/src/commands/evidence.ts (P5/Wk12 #73 of rev 2).
+import { registerEvidenceCommand } from "../commands/evidence.js";
+registerEvidenceCommand(program);
+
 program
   .command("eval")
   .description("Run capability evaluation probes against a model")

--- a/packages/cli/src/commands/evidence.ts
+++ b/packages/cli/src/commands/evidence.ts
@@ -1,0 +1,219 @@
+/**
+ * `brainstorm evidence verify --lineage <did> [--format human|json]` —
+ * v0.1 ratification surface defined in P5/Wk12 #73 of
+ * radiant-petting-kitten rev 2 (Phase G of the end-to-end verification
+ * sequence).
+ *
+ * Walks the evidence chain rooted at a HAI lineage_did and reports
+ * (in either human or JSON form):
+ *   - CHAIN     hash-link integrity + Dilithium signature verification
+ *   - LINEAGE   identity continuity across instance replacements
+ *   - MANIFEST  capabilities + autonomy registered for the lineage
+ *   - QUOTA     LLM calls brokered + rejected at the per-agent BR key
+ *   - POLICY    constitutional gate decisions on agent-initiated CS
+ *   - LIFECYCLE boot → running → killed → replaced trail per instance
+ *   - INTENT    A2A invocations linked by W3C traceparent
+ *   - REPLACE   instance_did → instance_did transitions, each with
+ *               a CP-signed replacement event
+ *
+ * Talks to brainstormVM CP `/api/v1/evidence/lineage/{lineage_did}`
+ * which returns the precomputed report. This CLI surface formats it
+ * for the operator; the verification math lives server-side because
+ * the CP holds the canonical chain.
+ */
+
+import { Command } from "commander";
+
+interface VerifyOptions {
+  lineage?: string;
+  format?: "human" | "json";
+  vmUrl?: string;
+  vmToken?: string;
+}
+
+interface SectionStatus {
+  ok: boolean;
+  summary: string;
+  details?: Record<string, unknown>;
+}
+
+interface VerifyReport {
+  lineage_did: string;
+  generated_at: string;
+  chain: SectionStatus;
+  lineage: SectionStatus;
+  manifest: SectionStatus;
+  quota: SectionStatus;
+  policy: SectionStatus;
+  lifecycle: SectionStatus;
+  intent: SectionStatus;
+  replace: SectionStatus;
+}
+
+const SECTIONS: Array<{
+  key: keyof VerifyReport;
+  label: string;
+}> = [
+  { key: "chain", label: "CHAIN" },
+  { key: "lineage", label: "LINEAGE" },
+  { key: "manifest", label: "MANIFEST" },
+  { key: "quota", label: "QUOTA" },
+  { key: "policy", label: "POLICY" },
+  { key: "lifecycle", label: "LIFECYCLE" },
+  { key: "intent", label: "INTENT" },
+  { key: "replace", label: "REPLACE" },
+];
+
+function isSectionStatus(v: unknown): v is SectionStatus {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    typeof (v as SectionStatus).ok === "boolean" &&
+    typeof (v as SectionStatus).summary === "string"
+  );
+}
+
+export function renderHuman(report: VerifyReport): string {
+  const overallOk = SECTIONS.every((s) =>
+    isSectionStatus(report[s.key])
+      ? (report[s.key] as SectionStatus).ok
+      : false,
+  );
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(`  Evidence verify — ${report.lineage_did}`);
+  lines.push(`  Generated:       ${report.generated_at}`);
+  lines.push(
+    `  Overall:         ${overallOk ? "✓ PASS" : "✗ FAIL — see sections below"}`,
+  );
+  lines.push("");
+  for (const s of SECTIONS) {
+    const v = report[s.key];
+    if (!isSectionStatus(v)) {
+      lines.push(`  [${s.label}] (missing section)`);
+      continue;
+    }
+    const tick = v.ok ? "✓" : "✗";
+    lines.push(`  [${s.label}] ${tick} ${v.summary}`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+async function fetchReport(
+  baseUrl: string,
+  token: string,
+  lineageDID: string,
+): Promise<{ status: number; body: unknown }> {
+  const url = `${baseUrl.replace(/\/$/, "")}/api/v1/evidence/lineage/${encodeURIComponent(
+    lineageDID,
+  )}`;
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(30_000),
+  });
+  let body: unknown = null;
+  try {
+    body = await res.json();
+  } catch {
+    /* keep null */
+  }
+  return { status: res.status, body };
+}
+
+export function registerEvidenceCommand(program: Command): void {
+  const cmd = program
+    .command("evidence")
+    .description("Evidence-chain operations");
+
+  cmd
+    .command("verify")
+    .description("Verify a HAI lineage chain end-to-end (Phase G ratification)")
+    .requiredOption("--lineage <did>", "lineage_did to verify")
+    .option(
+      "--format <fmt>",
+      "Output format (human | json)",
+      (v): "human" | "json" => {
+        if (v !== "human" && v !== "json") {
+          throw new Error(`unknown format ${v}: must be 'human' or 'json'`);
+        }
+        return v;
+      },
+      "human",
+    )
+    .option(
+      "--vm-url <url>",
+      "brainstormVM CP URL (default $BRAINSTORM_VM_URL)",
+    )
+    .option(
+      "--vm-token <token>",
+      "VM bearer token (default $BRAINSTORM_VM_API_KEY)",
+    )
+    .action(async (opts: VerifyOptions) => {
+      const baseUrl =
+        opts.vmUrl ??
+        process.env.BRAINSTORM_VM_URL ??
+        "https://vm.brainstorm.co";
+      const token = opts.vmToken ?? process.env.BRAINSTORM_VM_API_KEY ?? "";
+      if (!token) {
+        console.error(
+          "  Error: BRAINSTORM_VM_API_KEY not set (or pass --vm-token).",
+        );
+        process.exitCode = 2;
+        return;
+      }
+      if (!opts.lineage || !opts.lineage.startsWith("did:bvm:")) {
+        console.error(
+          `  Error: --lineage must be a did:bvm:... lineage DID (got ${opts.lineage})`,
+        );
+        process.exitCode = 2;
+        return;
+      }
+
+      try {
+        const { status, body } = await fetchReport(
+          baseUrl,
+          token,
+          opts.lineage,
+        );
+        if (status === 404) {
+          console.error(
+            `  ✗ lineage ${opts.lineage} not found on CP at ${baseUrl}`,
+          );
+          process.exitCode = 1;
+          return;
+        }
+        if (status >= 400) {
+          console.error(`  ✗ HTTP ${status} from CP — ${JSON.stringify(body)}`);
+          process.exitCode = 1;
+          return;
+        }
+        const report = body as VerifyReport;
+        if (opts.format === "json") {
+          console.log(JSON.stringify(report, null, 2));
+        } else {
+          console.log(renderHuman(report));
+        }
+        const overallOk = SECTIONS.every((s) =>
+          isSectionStatus(report[s.key])
+            ? (report[s.key] as SectionStatus).ok
+            : false,
+        );
+        if (!overallOk) {
+          process.exitCode = 1;
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`  ✗ evidence verify failed: ${msg}`);
+        process.exitCode = 1;
+      }
+    });
+}
+
+// Exported for tests.
+export const __test = {
+  renderHuman,
+  isSectionStatus,
+  SECTIONS,
+  fetchReport,
+};


### PR DESCRIPTION
## Summary
- New `brainstorm evidence verify --lineage <did> [--format human|json]` — Phase G ratification surface from radiant-petting-kitten rev 2
- Queries brainstormVM CP `/api/v1/evidence/lineage/{lineage_did}` and renders 8 status sections (CHAIN / LINEAGE / MANIFEST / QUOTA / POLICY / LIFECYCLE / INTENT / REPLACE)
- Overall PASS iff every section reports ok=true; exits 1 on any FAIL so demo gate plumbing is automatic
- Validates `did:bvm:` prefix client-side; reuses `--vm-token` / `--vm-url` per-product credential convention from #349
- 5 vitest tests: full pass render, partial-fail rendering, missing-section defensive default, URL encoding + bearer auth, 404 with non-JSON body

## Plan reference
P5/Wk12 #73 of `radiant-petting-kitten` rev 2.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/__tests__/evidence.test.ts` — 5/5 green
- [ ] End-to-end against a real brainstormVM CP — substrate-blocked per /goal

🤖 Generated with [Claude Code](https://claude.com/claude-code)