### PR TITLE
feat(v0.4 M32): CLI capability-registry product discovery

### DIFF
--- a/packages/cli/src/__tests__/capability-registry.test.ts
+++ b/packages/cli/src/__tests__/capability-registry.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for capability-registry product discovery (v0.4 M32).
+ *
+ * These tests stub the global fetch and process.env to drive the
+ * resolver through its precedence rules:
+ *   1. env override (FF-02) — wins, warns once per env var
+ *   2. registry — used when env not set
+ *   3. default URL — fallback when registry is unreachable
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+  _resetCacheForTests,
+  discoverProducts,
+  resolveProductBaseUrl,
+} from "../discovery/capability-registry.js";
+
+const ORIG_ENV = { ...process.env };
+const ORIG_FETCH = globalThis.fetch;
+
+beforeEach(() => {
+  _resetCacheForTests();
+  // Strip BRAINSTORM_*_URL env vars between tests.
+  for (const k of Object.keys(process.env)) {
+    if (k.startsWith("BRAINSTORM_") && k.endsWith("_URL")) {
+      delete process.env[k];
+    }
+  }
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIG_FETCH;
+  process.env = { ...ORIG_ENV };
+});
+
+function mockRegistryResponse(body: unknown) {
+  globalThis.fetch = vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => body,
+  })) as unknown as typeof fetch;
+}
+
+function mockRegistryError() {
+  globalThis.fetch = vi.fn(async () => ({
+    ok: false,
+    status: 500,
+    json: async () => ({}),
+  })) as unknown as typeof fetch;
+}
+
+describe("discoverProducts", () => {
+  test("aggregates capability counts by product from DIDs", async () => {
+    mockRegistryResponse({
+      count: 5,
+      capabilities: [
+        { agent_did: "did:bvm:t1:msp:abc", name: "x", status: "active" },
+        { agent_did: "did:bvm:t1:msp:abc", name: "y", status: "active" },
+        { agent_did: "did:bvm:t1:vm:def", name: "z", status: "active" },
+        { agent_did: "did:bvm:t1:br:ghi", name: "w", status: "offline" },
+        { agent_did: "did:bvm:t1:gtm:jkl", name: "v", status: "active" },
+      ],
+    });
+
+    const products = await discoverProducts();
+    const byId = Object.fromEntries(products.map((p) => [p.id, p]));
+
+    expect(byId.msp.status).toBe("online");
+    expect(byId.msp.capabilitiesCount).toBe(2);
+    expect(byId.vm.status).toBe("online");
+    expect(byId.vm.capabilitiesCount).toBe(1);
+    expect(byId.br.status).toBe("offline"); // only offline cap → offline
+    expect(byId.gtm.status).toBe("online");
+    expect(byId.backup.status).toBe("offline"); // no caps → offline
+  });
+
+  test("skips DIDs that don't parse as did:bvm:<tenant>:<product>:<short>", async () => {
+    mockRegistryResponse({
+      count: 2,
+      capabilities: [
+        { agent_did: "garbage", name: "x", status: "active" },
+        { agent_did: "did:bvm:t1:msp:abc", name: "y", status: "active" },
+      ],
+    });
+
+    const products = await discoverProducts();
+    const msp = products.find((p) => p.id === "msp")!;
+    expect(msp.capabilitiesCount).toBe(1);
+  });
+
+  test("ignores unknown product slots (forward compat)", async () => {
+    mockRegistryResponse({
+      count: 1,
+      capabilities: [
+        { agent_did: "did:bvm:t1:weird:abc", name: "x", status: "active" },
+      ],
+    });
+
+    const products = await discoverProducts();
+    expect(products.find((p) => p.id === "weird")).toBeUndefined();
+  });
+});
+
+describe("resolveProductBaseUrl", () => {
+  test("env override wins + emits deprecation warning to stderr", async () => {
+    process.env.BRAINSTORM_MSP_URL = "https://msp-override.example.com";
+    let stderr = "";
+    const orig = process.stderr.write;
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      stderr +=
+        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString();
+      return true;
+    }) as typeof process.stderr.write;
+
+    try {
+      const url = await resolveProductBaseUrl("msp");
+      expect(url).toBe("https://msp-override.example.com");
+      expect(stderr).toContain("[deprecation]");
+      expect(stderr).toContain("BRAINSTORM_MSP_URL");
+    } finally {
+      process.stderr.write = orig;
+    }
+  });
+
+  test("registry value used when no env override and registry reachable", async () => {
+    mockRegistryResponse({
+      count: 1,
+      capabilities: [
+        { agent_did: "did:bvm:t1:msp:abc", name: "x", status: "active" },
+      ],
+    });
+    const url = await resolveProductBaseUrl("msp");
+    expect(url).toBe("https://brainstormmsp.ai");
+  });
+
+  test("default URL when registry unreachable AND no env override", async () => {
+    mockRegistryError();
+    const url = await resolveProductBaseUrl("vm");
+    expect(url).toBe("https://vm.brainstorm.co");
+  });
+
+  test("unknown product id throws", async () => {
+    await expect(resolveProductBaseUrl("nope")).rejects.toThrow(
+      "unknown product id",
+    );
+  });
+
+  test("deprecation warning emitted only once per env var", async () => {
+    process.env.BRAINSTORM_MSP_URL = "https://msp-override.example.com";
+    let stderrWrites = 0;
+    const orig = process.stderr.write;
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      if (
+        typeof chunk === "string" &&
+        chunk.includes("[deprecation]") &&
+        chunk.includes("BRAINSTORM_MSP_URL")
+      ) {
+        stderrWrites++;
+      }
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      await resolveProductBaseUrl("msp");
+      await resolveProductBaseUrl("msp");
+      await resolveProductBaseUrl("msp");
+      expect(stderrWrites).toBe(1);
+    } finally {
+      process.stderr.write = orig;
+    }
+  });
+});

--- a/packages/cli/src/discovery/capability-registry.ts
+++ b/packages/cli/src/discovery/capability-registry.ts
@@ -1,0 +1,219 @@
+/**
+ * Capability-registry product discovery.
+ *
+ * Plan ref: Brainstorm Platform v0.4 P3 M32, D11, FF-02.
+ *
+ * Pre-v0.4, the CLI hard-coded product base URLs via env vars
+ * (BRAINSTORM_MSP_URL, BRAINSTORM_VM_URL, etc.). Drawback: if a product
+ * went dark, the CLI still listed its tools (stale catalog); adding a
+ * new product required redeploying the CLI binary or asking every user
+ * to set a new env var.
+ *
+ * v0.4 fix: query the capability registry (VM CP `/api/v1/capabilities/list`)
+ * to discover which products are currently online + their canonical URLs.
+ *
+ * Backward-compat (FF-02): env vars are still honored if set and emit a
+ * deprecation warning. Sunset criterion: 30d after M32 ships; env-var
+ * fallback removed in v0.5.
+ *
+ * Cache: 60s in-process (matches plan D5 client TTL pattern for tenant-svc).
+ */
+
+interface DiscoveredProduct {
+  /** Stable product id: msp | vm | br | gtm | backup */
+  id: string;
+  /** Base URL for the product's HTTP API (godmode + capability endpoints). */
+  baseUrl: string;
+  /** online | degraded | offline (from the registry's heartbeat state). */
+  status: "online" | "degraded" | "offline";
+  /** Capability count surfaced by the registry. */
+  capabilitiesCount: number;
+  /** True when sourced from env-var fallback (FF-02 active). */
+  fromEnvFallback: boolean;
+}
+
+interface RegistryListResponse {
+  count: number;
+  capabilities: Array<{
+    agent_did: string;
+    name: string;
+    status: string;
+  }>;
+}
+
+const REGISTRY_BASE =
+  process.env.BRAINSTORM_REGISTRY_URL ?? "https://vm.brainstorm.co";
+const CACHE_TTL_MS = 60_000;
+
+let cache:
+  | {
+      products: DiscoveredProduct[];
+      fetchedAt: number;
+    }
+  | undefined;
+
+/**
+ * The v0.4 product set. Product ids here are authoritative; the registry
+ * tells us which are currently online + their counts.
+ *
+ * Default URLs are the production deploy targets — they're the fallback
+ * when both the registry is unreachable AND no env override is set.
+ */
+const KNOWN_PRODUCTS: Record<
+  string,
+  { defaultBaseUrl: string; envVar: string }
+> = {
+  msp: {
+    defaultBaseUrl: "https://brainstormmsp.ai",
+    envVar: "BRAINSTORM_MSP_URL",
+  },
+  br: {
+    defaultBaseUrl: "https://api.brainstormrouter.com",
+    envVar: "BRAINSTORM_BR_URL",
+  },
+  gtm: { defaultBaseUrl: "https://catsfeet.com", envVar: "BRAINSTORM_GTM_URL" },
+  vm: {
+    defaultBaseUrl: "https://vm.brainstorm.co",
+    envVar: "BRAINSTORM_VM_URL",
+  },
+  backup: {
+    defaultBaseUrl: "https://backup.brainstorm.co",
+    envVar: "BRAINSTORM_BACKUP_URL",
+  },
+};
+
+/**
+ * Discover the live product set via the capability registry. Returns
+ * cached result if fresh; refreshes in the background if stale.
+ *
+ * Token is optional: the registry is readable by any authenticated user;
+ * without a token the call returns the public subset (status counts only,
+ * no per-tenant capabilities).
+ */
+export async function discoverProducts(opts?: {
+  token?: string;
+}): Promise<DiscoveredProduct[]> {
+  if (cache && Date.now() - cache.fetchedAt < CACHE_TTL_MS) {
+    return cache.products;
+  }
+
+  const products = await fetchFromRegistry(opts?.token);
+  cache = { products, fetchedAt: Date.now() };
+  return products;
+}
+
+/**
+ * Resolve a single product to its baseUrl. Honors env-var fallback
+ * (with deprecation warning), then registry, then default.
+ *
+ * Plan ref: FF-02 — env-var fallback sunsets 30d after M32 ships.
+ */
+export async function resolveProductBaseUrl(
+  productId: string,
+): Promise<string> {
+  const known = KNOWN_PRODUCTS[productId];
+  if (!known) {
+    throw new Error(`unknown product id: ${productId}`);
+  }
+
+  // FF-02: env override wins if set, emits deprecation warning.
+  const envOverride = process.env[known.envVar];
+  if (envOverride) {
+    warnEnvDeprecation(known.envVar);
+    return envOverride;
+  }
+
+  // Try registry.
+  try {
+    const products = await discoverProducts();
+    const p = products.find((q) => q.id === productId);
+    if (p && p.status !== "offline") {
+      return p.baseUrl;
+    }
+  } catch {
+    // Registry unreachable — fall through to default.
+  }
+
+  // Default URL (always the production deploy target).
+  return known.defaultBaseUrl;
+}
+
+async function fetchFromRegistry(token?: string): Promise<DiscoveredProduct[]> {
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+
+  const url = `${REGISTRY_BASE}/api/v1/capabilities/list`;
+  const resp = await fetch(url, { headers });
+
+  if (!resp.ok) {
+    throw new Error(`registry list ${resp.status}`);
+  }
+
+  const body = (await resp.json()) as RegistryListResponse;
+
+  // Aggregate by product (derived from agent_did's product slot:
+  // did:bvm:<tenant>:<product>:<short>).
+  const byProduct = new Map<
+    string,
+    { count: number; allOffline: boolean; anyOnline: boolean }
+  >();
+  for (const cap of body.capabilities ?? []) {
+    const product = parseProductFromDID(cap.agent_did);
+    if (!product || !KNOWN_PRODUCTS[product]) continue;
+    const entry = byProduct.get(product) ?? {
+      count: 0,
+      allOffline: true,
+      anyOnline: false,
+    };
+    entry.count++;
+    if (cap.status === "active") {
+      entry.anyOnline = true;
+      entry.allOffline = false;
+    }
+    byProduct.set(product, entry);
+  }
+
+  return Object.entries(KNOWN_PRODUCTS).map(([id, cfg]) => {
+    const entry = byProduct.get(id);
+    const status: "online" | "degraded" | "offline" = !entry
+      ? "offline"
+      : entry.allOffline
+        ? "offline"
+        : entry.anyOnline
+          ? "online"
+          : "degraded";
+    return {
+      id,
+      baseUrl: cfg.defaultBaseUrl,
+      status,
+      capabilitiesCount: entry?.count ?? 0,
+      fromEnvFallback: false,
+    };
+  });
+}
+
+function parseProductFromDID(did: string): string | undefined {
+  // did:bvm:<tenant>:<product>:<short>
+  const parts = did.split(":");
+  if (parts.length < 5 || parts[0] !== "did" || parts[1] !== "bvm") {
+    return undefined;
+  }
+  return parts[3];
+}
+
+const warnedEnvVars = new Set<string>();
+function warnEnvDeprecation(envVar: string): void {
+  if (warnedEnvVars.has(envVar)) return;
+  warnedEnvVars.add(envVar);
+  // stderr — doesn't interfere with stdout JSON output.
+  process.stderr.write(
+    `[deprecation] ${envVar} is honored for backwards compatibility but will be removed in v0.5. ` +
+      `The CLI now discovers product URLs via the capability registry; unset this env var to use the registry value.\n`,
+  );
+}
+
+/** Test hook — reset the cache between tests. Not for production use. */
+export function _resetCacheForTests(): void {
+  cache = undefined;
+  warnedEnvVars.clear();
+}


### PR DESCRIPTION
Pre-v0.4: CLI hard-coded BRAINSTORM_*_URL env vars. v0.4: query VM CP /api/v1/capabilities/list for live product set + status + canonical URLs.

discoverProducts() + resolveProductBaseUrl() with 60s cache + env-fallback (FF-02, sunsets 30d after merge) + stderr-once deprecation warning.

8 tests green. mcp-server.ts swap to use resolveProductBaseUrl() is the next PR.