### PR TITLE
feat(v0.6 M24): CLI per-product API defaults — opt-in unified base URL

### DIFF
--- a/packages/cli/src/__tests__/backup.test.ts
+++ b/packages/cli/src/__tests__/backup.test.ts
@@ -8,7 +8,10 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Command } from "commander";
-import { registerBackupCommand } from "../commands/backup.js";
+import {
+  registerBackupCommand,
+  parseRetentionDays,
+} from "../commands/backup.js";
 
 describe("brainstorm backup", () => {
   let program: Command;
@@ -57,15 +60,36 @@ describe("brainstorm backup", () => {
     ).toThrow();
   });
 
-  it("list-schedules takes an optional --tenant", () => {
+  it("list-schedules takes an optional --tenant via shared options", () => {
     const backup = program.commands.find((c) => c.name() === "backup")!;
     const listSchedules = backup.commands.find(
       (c) => c.name() === "list-schedules",
     )!;
     const tenantOpt = listSchedules.options.find((o) => o.long === "--tenant");
     expect(tenantOpt).toBeDefined();
-    // Optional flag with `--tenant <id>` (angle brackets without `--required`)
-    // means the option itself is not required; verify by mandatory flag.
     expect(tenantOpt!.mandatory).toBe(false);
+  });
+});
+
+describe("parseRetentionDays", () => {
+  it("returns undefined for empty input", () => {
+    expect(parseRetentionDays(undefined)).toBeUndefined();
+    expect(parseRetentionDays("")).toBeUndefined();
+  });
+
+  it("parses '<N>d' into a day count", () => {
+    expect(parseRetentionDays("30d")).toBe(30);
+    expect(parseRetentionDays("90d")).toBe(90);
+    expect(parseRetentionDays("365d")).toBe(365);
+  });
+
+  it("tolerates surrounding whitespace", () => {
+    expect(parseRetentionDays(" 7d ")).toBe(7);
+  });
+
+  it("throws on malformed input", () => {
+    expect(() => parseRetentionDays("30")).toThrow();
+    expect(() => parseRetentionDays("1 month")).toThrow();
+    expect(() => parseRetentionDays("30days")).toThrow();
   });
 });

--- a/packages/cli/src/__tests__/backup.test.ts
+++ b/packages/cli/src/__tests__/backup.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for `brainstorm backup` subcommand registration.
+ *
+ * The actual god-mode POST is mocked at fetch boundary — these tests
+ * just verify the command tree wires up cleanly and the option parser
+ * rejects malformed invocations.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Command } from "commander";
+import { registerBackupCommand } from "../commands/backup.js";
+
+describe("brainstorm backup", () => {
+  let program: Command;
+
+  beforeEach(() => {
+    program = new Command();
+    program.exitOverride(); // throw instead of process.exit
+    registerBackupCommand(program);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers the backup command with 6 subcommands", () => {
+    const backup = program.commands.find((c) => c.name() === "backup");
+    expect(backup).toBeDefined();
+    const subcommandNames = backup!.commands.map((c) => c.name()).sort();
+    expect(subcommandNames).toEqual([
+      "create-schedule",
+      "list-drills",
+      "list-schedules",
+      "purge",
+      "run-now",
+      "run-restore-drill",
+    ]);
+  });
+
+  it("create-schedule requires --name, --cadence, --target", () => {
+    expect(() =>
+      program.parse(["backup", "create-schedule"], { from: "user" }),
+    ).toThrow();
+  });
+
+  it("run-now requires --schedule-id", () => {
+    expect(() =>
+      program.parse(["backup", "run-now"], { from: "user" }),
+    ).toThrow();
+  });
+
+  it("purge requires --confirm", () => {
+    expect(() =>
+      program.parse(["backup", "purge", "--schedule-id", "abc"], {
+        from: "user",
+      }),
+    ).toThrow();
+  });
+
+  it("list-schedules takes an optional --tenant", () => {
+    const backup = program.commands.find((c) => c.name() === "backup")!;
+    const listSchedules = backup.commands.find(
+      (c) => c.name() === "list-schedules",
+    )!;
+    const tenantOpt = listSchedules.options.find((o) => o.long === "--tenant");
+    expect(tenantOpt).toBeDefined();
+    // Optional flag with `--tenant <id>` (angle brackets without `--required`)
+    // means the option itself is not required; verify by mandatory flag.
+    expect(tenantOpt!.mandatory).toBe(false);
+  });
+});

--- a/packages/cli/src/bin/brainstorm.ts
+++ b/packages/cli/src/bin/brainstorm.ts
@@ -428,6 +428,12 @@ registerEvidenceCommand(program);
 import { registerLoginCommand } from "../commands/login.js";
 registerLoginCommand(program);
 
+// `brainstorm backup` — operate the brainstorm-backup product (schedules,
+// drills, runs). v0.6 P0 M02 — closes v0.5 M23 (the CLI subcommand
+// shipped at v0.5 M22a but never wired through the operator CLI).
+import { registerBackupCommand } from "../commands/backup.js";
+registerBackupCommand(program);
+
 program
   .command("eval")
   .description("Run capability evaluation probes against a model")

--- a/packages/cli/src/commands/backup.ts
+++ b/packages/cli/src/commands/backup.ts
@@ -1,0 +1,265 @@
+/**
+ * `brainstorm backup ...` — operate the brainstorm-backup product from the CLI.
+ *
+ * Plan reference: v0.6 P0 M02 — closes v0.5 M23 (CLI subcommand was scoped
+ * but slipped at v0.5 ship). The backup service shipped its 6 god-mode tools
+ * in v0.5 P2 / brainstorm-backup PR #2:
+ *   - backup.create_schedule
+ *   - backup.list_schedules
+ *   - backup.run_now
+ *   - backup.run_restore_drill
+ *   - backup.list_drills
+ *   - backup.purge
+ *
+ * All flow through `POST {backup_url}/api/v1/god-mode/execute` per the
+ * platform contract v1. The CLI is a thin operator surface; the heavy
+ * lifting (scheduler, replication, drill engine) lives in the service.
+ *
+ * Auth: Bearer JWT from `~/.brainstorm/session` (same as `brainstorm a2a`).
+ * Backup URL default: `https://backup.brainstorm.co`. Override with --base
+ * or env `BRAINSTORM_BACKUP_URL`.
+ */
+
+import { Command } from "commander";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const DEFAULT_BACKUP_URL = "https://backup.brainstorm.co";
+const SESSION_PATH = join(homedir(), ".brainstorm", "session");
+
+interface SessionFile {
+  access_token?: string;
+}
+
+function loadToken(explicitToken: string | undefined): string | undefined {
+  if (explicitToken) return explicitToken;
+  const envToken = process.env.BRAINSTORM_API_KEY;
+  if (envToken) return envToken;
+  try {
+    const raw = readFileSync(SESSION_PATH, "utf8");
+    const parsed = JSON.parse(raw) as SessionFile;
+    return parsed.access_token;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveBackupUrl(explicitBase: string | undefined): string {
+  if (explicitBase) return explicitBase.replace(/\/$/, "");
+  const envUrl = process.env.BRAINSTORM_BACKUP_URL;
+  if (envUrl) return envUrl.replace(/\/$/, "");
+  return DEFAULT_BACKUP_URL;
+}
+
+interface InvokeOptions {
+  base?: string;
+  token?: string;
+  json?: boolean;
+}
+
+interface GodModeResponse {
+  success?: boolean;
+  data?: unknown;
+  error?: { code?: string; message?: string };
+  trace_id?: string;
+}
+
+async function invokeBackupTool(
+  toolName: string,
+  params: Record<string, unknown>,
+  opts: InvokeOptions,
+): Promise<void> {
+  const token = loadToken(opts.token);
+  if (!token) {
+    console.error(
+      "No auth token. Run `brainstorm login` first or pass --token.",
+    );
+    process.exit(2);
+  }
+  const url = `${resolveBackupUrl(opts.base)}/api/v1/god-mode/execute`;
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ tool: toolName, params }),
+    });
+  } catch (err) {
+    console.error(
+      `Network error reaching ${url}: ${(err as Error).message ?? err}`,
+    );
+    process.exit(4);
+  }
+
+  let body: GodModeResponse;
+  try {
+    body = (await response.json()) as GodModeResponse;
+  } catch {
+    console.error(`Non-JSON response (HTTP ${response.status}) from ${url}`);
+    process.exit(5);
+  }
+
+  if (!response.ok || body.error) {
+    const code = body.error?.code ?? `HTTP_${response.status}`;
+    const msg =
+      body.error?.message ?? `${response.status} ${response.statusText}`;
+    if (opts.json) {
+      process.stdout.write(JSON.stringify(body));
+      process.stdout.write("\n");
+    } else {
+      console.error(`backup.${toolName} failed: [${code}] ${msg}`);
+    }
+    process.exit(1);
+  }
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(body.data, null, 2));
+    process.stdout.write("\n");
+  } else {
+    process.stdout.write(JSON.stringify(body.data, null, 2));
+    process.stdout.write("\n");
+  }
+}
+
+export function registerBackupCommand(program: Command): void {
+  const backup = program
+    .command("backup")
+    .description(
+      "Operate the brainstorm-backup product (schedules, drills, runs)",
+    );
+
+  // Shared option set — every subcommand needs base + token + json.
+  const sharedOptions = (cmd: Command): Command =>
+    cmd
+      .option(
+        "--base <url>",
+        `Backup service base URL (default ${DEFAULT_BACKUP_URL})`,
+      )
+      .option(
+        "--token <jwt>",
+        "Bearer JWT (default: BRAINSTORM_API_KEY env or ~/.brainstorm/session)",
+      )
+      .option(
+        "--json",
+        "Emit raw JSON response (default: pretty-printed data)",
+      );
+
+  sharedOptions(
+    backup
+      .command("list-schedules")
+      .description("List backup schedules for the current tenant")
+      .option("--tenant <id>", "Tenant ID (default: derived from JWT)"),
+  ).action(async (opts: InvokeOptions & { tenant?: string }) => {
+    const params: Record<string, unknown> = {};
+    if (opts.tenant) params.tenant_id = opts.tenant;
+    await invokeBackupTool("backup.list_schedules", params, opts);
+  });
+
+  sharedOptions(
+    backup
+      .command("create-schedule")
+      .description("Create a new backup schedule")
+      .requiredOption("--name <name>", "Schedule name (unique per tenant)")
+      .requiredOption(
+        "--cadence <cron>",
+        "Cron expression (e.g. '0 2 * * *' for nightly at 02:00)",
+      )
+      .requiredOption(
+        "--target <provider>",
+        "Replication target: 's3' or 'linstor'",
+      )
+      .option(
+        "--retention <duration>",
+        "Retention period (e.g. '30d', '90d')",
+        "30d",
+      )
+      .option("--source <id>", "Source resource ID to back up"),
+  ).action(
+    async (
+      opts: InvokeOptions & {
+        name: string;
+        cadence: string;
+        target: string;
+        retention: string;
+        source?: string;
+      },
+    ) => {
+      const params: Record<string, unknown> = {
+        name: opts.name,
+        cadence: opts.cadence,
+        target: opts.target,
+        retention: opts.retention,
+      };
+      if (opts.source) params.source_id = opts.source;
+      await invokeBackupTool("backup.create_schedule", params, opts);
+    },
+  );
+
+  sharedOptions(
+    backup
+      .command("run-now")
+      .description("Trigger an immediate backup run for a schedule")
+      .requiredOption("--schedule-id <id>", "Schedule ID"),
+  ).action(async (opts: InvokeOptions & { scheduleId: string }) => {
+    await invokeBackupTool(
+      "backup.run_now",
+      { schedule_id: opts.scheduleId },
+      opts,
+    );
+  });
+
+  sharedOptions(
+    backup
+      .command("list-drills")
+      .description("List restore drills for the current tenant")
+      .option("--schedule-id <id>", "Filter to one schedule"),
+  ).action(async (opts: InvokeOptions & { scheduleId?: string }) => {
+    const params: Record<string, unknown> = {};
+    if (opts.scheduleId) params.schedule_id = opts.scheduleId;
+    await invokeBackupTool("backup.list_drills", params, opts);
+  });
+
+  sharedOptions(
+    backup
+      .command("run-restore-drill")
+      .description(
+        "Run a restore drill — restore latest backup to scratch + checksum",
+      )
+      .requiredOption("--schedule-id <id>", "Schedule ID"),
+  ).action(async (opts: InvokeOptions & { scheduleId: string }) => {
+    await invokeBackupTool(
+      "backup.run_restore_drill",
+      { schedule_id: opts.scheduleId },
+      opts,
+    );
+  });
+
+  sharedOptions(
+    backup
+      .command("purge")
+      .description(
+        "Delete a schedule + cascade its runs + drills (destructive)",
+      )
+      .requiredOption("--schedule-id <id>", "Schedule ID")
+      .requiredOption(
+        "--confirm",
+        "Must pass --confirm to acknowledge destruction",
+      ),
+  ).action(
+    async (opts: InvokeOptions & { scheduleId: string; confirm: boolean }) => {
+      if (!opts.confirm) {
+        console.error("Refusing to purge without --confirm.");
+        process.exit(2);
+      }
+      await invokeBackupTool(
+        "backup.purge",
+        { schedule_id: opts.scheduleId, confirm: true },
+        opts,
+      );
+    },
+  );
+}

--- a/packages/cli/src/commands/backup.ts
+++ b/packages/cli/src/commands/backup.ts
@@ -30,19 +30,65 @@ const SESSION_PATH = join(homedir(), ".brainstorm", "session");
 
 interface SessionFile {
   access_token?: string;
+  /** `did:bvm:<tenant>:<user>` per v0.3 login.ts comment. */
+  did?: string;
 }
 
-function loadToken(explicitToken: string | undefined): string | undefined {
-  if (explicitToken) return explicitToken;
+interface SessionContext {
+  token: string | undefined;
+  tenantId: string | undefined;
+}
+
+function loadSession(explicitToken: string | undefined): SessionContext {
+  if (explicitToken) {
+    return { token: explicitToken, tenantId: undefined };
+  }
   const envToken = process.env.BRAINSTORM_API_KEY;
-  if (envToken) return envToken;
+  if (envToken) {
+    return { token: envToken, tenantId: undefined };
+  }
   try {
     const raw = readFileSync(SESSION_PATH, "utf8");
     const parsed = JSON.parse(raw) as SessionFile;
-    return parsed.access_token;
+    return {
+      token: parsed.access_token,
+      tenantId: parseTenantFromDid(parsed.did),
+    };
   } catch {
-    return undefined;
+    return { token: undefined, tenantId: undefined };
   }
+}
+
+function parseTenantFromDid(did: string | undefined): string | undefined {
+  if (!did) return undefined;
+  // `did:bvm:<tenant>:<user>` — tenant is the third segment.
+  const parts = did.split(":");
+  return parts.length >= 4 ? parts[2] : undefined;
+}
+
+/**
+ * Codex r1 P1: token leaks over http:// if --base or env hands us a
+ * plaintext URL. Reject anything that isn't https://, except an
+ * explicit localhost/loopback dev escape hatch.
+ */
+function assertSecureBase(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    console.error(`Invalid backup base URL: ${url}`);
+    process.exit(3);
+  }
+  if (parsed.protocol === "https:") return;
+  const host = parsed.hostname;
+  const isLocalhost =
+    host === "localhost" || host === "127.0.0.1" || host === "::1";
+  if (parsed.protocol === "http:" && isLocalhost) return;
+  console.error(
+    `Refusing to send bearer token over ${parsed.protocol}//${host}. ` +
+      `Use https:// or a localhost/loopback base URL for dev.`,
+  );
+  process.exit(3);
 }
 
 function resolveBackupUrl(explicitBase: string | undefined): string {
@@ -56,6 +102,8 @@ interface InvokeOptions {
   base?: string;
   token?: string;
   json?: boolean;
+  /** Override the X-Tenant-ID header (otherwise parsed from session DID). */
+  tenant?: string;
 }
 
 interface GodModeResponse {
@@ -65,28 +113,59 @@ interface GodModeResponse {
   trace_id?: string;
 }
 
+/**
+ * Parses a retention duration string like "30d" or "90d" into a day count.
+ * Returns undefined when the input is empty/undefined; throws on malformed.
+ */
+export function parseRetentionDays(
+  value: string | undefined,
+): number | undefined {
+  if (!value) return undefined;
+  const m = /^([0-9]+)d$/.exec(value.trim());
+  if (!m) {
+    throw new Error(
+      `Invalid retention '${value}'. Expected '<N>d' (e.g. '30d').`,
+    );
+  }
+  return Number.parseInt(m[1], 10);
+}
+
 async function invokeBackupTool(
   toolName: string,
-  params: Record<string, unknown>,
+  input: Record<string, unknown>,
   opts: InvokeOptions,
 ): Promise<void> {
-  const token = loadToken(opts.token);
-  if (!token) {
+  const session = loadSession(opts.token);
+  if (!session.token) {
     console.error(
       "No auth token. Run `brainstorm login` first or pass --token.",
     );
     process.exit(2);
   }
-  const url = `${resolveBackupUrl(opts.base)}/api/v1/god-mode/execute`;
+  const tenantId = opts.tenant ?? session.tenantId;
+  if (!tenantId) {
+    console.error(
+      "No tenant context. Pass --tenant <id>, or run `brainstorm login` to " +
+        "bind a session whose DID encodes the tenant.",
+    );
+    process.exit(2);
+  }
+  const baseUrl = resolveBackupUrl(opts.base);
+  assertSecureBase(baseUrl);
+  const url = `${baseUrl}/api/v1/god-mode/execute`;
   let response: Response;
   try {
     response = await fetch(url, {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${token}`,
+        Authorization: `Bearer ${session.token}`,
         "Content-Type": "application/json",
+        // Codex r1 P1: backup service reads tenant from this header, not
+        // from the bearer token payload. Missing it returns 400 missing_tenant.
+        "X-Tenant-ID": tenantId,
       },
-      body: JSON.stringify({ tool: toolName, params }),
+      // Codex r1 P1: backup service expects `input`, not `params`.
+      body: JSON.stringify({ tool: toolName, input }),
     });
   } catch (err) {
     console.error(
@@ -116,13 +195,8 @@ async function invokeBackupTool(
     process.exit(1);
   }
 
-  if (opts.json) {
-    process.stdout.write(JSON.stringify(body.data, null, 2));
-    process.stdout.write("\n");
-  } else {
-    process.stdout.write(JSON.stringify(body.data, null, 2));
-    process.stdout.write("\n");
-  }
+  process.stdout.write(JSON.stringify(body.data, null, 2));
+  process.stdout.write("\n");
 }
 
 export function registerBackupCommand(program: Command): void {
@@ -132,7 +206,10 @@ export function registerBackupCommand(program: Command): void {
       "Operate the brainstorm-backup product (schedules, drills, runs)",
     );
 
-  // Shared option set — every subcommand needs base + token + json.
+  // Shared option set — every subcommand needs base + token + json + tenant.
+  // The service reads tenant from the X-Tenant-ID header (not the JWT body),
+  // so --tenant is universal: pass explicitly, or auto-resolve from the
+  // session DID at request time.
   const sharedOptions = (cmd: Command): Command =>
     cmd
       .option(
@@ -143,6 +220,7 @@ export function registerBackupCommand(program: Command): void {
         "--token <jwt>",
         "Bearer JWT (default: BRAINSTORM_API_KEY env or ~/.brainstorm/session)",
       )
+      .option("--tenant <id>", "Tenant ID (default: parsed from session DID)")
       .option(
         "--json",
         "Emit raw JSON response (default: pretty-printed data)",
@@ -151,12 +229,9 @@ export function registerBackupCommand(program: Command): void {
   sharedOptions(
     backup
       .command("list-schedules")
-      .description("List backup schedules for the current tenant")
-      .option("--tenant <id>", "Tenant ID (default: derived from JWT)"),
-  ).action(async (opts: InvokeOptions & { tenant?: string }) => {
-    const params: Record<string, unknown> = {};
-    if (opts.tenant) params.tenant_id = opts.tenant;
-    await invokeBackupTool("backup.list_schedules", params, opts);
+      .description("List backup schedules for the current tenant"),
+  ).action(async (opts: InvokeOptions) => {
+    await invokeBackupTool("backup.list_schedules", {}, opts);
   });
 
   sharedOptions(
@@ -188,14 +263,23 @@ export function registerBackupCommand(program: Command): void {
         source?: string;
       },
     ) => {
-      const params: Record<string, unknown> = {
+      // Codex r1 P1: service field names are cron + retention_days + source,
+      // not the friendlier CLI flag names. Translate at the boundary.
+      let retentionDays: number;
+      try {
+        retentionDays = parseRetentionDays(opts.retention) ?? 30;
+      } catch (e) {
+        console.error((e as Error).message);
+        process.exit(2);
+      }
+      const input: Record<string, unknown> = {
         name: opts.name,
-        cadence: opts.cadence,
+        cron: opts.cadence,
         target: opts.target,
-        retention: opts.retention,
+        retention_days: retentionDays,
       };
-      if (opts.source) params.source_id = opts.source;
-      await invokeBackupTool("backup.create_schedule", params, opts);
+      if (opts.source) input.source = opts.source;
+      await invokeBackupTool("backup.create_schedule", input, opts);
     },
   );
 
@@ -218,9 +302,9 @@ export function registerBackupCommand(program: Command): void {
       .description("List restore drills for the current tenant")
       .option("--schedule-id <id>", "Filter to one schedule"),
   ).action(async (opts: InvokeOptions & { scheduleId?: string }) => {
-    const params: Record<string, unknown> = {};
-    if (opts.scheduleId) params.schedule_id = opts.scheduleId;
-    await invokeBackupTool("backup.list_drills", params, opts);
+    const input: Record<string, unknown> = {};
+    if (opts.scheduleId) input.schedule_id = opts.scheduleId;
+    await invokeBackupTool("backup.list_drills", input, opts);
   });
 
   sharedOptions(

--- a/packages/cli/src/discovery/capability-registry.ts
+++ b/packages/cli/src/discovery/capability-registry.ts
@@ -59,7 +59,17 @@ let cache:
  * Default URLs are the production deploy targets — they're the fallback
  * when both the registry is unreachable AND no env override is set.
  */
-const KNOWN_PRODUCTS: Record<
+// v0.6 M24: when BRAINSTORM_UNIFIED_API=1, the per-product defaults
+// point at brainstorm.co/api/v1/<product> (the collapsed surface that
+// M22 ALB rules route to the same backend services). Default stays
+// "0" until the 30-day overlap-watch (M25) confirms the collapsed
+// surface is stable in prod — flipping the CLI default before that
+// would break every existing CLI install at once.
+const USE_UNIFIED_API =
+  (process.env.BRAINSTORM_UNIFIED_API || "0").toLowerCase() === "1" ||
+  (process.env.BRAINSTORM_UNIFIED_API || "").toLowerCase() === "true";
+
+const LEGACY_DEFAULTS: Record<
   string,
   { defaultBaseUrl: string; envVar: string }
 > = {
@@ -81,6 +91,37 @@ const KNOWN_PRODUCTS: Record<
     envVar: "BRAINSTORM_BACKUP_URL",
   },
 };
+
+const UNIFIED_DEFAULTS: Record<
+  string,
+  { defaultBaseUrl: string; envVar: string }
+> = {
+  msp: {
+    defaultBaseUrl: "https://brainstorm.co/api/v1/msp",
+    envVar: "BRAINSTORM_MSP_URL",
+  },
+  br: {
+    defaultBaseUrl: "https://brainstorm.co/api/v1/router",
+    envVar: "BRAINSTORM_BR_URL",
+  },
+  gtm: {
+    defaultBaseUrl: "https://brainstorm.co/api/v1/gtm",
+    envVar: "BRAINSTORM_GTM_URL",
+  },
+  vm: {
+    defaultBaseUrl: "https://vm.brainstorm.co",
+    envVar: "BRAINSTORM_VM_URL",
+  },
+  backup: {
+    defaultBaseUrl: "https://brainstorm.co/api/v1/backup",
+    envVar: "BRAINSTORM_BACKUP_URL",
+  },
+};
+
+const KNOWN_PRODUCTS: Record<
+  string,
+  { defaultBaseUrl: string; envVar: string }
+> = USE_UNIFIED_API ? UNIFIED_DEFAULTS : LEGACY_DEFAULTS;
 
 /**
  * Discover the live product set via the capability registry. Returns
@@ -166,7 +207,7 @@ async function fetchFromRegistry(token?: string): Promise<DiscoveredProduct[]> {
       anyOnline: false,
     };
     entry.count++;
-    if (cap.status === "active") {
+    if (isCapabilityStatusInvokable(cap.status)) {
       entry.anyOnline = true;
       entry.allOffline = false;
     }
@@ -192,13 +233,19 @@ async function fetchFromRegistry(token?: string): Promise<DiscoveredProduct[]> {
   });
 }
 
-function parseProductFromDID(did: string): string | undefined {
+export function parseProductFromDID(did: string): string | undefined {
   // did:bvm:<tenant>:<product>:<short>
   const parts = did.split(":");
   if (parts.length < 5 || parts[0] !== "did" || parts[1] !== "bvm") {
     return undefined;
   }
   return parts[3];
+}
+
+export function isCapabilityStatusInvokable(
+  status: string | undefined,
+): boolean {
+  return status === "active";
 }
 
 const warnedEnvVars = new Set<string>();


### PR DESCRIPTION
Adds `BRAINSTORM_UNIFIED_API=1` env flag that flips per-product CLI default base URLs to the v0.6 collapsed surface (`brainstorm.co/api/v1/<product>`). Default behavior unchanged — operators opt in via env after M22 TF apply + M25 overlap-watch baseline is clean. Flip to default-on lands in v0.7.

Plan R12 + v0.6-overlap-watch runbook (BrainstormOps#49) for the rollout discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)