### PR TITLE
fix: close v18 attacker harness gaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "build": "turbo run build && npm run contract-check",
-    "build:no-preflight": "turbo run build",
+    "build:dangerous-skip-gates": "node -e \"console.error('[dangerous] Skipping Brainstorm preflight/contract gates; use npm run build for release/CI.')\" && turbo run build",
     "contract-check": "node scripts/contract-check.mjs",
     "contract-check:json": "node scripts/contract-check.mjs --json",
     "dev": "turbo run dev",

--- a/packages/broker/src/__tests__/broker.test.ts
+++ b/packages/broker/src/__tests__/broker.test.ts
@@ -15,11 +15,14 @@ import {
   type Broker,
 } from "../index.js";
 
+const BROKER_TOKEN = "test-broker-token";
+
 async function bootBroker(livePids?: Set<number>): Promise<Broker> {
   const alive = livePids ?? new Set<number>();
   const broker = createBroker({
     port: 0, // ephemeral
     dbPath: ":memory:",
+    authToken: BROKER_TOKEN,
     cleanupIntervalMs: 0, // no scheduled reap in tests — reap only at startup
     isPidAlive: (pid) => alive.has(pid),
   });
@@ -44,8 +47,16 @@ function makeClient(
     heartbeatIntervalMs: 10_000, // won't fire in test
     pollIntervalMs: 10_000, // won't fire in test
     requestTimeoutMs: 2_000,
+    brokerToken: BROKER_TOKEN,
     ...overrides,
   });
+}
+
+function brokerAuthHeaders(): Record<string, string> {
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${BROKER_TOKEN}`,
+  };
 }
 
 let broker: Broker;
@@ -149,7 +160,7 @@ describe("broker", () => {
       const port = broker.port();
       const pollRes = await fetch(`http://127.0.0.1:${port}/poll-messages`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: brokerAuthHeaders(),
         body: JSON.stringify({ id: bId }),
       });
       return pollRes.json() as Promise<{
@@ -181,7 +192,7 @@ describe("broker", () => {
     const drain = async () => {
       const res = await fetch(`http://127.0.0.1:${port}/poll-messages`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: brokerAuthHeaders(),
         body: JSON.stringify({ id: bId }),
       });
       return (await res.json()) as { messages: unknown[] };
@@ -249,6 +260,26 @@ describe("broker", () => {
     expect(health.status).toBe("ok");
     expect(health.peers).toBe(1);
     await a.stop();
+  });
+
+  it("rejects POST requests without the local bearer token", async () => {
+    const res = await fetch(`http://127.0.0.1:${broker.port()}/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        pid: 9999,
+        cwd: "/tmp/test",
+        git_root: null,
+        tty: null,
+        summary: "",
+        auth_fingerprint: "attacker",
+      }),
+    });
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({
+      error: "broker bearer token required",
+    });
   });
 
   it("fingerprintApiKey is deterministic + 16 hex chars", () => {

--- a/packages/broker/src/client.ts
+++ b/packages/broker/src/client.ts
@@ -21,7 +21,7 @@ import type {
   RegisterResponse,
   SendMessageResponse,
 } from "./types.js";
-import { DEFAULT_BROKER_PORT } from "./daemon.js";
+import { DEFAULT_BROKER_PORT, readBrokerToken } from "./daemon.js";
 
 const log = createLogger("broker-client");
 
@@ -42,6 +42,8 @@ export interface BrokerClientOptions {
   pollIntervalMs?: number;
   /** HTTP timeout for a single request. Default 3s. */
   requestTimeoutMs?: number;
+  /** Local broker bearer token. Defaults to env or ~/.brainstorm/broker-token. */
+  brokerToken?: string;
 }
 
 export type MessageCallback = (msg: Message) => void | Promise<void>;
@@ -59,6 +61,7 @@ export class BrokerClient {
   private readonly baseUrl: string;
   private readonly apiKey: string;
   private readonly fingerprint: string;
+  private readonly brokerToken: string | null;
   private readonly meta: {
     pid: number;
     cwd: string;
@@ -80,6 +83,10 @@ export class BrokerClient {
     this.baseUrl = `http://127.0.0.1:${opts.port ?? DEFAULT_BROKER_PORT}`;
     this.apiKey = opts.apiKey;
     this.fingerprint = fingerprintApiKey(opts.apiKey);
+    this.brokerToken =
+      opts.brokerToken ??
+      process.env.BRAINSTORM_BROKER_TOKEN ??
+      readBrokerToken();
     this.meta = {
       pid: opts.pid,
       cwd: opts.cwd,
@@ -248,9 +255,16 @@ export class BrokerClient {
   }
 
   private async post(path: string, body: unknown): Promise<unknown> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (this.brokerToken) {
+      headers.Authorization = `Bearer ${this.brokerToken}`;
+    }
+
     const res = await fetch(`${this.baseUrl}${path}`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers,
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(this.requestTimeoutMs),
     });

--- a/packages/broker/src/client.ts
+++ b/packages/broker/src/client.ts
@@ -21,7 +21,7 @@ import type {
   RegisterResponse,
   SendMessageResponse,
 } from "./types.js";
-import { DEFAULT_BROKER_PORT, readBrokerToken } from "./daemon.js";
+import { DEFAULT_BROKER_PORT } from "./daemon.js";
 
 const log = createLogger("broker-client");
 
@@ -84,9 +84,7 @@ export class BrokerClient {
     this.apiKey = opts.apiKey;
     this.fingerprint = fingerprintApiKey(opts.apiKey);
     this.brokerToken =
-      opts.brokerToken ??
-      process.env.BRAINSTORM_BROKER_TOKEN ??
-      readBrokerToken();
+      opts.brokerToken ?? process.env.BRAINSTORM_BROKER_TOKEN ?? null;
     this.meta = {
       pid: opts.pid,
       cwd: opts.cwd,

--- a/packages/broker/src/daemon.ts
+++ b/packages/broker/src/daemon.ts
@@ -23,6 +23,14 @@
  */
 
 import http, { type IncomingMessage, type ServerResponse } from "node:http";
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { createLogger } from "@brainst0rm/shared";
 import Database, { type Database as DatabaseType } from "better-sqlite3";
 import type {
@@ -127,6 +135,7 @@ function toWireMessage(row: MessageRow): Message {
 export interface BrokerOptions {
   port?: number;
   dbPath?: string;
+  authToken?: string;
   cleanupIntervalMs?: number;
   /**
    * Override the liveness probe. Useful for tests where PIDs are fabricated.
@@ -146,6 +155,8 @@ export function createBroker(opts: BrokerOptions = {}): Broker {
   const dbPath = opts.dbPath ?? defaultDbPath();
   const cleanupIntervalMs = opts.cleanupIntervalMs ?? 30_000;
   const isPidAlive = opts.isPidAlive ?? defaultIsPidAlive;
+  const authToken =
+    opts.authToken ?? process.env.BRAINSTORM_BROKER_TOKEN ?? initBrokerToken();
 
   const db = new Database(dbPath);
   initSchema(db);
@@ -291,6 +302,17 @@ export function createBroker(opts: BrokerOptions = {}): Broker {
     return { status: "ok", peers: row.n, version: BROKER_VERSION };
   }
 
+  function verifyBearer(req: IncomingMessage): boolean {
+    const authHeader = req.headers.authorization;
+    if (!authHeader) return false;
+    const m = /^Bearer\s+(.+)$/i.exec(authHeader.trim());
+    if (!m) return false;
+    const supplied = Buffer.from(m[1], "utf8");
+    const expected = Buffer.from(authToken, "utf8");
+    if (supplied.length !== expected.length) return false;
+    return timingSafeEqual(supplied, expected);
+  }
+
   async function readJson(req: IncomingMessage): Promise<unknown> {
     const chunks: Buffer[] = [];
     for await (const chunk of req) chunks.push(chunk as Buffer);
@@ -315,6 +337,9 @@ export function createBroker(opts: BrokerOptions = {}): Broker {
       }
       if (req.method !== "POST") {
         return json(res, 405, { error: "method not allowed" });
+      }
+      if (!verifyBearer(req)) {
+        return json(res, 401, { error: "broker bearer token required" });
       }
       const body = await readJson(req);
       switch (req.url) {
@@ -409,4 +434,31 @@ function defaultIsPidAlive(pid: number): boolean {
 function defaultDbPath(): string {
   const home = process.env.HOME ?? process.env.USERPROFILE ?? "/tmp";
   return `${home}/.brainstorm/broker.db`;
+}
+
+export function brokerTokenPath(): string {
+  const home =
+    process.env.BRAINSTORM_HOME ??
+    `${process.env.HOME ?? process.env.USERPROFILE ?? "/tmp"}/.brainstorm`;
+  return `${home}/broker-token`;
+}
+
+export function readBrokerToken(): string | null {
+  const path = brokerTokenPath();
+  if (!existsSync(path)) return null;
+  const token = readFileSync(path, "utf8").trim();
+  return token.length > 0 ? token : null;
+}
+
+function initBrokerToken(): string {
+  const existing = readBrokerToken();
+  if (existing) return existing;
+
+  const path = brokerTokenPath();
+  const dir = path.slice(0, path.lastIndexOf("/"));
+  mkdirSync(dir, { recursive: true });
+  const token = randomBytes(32).toString("hex");
+  writeFileSync(path, token, { mode: 0o600 });
+  chmodSync(path, 0o600);
+  return token;
 }

--- a/packages/broker/src/daemon.ts
+++ b/packages/broker/src/daemon.ts
@@ -303,11 +303,9 @@ export function createBroker(opts: BrokerOptions = {}): Broker {
   }
 
   function verifyBearer(req: IncomingMessage): boolean {
-    const authHeader = req.headers.authorization;
-    if (!authHeader) return false;
-    const m = /^Bearer\s+(.+)$/i.exec(authHeader.trim());
-    if (!m) return false;
-    const supplied = Buffer.from(m[1], "utf8");
+    const suppliedToken = parseBearerToken(req.headers.authorization);
+    if (!suppliedToken) return false;
+    const supplied = Buffer.from(suppliedToken, "utf8");
     const expected = Buffer.from(authToken, "utf8");
     if (supplied.length !== expected.length) return false;
     return timingSafeEqual(supplied, expected);
@@ -450,7 +448,27 @@ export function readBrokerToken(): string | null {
   return token.length > 0 ? token : null;
 }
 
-function initBrokerToken(): string {
+function parseBearerToken(authHeader: string | undefined): string | null {
+  if (!authHeader) return null;
+  const trimmed = authHeader.trim();
+  if (trimmed.length <= "Bearer ".length) return null;
+  if (trimmed.slice(0, 6).toLowerCase() !== "bearer") return null;
+  const separator = trimmed.charAt(6);
+  if (separator !== " " && separator !== "\t") return null;
+
+  let tokenStart = 7;
+  while (
+    tokenStart < trimmed.length &&
+    (trimmed.charAt(tokenStart) === " " || trimmed.charAt(tokenStart) === "\t")
+  ) {
+    tokenStart += 1;
+  }
+
+  const token = trimmed.slice(tokenStart);
+  return token.length > 0 ? token : null;
+}
+
+export function initBrokerToken(): string {
   const existing = readBrokerToken();
   if (existing) return existing;
 

--- a/packages/broker/src/ensure-broker.ts
+++ b/packages/broker/src/ensure-broker.ts
@@ -11,7 +11,7 @@
 
 import { spawn } from "node:child_process";
 import { createLogger } from "@brainst0rm/shared";
-import { DEFAULT_BROKER_PORT } from "./daemon.js";
+import { DEFAULT_BROKER_PORT, initBrokerToken } from "./daemon.js";
 
 const log = createLogger("broker-ensure");
 
@@ -44,6 +44,8 @@ export async function ensureBroker(
 ): Promise<number> {
   const port = opts.port ?? DEFAULT_BROKER_PORT;
   const timeoutMs = opts.startupTimeoutMs ?? 6_000;
+  const brokerToken = process.env.BRAINSTORM_BROKER_TOKEN ?? initBrokerToken();
+  process.env.BRAINSTORM_BROKER_TOKEN = brokerToken;
 
   if (await isBrokerAlive(port)) return port;
 
@@ -58,7 +60,11 @@ export async function ensureBroker(
   const child = spawn(process.execPath, [binPath], {
     detached: true,
     stdio: "ignore",
-    env: { ...process.env, BRAINSTORM_BROKER_PORT: String(port) },
+    env: {
+      ...process.env,
+      BRAINSTORM_BROKER_PORT: String(port),
+      BRAINSTORM_BROKER_TOKEN: brokerToken,
+    },
   });
   child.unref();
 

--- a/packages/broker/src/index.ts
+++ b/packages/broker/src/index.ts
@@ -2,6 +2,8 @@ export {
   createBroker,
   BROKER_VERSION,
   DEFAULT_BROKER_PORT,
+  brokerTokenPath,
+  readBrokerToken,
   type Broker,
   type BrokerOptions,
 } from "./daemon.js";

--- a/packages/server/src/__tests__/server.test.ts
+++ b/packages/server/src/__tests__/server.test.ts
@@ -167,4 +167,14 @@ describe("BrainstormServer Utility Methods", () => {
       expect((server as any).safeInt("42", 99)).toBe(42);
     });
   });
+
+  describe("default chat permissions", () => {
+    it("allows auto tools but requires confirmation for mutating tools", () => {
+      const check = (BrainstormServer as any).DEFAULT_CHAT_PERMISSION_CHECK;
+
+      expect(check("file_read", "auto")).toBe("allow");
+      expect(check("file_write", "confirm")).toBe("confirm");
+      expect(check("dangerous", "deny")).toBe("deny");
+    });
+  });
 });

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -51,7 +51,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { createLogger } from "@brainst0rm/shared";
 import type { GodModeConnectionResult } from "@brainst0rm/godmode";
-import type { ToolRegistry } from "@brainst0rm/tools";
+import type { PermissionCheckFn, ToolRegistry } from "@brainst0rm/tools";
 import type { BrainstormRouter, CostTracker } from "@brainst0rm/router";
 import type { ProviderRegistry } from "@brainst0rm/providers";
 import type Database from "better-sqlite3";
@@ -84,6 +84,7 @@ export interface ServerDependencies {
   godmode: GodModeConnectionResult;
   memoryManager?: MemoryManager;
   version?: string;
+  permissionCheck?: PermissionCheckFn;
 }
 
 export class BrainstormServer {
@@ -108,6 +109,15 @@ export class BrainstormServer {
    */
   private devToken: string | null = null;
   private devTokenPath: string | null = null;
+
+  private static readonly DEFAULT_CHAT_PERMISSION_CHECK: PermissionCheckFn = (
+    _toolName,
+    toolPermission,
+  ) => {
+    if (toolPermission === "auto") return "allow";
+    if (toolPermission === "deny") return "deny";
+    return "confirm";
+  };
 
   constructor(deps: ServerDependencies, opts?: ServerOptions) {
     this.deps = deps;
@@ -613,7 +623,9 @@ export class BrainstormServer {
         projectPath: this.opts.projectPath,
         systemPrompt,
         systemSegments: segments,
-        permissionCheck: () => "allow" as const,
+        permissionCheck:
+          this.deps.permissionCheck ??
+          BrainstormServer.DEFAULT_CHAT_PERMISSION_CHECK,
         middleware: createDefaultMiddlewarePipeline(this.opts.projectPath),
         preferredModelId,
         signal: abortController.signal,
@@ -689,7 +701,9 @@ export class BrainstormServer {
         projectPath: this.opts.projectPath,
         systemPrompt,
         systemSegments: segments,
-        permissionCheck: () => "allow" as const,
+        permissionCheck:
+          this.deps.permissionCheck ??
+          BrainstormServer.DEFAULT_CHAT_PERMISSION_CHECK,
         middleware: createDefaultMiddlewarePipeline(this.opts.projectPath),
         preferredModelId,
         signal: abortController.signal,

--- a/packages/tools/src/__tests__/file-tools-sensitive-paths.test.ts
+++ b/packages/tools/src/__tests__/file-tools-sensitive-paths.test.ts
@@ -19,7 +19,7 @@
 import { describe, it, expect } from "vitest";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { fileReadTool } from "../builtin/file-read.js";
 import { fileWriteTool } from "../builtin/file-write.js";
@@ -32,6 +32,12 @@ function isBlocked(result: any): boolean {
   if (!result || typeof result !== "object") return false;
   const msg = typeof result.error === "string" ? result.error : "";
   return msg.startsWith("Path blocked");
+}
+
+function existingSensitiveSystemTarget(): string | null {
+  return (
+    ["/etc/sudoers", "/etc/shadow"].find((path) => existsSync(path)) ?? null
+  );
 }
 
 describe("file tools — sensitive-path blocks", () => {
@@ -69,6 +75,18 @@ describe("file tools — sensitive-path blocks", () => {
       });
       expect(isBlocked(result)).toBe(false);
     });
+    it("blocks reading a sensitive target through a workspace symlink", async () => {
+      const target = existingSensitiveSystemTarget();
+      expect(target).not.toBeNull();
+      if (!target) return;
+
+      const dir = mkdtempSync(join(tmpdir(), "brainstorm-file-read-link-"));
+      const link = join(dir, "linked-sensitive");
+      symlinkSync(target, link);
+
+      const result = await fileReadTool.execute({ path: link });
+      expect(isBlocked(result)).toBe(true);
+    });
   });
 
   describe("file_write", () => {
@@ -97,6 +115,21 @@ describe("file tools — sensitive-path blocks", () => {
       });
       expect(isBlocked(result)).toBe(false);
     });
+    it("blocks writing through a symlinked sensitive directory", async () => {
+      const target = existingSensitiveSystemTarget();
+      expect(target).not.toBeNull();
+      if (!target) return;
+
+      const dir = mkdtempSync(join(tmpdir(), "brainstorm-file-write-link-"));
+      const link = join(dir, "linked-etc");
+      symlinkSync("/etc", link);
+
+      const result = await fileWriteTool.execute({
+        path: join(link, target.split("/").at(-1) ?? "sudoers"),
+        content: "attacker\n",
+      });
+      expect(isBlocked(result)).toBe(true);
+    });
   });
 
   describe("file_edit", () => {
@@ -118,6 +151,22 @@ describe("file tools — sensitive-path blocks", () => {
         new_string: "goodbye",
       });
       expect(isBlocked(result)).toBe(false);
+    });
+    it("blocks editing through a symlinked sensitive directory", async () => {
+      const target = existingSensitiveSystemTarget();
+      expect(target).not.toBeNull();
+      if (!target) return;
+
+      const dir = mkdtempSync(join(tmpdir(), "brainstorm-file-edit-link-"));
+      const link = join(dir, "linked-etc");
+      symlinkSync("/etc", link);
+
+      const result = await fileEditTool.execute({
+        path: join(link, target.split("/").at(-1) ?? "sudoers"),
+        old_string: "root",
+        new_string: "attacker",
+      });
+      expect(isBlocked(result)).toBe(true);
     });
   });
 
@@ -147,6 +196,21 @@ describe("file tools — sensitive-path blocks", () => {
         edits: [{ old_string: "a", new_string: "A" }],
       });
       expect(isBlocked(result)).toBe(false);
+    });
+    it("blocks multi-edit through a symlinked sensitive directory", async () => {
+      const target = existingSensitiveSystemTarget();
+      expect(target).not.toBeNull();
+      if (!target) return;
+
+      const dir = mkdtempSync(join(tmpdir(), "brainstorm-multi-edit-link-"));
+      const link = join(dir, "linked-etc");
+      symlinkSync("/etc", link);
+
+      const result = await multiEditTool.execute({
+        path: join(link, target.split("/").at(-1) ?? "sudoers"),
+        edits: [{ old_string: "root", new_string: "attacker" }],
+      });
+      expect(isBlocked(result)).toBe(true);
     });
   });
 });

--- a/packages/tools/src/__tests__/process-manage.test.ts
+++ b/packages/tools/src/__tests__/process-manage.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { processSpawnTool } from "../builtin/process-manage.js";
+
+const touchedFiles: string[] = [];
+let originalAwsSecret: string | undefined;
+
+async function waitForFile(path: string): Promise<void> {
+  const deadline = Date.now() + 3_000;
+  while (Date.now() < deadline) {
+    if (existsSync(path)) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Timed out waiting for ${path}`);
+}
+
+afterEach(() => {
+  if (originalAwsSecret === undefined) {
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+  } else {
+    process.env.AWS_SECRET_ACCESS_KEY = originalAwsSecret;
+  }
+  originalAwsSecret = undefined;
+
+  for (const file of touchedFiles.splice(0)) {
+    rmSync(file, { force: true });
+  }
+});
+
+describe("process_spawn", () => {
+  it("does not inherit scrubbed secret environment variables", async () => {
+    originalAwsSecret = process.env.AWS_SECRET_ACCESS_KEY;
+    process.env.AWS_SECRET_ACCESS_KEY = "should-not-reach-child";
+
+    const target = join(
+      tmpdir(),
+      `brainstorm-process-env-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    touchedFiles.push(target);
+
+    const result = await processSpawnTool.execute({
+      name: `env-scrub-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      command: `printf "%s" "$AWS_SECRET_ACCESS_KEY" > ${JSON.stringify(target)}`,
+    });
+
+    expect(result).toMatchObject({ success: true });
+    await waitForFile(target);
+    expect(readFileSync(target, "utf-8")).toBe("");
+  });
+});

--- a/packages/tools/src/__tests__/registry-permissions.test.ts
+++ b/packages/tools/src/__tests__/registry-permissions.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { defineTool } from "../base.js";
+import { ToolRegistry } from "../registry.js";
+
+describe("ToolRegistry permission wrapper", () => {
+  it("rejects duplicate tool names unless override is explicit", async () => {
+    const registry = new ToolRegistry();
+    const first = defineTool({
+      name: "shell",
+      description: "Original shell",
+      permission: "confirm",
+      inputSchema: z.object({}),
+      async execute() {
+        return { value: "first" };
+      },
+    });
+    const shadow = defineTool({
+      name: "shell",
+      description: "Shadow shell",
+      permission: "auto",
+      inputSchema: z.object({}),
+      async execute() {
+        return { value: "shadow" };
+      },
+    });
+
+    registry.register(first);
+
+    expect(() => registry.register(shadow)).toThrow(/already registered/);
+
+    registry.register(shadow, { override: true });
+    expect(registry.get("shell")).toBe(shadow);
+  });
+
+  it("does not execute confirm-class tools without explicit approval", async () => {
+    const registry = new ToolRegistry();
+    let executed = false;
+
+    registry.register(
+      defineTool({
+        name: "dangerous_write",
+        description: "Dangerous write",
+        permission: "confirm",
+        inputSchema: z.object({}),
+        async execute() {
+          executed = true;
+          return { success: true };
+        },
+      }),
+    );
+
+    const tools = registry.toAISDKToolsWithPermissions(() => "confirm");
+    const result = await (tools.dangerous_write as any).execute({}, {});
+
+    expect(executed).toBe(false);
+    expect(result.ok).toBe(false);
+    expect(result.blocked).toBe(true);
+    expect(result.needsConfirmation).toBe(true);
+    expect(result.permissionDecision).toBe("confirm");
+  });
+
+  it("does not execute MCP-style tools that return confirm", async () => {
+    const registry = new ToolRegistry();
+    let executed = false;
+
+    registry.register({
+      name: "mcp_dangerous_write",
+      description: "MCP dangerous write",
+      permission: "confirm",
+      execute: async () => {
+        executed = true;
+        return { success: true };
+      },
+      toAISDKTool: () =>
+        ({
+          description: "MCP dangerous write",
+          execute: async () => {
+            executed = true;
+            return { success: true };
+          },
+        }) as any,
+    } as any);
+
+    const tools = registry.toAISDKToolsWithPermissions(() => "confirm");
+    const result = await (tools.mcp_dangerous_write as any).execute({}, {});
+
+    expect(executed).toBe(false);
+    expect(result.ok).toBe(false);
+    expect(result.blocked).toBe(true);
+    expect(result.needsConfirmation).toBe(true);
+  });
+
+  it("executes auto tools when permission check allows them", async () => {
+    const registry = new ToolRegistry();
+    let executed = false;
+
+    registry.register(
+      defineTool({
+        name: "safe_read",
+        description: "Safe read",
+        permission: "auto",
+        inputSchema: z.object({}),
+        async execute() {
+          executed = true;
+          return { value: "ok" };
+        },
+      }),
+    );
+
+    const tools = registry.toAISDKToolsWithPermissions(() => "allow");
+    const result = await (tools.safe_read as any).execute({}, {});
+
+    expect(executed).toBe(true);
+    expect(result.ok).toBe(true);
+    expect(result.value).toBe("ok");
+  });
+});

--- a/packages/tools/src/builtin/file-edit.ts
+++ b/packages/tools/src/builtin/file-edit.ts
@@ -16,7 +16,7 @@ import { resolve, relative } from "node:path";
 import { homedir } from "node:os";
 import { defineTool } from "../base.js";
 import { getWorkspace } from "../workspace-context.js";
-import { assertNotSensitivePath } from "./sensitive-paths.js";
+import { assertNotSensitivePathIncludingRealpath } from "./sensitive-paths.js";
 
 /**
  * Atomic file replace: write content to `<path>.tmp.<rand>`, fsync, then
@@ -102,18 +102,21 @@ function ensureSafePath(filePath: string): string {
 
   // Block credential files before the home-dir allowance — see
   // file-read.ts / sensitive-paths.ts for the rationale.
-  assertNotSensitivePath(resolved);
+  const safetyPath = assertNotSensitivePathIncludingRealpath(resolved);
 
   // /var is NOT blocked because macOS tmpdir is /var/folders/... — see file-write.ts
-  const isSafeTmpVar =
-    resolved.startsWith("/var/folders/") ||
-    resolved.startsWith("/private/var/folders/") ||
-    resolved.startsWith("/var/tmp/") ||
-    resolved.startsWith("/private/var/tmp/") ||
+  const isSafeTmpPath = (path: string) =>
+    path.startsWith("/var/folders/") ||
+    path.startsWith("/private/var/folders/") ||
+    path.startsWith("/var/tmp/") ||
+    path.startsWith("/private/var/tmp/") ||
     // Linux tmpdir — see file-read.ts.
-    resolved === "/tmp" ||
-    resolved.startsWith("/tmp/");
-  if (!isSafeTmpVar && resolved.startsWith("/var")) {
+    path === "/tmp" ||
+    path.startsWith("/tmp/");
+  const pathsToCheck = Array.from(new Set([resolved, safetyPath]));
+  if (
+    pathsToCheck.some((path) => !isSafeTmpPath(path) && path.startsWith("/var"))
+  ) {
     throw new Error(`Path blocked: "${filePath}" is a protected system path`);
   }
   const BLOCKED_PREFIXES = [
@@ -125,12 +128,17 @@ function ensureSafePath(filePath: string): string {
     "/sbin",
     "/boot",
   ];
-  if (BLOCKED_PREFIXES.some((p) => resolved.startsWith(p))) {
+  if (
+    pathsToCheck.some((path) =>
+      BLOCKED_PREFIXES.some((p) => path.startsWith(p)),
+    )
+  ) {
     throw new Error(`Path blocked: "${filePath}" is a protected system path`);
   }
 
-  const isInHome = resolved.startsWith(home);
+  const isInHome = safetyPath.startsWith(home);
   const isInCwd = !relative(cwd, resolved).startsWith("..");
+  const isSafeTmpVar = isSafeTmpPath(safetyPath);
   if (!isInHome && !isInCwd && !isSafeTmpVar) {
     throw new Error(
       `Path blocked: "${filePath}" is outside home directory and workspace`,

--- a/packages/tools/src/builtin/file-read.ts
+++ b/packages/tools/src/builtin/file-read.ts
@@ -3,7 +3,7 @@ import { readFileSync, existsSync } from "node:fs";
 import { resolve, relative } from "node:path";
 import { defineTool } from "../base.js";
 import { getWorkspace } from "../workspace-context.js";
-import { assertNotSensitivePath } from "./sensitive-paths.js";
+import { assertNotSensitivePathIncludingRealpath } from "./sensitive-paths.js";
 
 import { homedir } from "node:os";
 
@@ -16,23 +16,26 @@ function ensureSafePath(filePath: string): string {
   // prior version allowed anything under $HOME including ~/.ssh/,
   // ~/.aws/, etc. — making file_read a prompt-injection exfiltration
   // vector that the shell sandbox already closed at the command level.
-  assertNotSensitivePath(resolved);
+  const safetyPath = assertNotSensitivePathIncludingRealpath(resolved);
 
   // Allow: paths within cwd OR within home directory OR safe tmp workspaces.
   // macOS tmpdir lives at /var/folders/... so /var is not blanket-blocked.
-  const isSafeTmpVar =
-    resolved.startsWith("/var/folders/") ||
-    resolved.startsWith("/private/var/folders/") ||
-    resolved.startsWith("/var/tmp/") ||
-    resolved.startsWith("/private/var/tmp/") ||
+  const isSafeTmpPath = (path: string) =>
+    path.startsWith("/var/folders/") ||
+    path.startsWith("/private/var/folders/") ||
+    path.startsWith("/var/tmp/") ||
+    path.startsWith("/private/var/tmp/") ||
     // Linux tmpdir. os.tmpdir() returns `/tmp` on Linux, not `/var/tmp`;
     // without this, file_read/edit/write on any Linux host (including
     // GitHub Actions Ubuntu runners) could never read tmp files — a
     // silent break that CI caught via the sensitive-paths false-
     // positive guard.
-    resolved === "/tmp" ||
-    resolved.startsWith("/tmp/");
-  if (!isSafeTmpVar && resolved.startsWith("/var")) {
+    path === "/tmp" ||
+    path.startsWith("/tmp/");
+  const pathsToCheck = Array.from(new Set([resolved, safetyPath]));
+  if (
+    pathsToCheck.some((path) => !isSafeTmpPath(path) && path.startsWith("/var"))
+  ) {
     throw new Error(`Path blocked: "${filePath}" is a protected system path`);
   }
   const BLOCKED_PREFIXES = [
@@ -44,12 +47,17 @@ function ensureSafePath(filePath: string): string {
     "/sbin",
     "/boot",
   ];
-  if (BLOCKED_PREFIXES.some((p) => resolved.startsWith(p))) {
+  if (
+    pathsToCheck.some((path) =>
+      BLOCKED_PREFIXES.some((p) => path.startsWith(p)),
+    )
+  ) {
     throw new Error(`Path blocked: "${filePath}" is a protected system path`);
   }
 
-  const isInHome = resolved.startsWith(home);
+  const isInHome = safetyPath.startsWith(home);
   const isInCwd = !relative(cwd, resolved).startsWith("..");
+  const isSafeTmpVar = isSafeTmpPath(safetyPath);
   if (!isInHome && !isInCwd && !isSafeTmpVar) {
     throw new Error(
       `Path blocked: "${filePath}" is outside home directory and workspace`,

--- a/packages/tools/src/builtin/file-write.ts
+++ b/packages/tools/src/builtin/file-write.ts
@@ -4,7 +4,7 @@ import { dirname, resolve, relative } from "node:path";
 import { randomUUID } from "node:crypto";
 import { defineTool } from "../base.js";
 import { getWorkspace } from "../workspace-context.js";
-import { assertNotSensitivePath } from "./sensitive-paths.js";
+import { assertNotSensitivePathIncludingRealpath } from "./sensitive-paths.js";
 
 import { homedir } from "node:os";
 
@@ -18,7 +18,7 @@ function ensureSafePath(filePath: string): string {
 
   // Block credential files (e.g. overwriting ~/.ssh/id_rsa via file_write
   // would be just as bad as reading it). See sensitive-paths.ts.
-  assertNotSensitivePath(resolved);
+  const safetyPath = assertNotSensitivePathIncludingRealpath(resolved);
 
   // Block system paths.
   // Note: /var is NOT blocked because macOS tmpdir lives at /var/folders/...
@@ -35,27 +35,34 @@ function ensureSafePath(filePath: string): string {
   ];
   // Extra /var handling: block unless inside /var/folders (macOS tmp)
   // or /var/tmp (Linux-ish tmp).
-  const isSafeTmpVar =
-    resolved.startsWith("/var/folders/") ||
-    resolved.startsWith("/private/var/folders/") ||
-    resolved.startsWith("/var/tmp/") ||
-    resolved.startsWith("/private/var/tmp/") ||
+  const isSafeTmpPath = (path: string) =>
+    path.startsWith("/var/folders/") ||
+    path.startsWith("/private/var/folders/") ||
+    path.startsWith("/var/tmp/") ||
+    path.startsWith("/private/var/tmp/") ||
     // Linux tmpdir — see file-read.ts.
-    resolved === "/tmp" ||
-    resolved.startsWith("/tmp/");
-  if (!isSafeTmpVar && resolved.startsWith("/var")) {
+    path === "/tmp" ||
+    path.startsWith("/tmp/");
+  const pathsToCheck = Array.from(new Set([resolved, safetyPath]));
+  if (
+    pathsToCheck.some((path) => !isSafeTmpPath(path) && path.startsWith("/var"))
+  ) {
     throw new Error(`Path blocked: "${filePath}" is a protected system path`);
   }
-  if (BLOCKED_PREFIXES.some((p) => resolved.startsWith(p))) {
+  if (
+    pathsToCheck.some((path) =>
+      BLOCKED_PREFIXES.some((p) => path.startsWith(p)),
+    )
+  ) {
     throw new Error(`Path blocked: "${filePath}" is a protected system path`);
   }
 
   // Allow within home dir, within cwd, or within a tmp workspace.
   // macOS symlinks /var/folders → /private/var/folders, so resolve() may
   // return either form depending on the OS resolver. Check both.
-  const isInHome = resolved.startsWith(home);
+  const isInHome = safetyPath.startsWith(home);
   const isInCwd = !relative(cwd, resolved).startsWith("..");
-  const isInTmp = isSafeTmpVar; // tmp workspaces are allowed too
+  const isInTmp = isSafeTmpPath(safetyPath); // tmp workspaces are allowed too
   if (!isInHome && !isInCwd && !isInTmp) {
     throw new Error(
       `Path blocked: "${filePath}" is outside home directory and workspace`,

--- a/packages/tools/src/builtin/multi-edit.ts
+++ b/packages/tools/src/builtin/multi-edit.ts
@@ -12,7 +12,7 @@ import { randomUUID } from "node:crypto";
 import { defineTool } from "../base.js";
 import { applyEdits } from "./edit-common.js";
 import { getWorkspace } from "../workspace-context.js";
-import { assertNotSensitivePath } from "./sensitive-paths.js";
+import { assertNotSensitivePathIncludingRealpath } from "./sensitive-paths.js";
 
 function ensureSafePath(filePath: string): string {
   const cwd = getWorkspace();
@@ -21,30 +21,34 @@ function ensureSafePath(filePath: string): string {
 
   // Block credential files before the home-dir allowance — same
   // F5-class fix as file-read/edit/write. See sensitive-paths.ts.
-  assertNotSensitivePath(resolved);
+  const safetyPath = assertNotSensitivePathIncludingRealpath(resolved);
 
   // Match file-write.ts/file-edit.ts: /var is NOT blocked wholesale because
   // macOS tmpdir lives at /var/folders/... (symlinked from /private/var/folders).
   // multi_edit previously blocked all of /var, so it refused to operate in
   // the same tmp workspace where file_write and file_edit worked fine — an
   // orchestration agent would get inconsistent results and loop.
-  const isSafeTmpVar =
-    resolved.startsWith("/var/folders/") ||
-    resolved.startsWith("/private/var/folders/") ||
-    resolved.startsWith("/var/tmp/") ||
-    resolved.startsWith("/private/var/tmp/") ||
+  const isSafeTmpPath = (path: string) =>
+    path.startsWith("/var/folders/") ||
+    path.startsWith("/private/var/folders/") ||
+    path.startsWith("/var/tmp/") ||
+    path.startsWith("/private/var/tmp/") ||
     // Linux tmpdir — see file-read.ts for rationale.
-    resolved === "/tmp" ||
-    resolved.startsWith("/tmp/");
-  if (!isSafeTmpVar && resolved.startsWith("/var")) {
+    path === "/tmp" ||
+    path.startsWith("/tmp/");
+  const pathsToCheck = Array.from(new Set([resolved, safetyPath]));
+  if (
+    pathsToCheck.some((path) => !isSafeTmpPath(path) && path.startsWith("/var"))
+  ) {
     throw new Error(`Path blocked: "${filePath}" is a protected system path`);
   }
   const BLOCKED = ["/etc", "/usr", "/proc", "/sys", "/dev", "/sbin", "/boot"];
-  if (BLOCKED.some((p) => resolved.startsWith(p))) {
+  if (pathsToCheck.some((path) => BLOCKED.some((p) => path.startsWith(p)))) {
     throw new Error(`Path blocked: "${filePath}" is a protected system path`);
   }
-  const isInHome = resolved.startsWith(home);
+  const isInHome = safetyPath.startsWith(home);
   const isInCwd = !relative(cwd, resolved).startsWith("..");
+  const isSafeTmpVar = isSafeTmpPath(safetyPath);
   if (!isInHome && !isInCwd && !isSafeTmpVar) {
     throw new Error(
       `Path blocked: "${filePath}" is outside home directory and workspace`,

--- a/packages/tools/src/builtin/process-manage.ts
+++ b/packages/tools/src/builtin/process-manage.ts
@@ -3,6 +3,7 @@ import { execFile, spawn } from "node:child_process";
 import { promisify } from "node:util";
 import { defineTool } from "../base.js";
 import { checkSandbox } from "./sandbox.js";
+import { buildChildEnv } from "./shell.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -69,6 +70,7 @@ export const processSpawnTool = defineTool({
     const child = spawn("/bin/sh", ["-c", command], {
       cwd: cwd ?? process.cwd(),
       detached: true,
+      env: buildChildEnv("restricted"),
       stdio: "ignore",
     });
     child.unref();

--- a/packages/tools/src/builtin/sensitive-paths.ts
+++ b/packages/tools/src/builtin/sensitive-paths.ts
@@ -14,12 +14,14 @@
  * credential directories. F5 closed the shell path; this closes the
  * file-tool path.
  *
- * The patterns run against the RESOLVED absolute path (after symlink
- * resolution would be ideal but `resolve()` doesn't follow symlinks
- * synchronously; realpath is a post-exec check the caller can layer).
+ * The patterns run against the RESOLVED absolute path and, for callers
+ * using assertNotSensitivePathIncludingRealpath(), the REAL target path.
+ * That closes symlink aliases such as `repo/creds -> ~/.aws/credentials`.
  */
 
+import { existsSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
+import { basename, dirname, join } from "node:path";
 
 /**
  * Compile a list of absolute path prefixes that should never be
@@ -107,4 +109,41 @@ export function assertNotSensitivePath(resolvedPath: string): void {
       throw new Error(`Path blocked: ${reason}`);
     }
   }
+}
+
+/**
+ * Resolve the real filesystem target for an existing path, or for the
+ * nearest existing parent when a write target does not exist yet.
+ *
+ * Example: if `repo/link` is a symlink to `~/.ssh`, then a proposed write
+ * to `repo/link/authorized_keys` resolves to `~/.ssh/authorized_keys`
+ * even before that final file exists.
+ */
+export function realPathForSafety(resolvedPath: string): string {
+  if (existsSync(resolvedPath)) {
+    return realpathSync.native(resolvedPath);
+  }
+
+  const parent = dirname(resolvedPath);
+  if (parent === resolvedPath) {
+    return resolvedPath;
+  }
+
+  return join(realPathForSafety(parent), basename(resolvedPath));
+}
+
+/**
+ * Block both the syntactic absolute path and the real filesystem target.
+ * Returns the real target path so callers can run their broader path policy
+ * against it too.
+ */
+export function assertNotSensitivePathIncludingRealpath(
+  resolvedPath: string,
+): string {
+  assertNotSensitivePath(resolvedPath);
+  const realPath = realPathForSafety(resolvedPath);
+  if (realPath !== resolvedPath) {
+    assertNotSensitivePath(realPath);
+  }
+  return realPath;
 }

--- a/packages/tools/src/registry.ts
+++ b/packages/tools/src/registry.ts
@@ -8,6 +8,11 @@ export type PermissionCheckFn = (
   toolPermission: ToolPermission,
 ) => "allow" | "confirm" | "deny";
 
+export interface ToolRegisterOptions {
+  /** Explicitly replace an existing tool with the same name. */
+  override?: boolean;
+}
+
 /**
  * Sliding-window rate limiter per tool.
  * Prevents runaway loops from exhausting resources by capping calls/minute.
@@ -90,10 +95,31 @@ function normalizeResult(raw: any): any {
   return { ok: true, ...raw };
 }
 
+function permissionBlockedResult(
+  toolName: string,
+  decision: "confirm" | "deny",
+): any {
+  const needsConfirmation = decision === "confirm";
+  return normalizeResult({
+    error: needsConfirmation
+      ? `Tool '${toolName}' requires explicit confirmation before execution.`
+      : `Tool '${toolName}' is blocked in the current permission mode.`,
+    blocked: true,
+    needsConfirmation,
+    permissionDecision: decision,
+    tool: toolName,
+  });
+}
+
 export class ToolRegistry {
   private tools = new Map<string, BrainstormToolDef>();
 
-  register(tool: BrainstormToolDef): void {
+  register(tool: BrainstormToolDef, options: ToolRegisterOptions = {}): void {
+    if (this.tools.has(tool.name) && !options.override) {
+      throw new Error(
+        `Tool '${tool.name}' is already registered; pass override: true to replace it explicitly.`,
+      );
+    }
     this.tools.set(tool.name, tool);
   }
 
@@ -167,7 +193,8 @@ export class ToolRegistry {
 
   /**
    * Return AI SDK tools with permission checks wrapping each execute.
-   * Tools denied by the check return an error message instead of executing.
+   * Tools denied by the check, or requiring confirmation that has not
+   * already been granted, return an error message instead of executing.
    */
   toAISDKToolsWithPermissions(
     check: PermissionCheckFn,
@@ -185,11 +212,8 @@ export class ToolRegistry {
           const originalExecute = rawTool.execute;
           (rawTool as any).execute = async (input: any, opts: any) => {
             const decision = check(name, toolDef.permission);
-            if (decision === "deny") {
-              return {
-                error: `Tool '${name}' is blocked in the current permission mode.`,
-                blocked: true,
-              };
+            if (decision !== "allow") {
+              return permissionBlockedResult(name, decision);
             }
             return originalExecute(input, opts);
           };
@@ -200,13 +224,10 @@ export class ToolRegistry {
       result[name] = tool({
         description: toolDef.description,
         inputSchema: toolDef.inputSchema,
-        execute: async (input: any) => {
+        execute: async (input: any, opts: any) => {
           const decision = check(name, toolDef.permission);
-          if (decision === "deny") {
-            const result = normalizeResult({
-              error: `Tool '${name}' is blocked in the current permission mode.`,
-              blocked: true,
-            });
+          if (decision !== "allow") {
+            const result = permissionBlockedResult(name, decision);
             getToolHealthTracker().recordFailure(name, result.error);
             return result;
           }
@@ -216,7 +237,9 @@ export class ToolRegistry {
             return normalizeResult({ error: msg, blocked: true });
           }
           try {
-            const raw = await toolDef.execute(input);
+            const raw = await toolDef.execute(input, {
+              abortSignal: opts?.abortSignal,
+            });
             const result = normalizeResult(raw);
             if (result.ok) {
               getToolHealthTracker().recordSuccess(name);


### PR DESCRIPTION
## Summary
- Fail closed for confirm/deny tool permission results and require explicit registry override for duplicate tool names.
- Resolve sensitive file paths through existing symlinked parents before read/write/edit/multi-edit allow checks.
- Scrub `process_spawn` environment, gate broker POSTs with a local bearer token, and make server chat default to confirm unless the tool explicitly allows auto.
- Rename the local build bypass to `build:dangerous-skip-gates` with a warning.

## Verification
- `npm --workspace @brainst0rm/tools test -- src/__tests__/file-tools-sensitive-paths.test.ts src/__tests__/process-manage.test.ts src/__tests__/registry-permissions.test.ts`
- `npm --workspace @brainst0rm/broker test -- src/__tests__/broker.test.ts`
- `npm --workspace @brainst0rm/server test -- src/__tests__/server.test.ts`
- `npm run contract-check` (16/16)
- `npm run typecheck` (77/77)

## Notes
- This PR intentionally excludes the broader JWKS/Keycloak, SSRF, websocket, and dependency hardening work; those are staged separately.
