### PR TITLE
feat(providers): live-fetch model catalog from BrainstormRouter

### DIFF
--- a/packages/providers/src/__tests__/br-catalog.test.ts
+++ b/packages/providers/src/__tests__/br-catalog.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  brEntryToModel,
+  mergeBrCatalog,
+  fetchBrCatalog,
+  type BrCatalogEntry,
+} from "../cloud/br-catalog.js";
+import { CLOUD_MODELS } from "../cloud/models.js";
+import type { ModelEntry } from "@brainst0rm/shared";
+
+describe("brEntryToModel", () => {
+  it("uses BR pricing and capability flags when present", () => {
+    const br: BrCatalogEntry = {
+      id: "openai/gpt-5.5",
+      owned_by: "openai",
+      x_model_router: {
+        pricing: { input: 5, output: 15 },
+        capabilities: ["streaming", "vision", "tools"],
+      },
+    };
+    const model = brEntryToModel(br, new Map());
+    expect(model.id).toBe("openai/gpt-5.5");
+    expect(model.provider).toBe("openai");
+    expect(model.pricing.inputPer1MTokens).toBe(5);
+    expect(model.pricing.outputPer1MTokens).toBe(15);
+    expect(model.capabilities.toolCalling).toBe(true);
+    expect(model.capabilities.vision).toBe(true);
+    expect(model.capabilities.streaming).toBe(true);
+  });
+
+  it("overlays local qualityTier/speedTier/bestFor/scores when id matches", () => {
+    const local: ModelEntry = {
+      id: "anthropic/claude-opus-4-6",
+      provider: "anthropic",
+      name: "Claude Opus 4.6",
+      capabilities: {
+        toolCalling: true,
+        streaming: true,
+        vision: true,
+        reasoning: true,
+        contextWindow: 1_000_000,
+        qualityTier: 1,
+        speedTier: 3,
+        bestFor: ["analysis"],
+        capabilityScores: {
+          toolSelection: 0.96,
+          toolSequencing: 0.94,
+          codeGeneration: 0.95,
+          multiStepReasoning: 0.97,
+          instructionFollowing: 0.95,
+          contextUtilization: 0.96,
+          selfCorrection: 0.93,
+        },
+      },
+      pricing: { inputPer1MTokens: 15, outputPer1MTokens: 75 },
+      limits: { contextWindow: 1_000_000, maxOutputTokens: 32_768 },
+      status: "available",
+      isLocal: false,
+      lastHealthCheck: 0,
+    };
+    const br: BrCatalogEntry = {
+      id: "anthropic/claude-opus-4-6",
+      owned_by: "anthropic",
+      x_model_router: { pricing: { input: 15, output: 75 } },
+    };
+    const model = brEntryToModel(br, new Map([[local.id, local]]));
+    expect(model.capabilities.qualityTier).toBe(1);
+    expect(model.capabilities.speedTier).toBe(3);
+    expect(model.capabilities.bestFor).toEqual(["analysis"]);
+    expect(model.capabilities.capabilityScores?.toolSelection).toBe(0.96);
+    expect(model.name).toBe("Claude Opus 4.6");
+  });
+
+  it("applies safe defaults for an unknown id with no local overlay", () => {
+    const br: BrCatalogEntry = {
+      id: "x-ai/grok-3",
+      owned_by: "x-ai",
+    };
+    const model = brEntryToModel(br, new Map());
+    expect(model.capabilities.qualityTier).toBe(2);
+    expect(model.capabilities.speedTier).toBe(2);
+    expect(model.capabilities.contextWindow).toBe(128_000);
+    expect(model.capabilities.toolCalling).toBe(false);
+    expect(model.pricing.inputPer1MTokens).toBe(0);
+    expect(model.name).toBe("grok-3");
+    expect(model.status).toBe("available");
+    expect(model.isLocal).toBe(false);
+  });
+
+  it("infers provider from id when owned_by is missing", () => {
+    const br: BrCatalogEntry = { id: "moonshot/kimi-k2.6" };
+    expect(brEntryToModel(br, new Map()).provider).toBe("moonshot");
+  });
+});
+
+describe("mergeBrCatalog", () => {
+  it("returns one entry per BR id (BR is source of truth for catalog membership)", () => {
+    const brEntries: BrCatalogEntry[] = [
+      { id: "openai/gpt-5.5", owned_by: "openai" },
+      { id: "x-ai/grok-3", owned_by: "x-ai" },
+    ];
+    const result = mergeBrCatalog(brEntries, CLOUD_MODELS);
+    expect(result.map((m) => m.id)).toEqual(["openai/gpt-5.5", "x-ai/grok-3"]);
+  });
+
+  it("does NOT include local-only models that BR doesn't serve", () => {
+    // A model present in CLOUD_MODELS but not in BR's catalog should not appear.
+    const localOnly = CLOUD_MODELS[0]!;
+    const brEntries: BrCatalogEntry[] = [{ id: "openai/gpt-5.5" }];
+    const result = mergeBrCatalog(brEntries, [localOnly]);
+    expect(result.find((m) => m.id === localOnly.id)).toBeUndefined();
+    expect(result).toHaveLength(1);
+  });
+
+  it("preserves local capability metadata for matched ids", () => {
+    const opus = CLOUD_MODELS.find((m) => m.id === "anthropic/claude-opus-4-6");
+    expect(opus).toBeDefined();
+    const brEntries: BrCatalogEntry[] = [
+      { id: "anthropic/claude-opus-4-6", owned_by: "anthropic" },
+    ];
+    const [merged] = mergeBrCatalog(brEntries, CLOUD_MODELS);
+    expect(merged!.capabilities.qualityTier).toBe(
+      opus!.capabilities.qualityTier,
+    );
+    expect(merged!.capabilities.capabilityScores).toEqual(
+      opus!.capabilities.capabilityScores,
+    );
+  });
+});
+
+describe("fetchBrCatalog", () => {
+  const originalFetch = globalThis.fetch;
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.useRealTimers();
+  });
+
+  it("returns parsed data[] on 200", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        object: "list",
+        data: [{ id: "openai/gpt-5.5", owned_by: "openai" }],
+      }),
+    }) as unknown as typeof fetch;
+    const result = await fetchBrCatalog("br_live_test");
+    expect(result).toEqual([{ id: "openai/gpt-5.5", owned_by: "openai" }]);
+  });
+
+  it("returns null on non-2xx (no throw)", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: "auth" }),
+    }) as unknown as typeof fetch;
+    const result = await fetchBrCatalog("bad_key");
+    expect(result).toBeNull();
+  });
+
+  it("returns null on network error (no throw)", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockRejectedValue(
+        new Error("network unreachable"),
+      ) as unknown as typeof fetch;
+    const result = await fetchBrCatalog("br_live_test");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when response has no data[] array", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ object: "list" }), // missing data
+    }) as unknown as typeof fetch;
+    const result = await fetchBrCatalog("br_live_test");
+    expect(result).toBeNull();
+  });
+
+  it("sends Bearer Authorization header", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [] }),
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    await fetchBrCatalog("br_live_xyz");
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining("/v1/models"),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer br_live_xyz",
+        }),
+      }),
+    );
+  });
+});

--- a/packages/providers/src/cloud/br-catalog.ts
+++ b/packages/providers/src/cloud/br-catalog.ts
@@ -1,0 +1,159 @@
+import type { ModelEntry } from "@brainst0rm/shared";
+import { createLogger } from "@brainst0rm/shared";
+
+const log = createLogger("br-catalog");
+
+const DEFAULT_BR_BASE_URL = "https://api.brainstormrouter.com";
+const FETCH_TIMEOUT_MS = 10_000;
+
+/**
+ * Wire shape of an entry in BR's `/v1/models` response. Matches the
+ * actual production payload at api.brainstormrouter.com:
+ *
+ *   { id, object, created, owned_by, x_model_router: { pricing, capabilities, endpoints } }
+ *
+ * `x_model_router` is BR's vendor extension to the OpenAI /v1/models
+ * format and may be absent for very stripped-down catalog entries; both
+ * paths are handled by the merge logic.
+ */
+export interface BrCatalogEntry {
+  id: string;
+  owned_by?: string;
+  x_model_router?: {
+    pricing?: { input?: number; output?: number };
+    capabilities?: string[];
+    endpoints?: number;
+  };
+}
+
+interface BrCatalogResponse {
+  data?: BrCatalogEntry[];
+}
+
+/**
+ * Fetch BR's live model catalog. Returns `null` on any failure
+ * (network, non-200, malformed body) so callers can fall back to the
+ * static CLOUD_MODELS list without a try/catch dance. Failures are
+ * logged at warn level — they're not fatal because brainstorm should
+ * still work offline against direct provider keys.
+ */
+export async function fetchBrCatalog(
+  apiKey: string,
+  baseUrl: string = DEFAULT_BR_BASE_URL,
+): Promise<BrCatalogEntry[] | null> {
+  try {
+    const res = await fetch(`${baseUrl}/v1/models`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      log.warn(
+        { status: res.status },
+        "BR /v1/models returned non-OK; using static fallback",
+      );
+      return null;
+    }
+    const body = (await res.json()) as BrCatalogResponse;
+    if (!Array.isArray(body.data)) {
+      log.warn(
+        { body: JSON.stringify(body).slice(0, 200) },
+        "BR /v1/models response missing data[]",
+      );
+      return null;
+    }
+    return body.data;
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "BR /v1/models fetch failed; using static fallback",
+    );
+    return null;
+  }
+}
+
+/**
+ * Map a BR catalog entry to a brainstorm ModelEntry, overlaying local
+ * capability metadata (qualityTier, speedTier, bestFor, capabilityScores)
+ * from CLOUD_MODELS when an entry with the same id exists. BR provides
+ * the authoritative model id, owned_by, pricing, and coarse capability
+ * flags; the local overlay carries the heuristics brainstorm's router
+ * uses for strategy selection (which BR doesn't track).
+ */
+export function brEntryToModel(
+  br: BrCatalogEntry,
+  overlay: Map<string, ModelEntry>,
+): ModelEntry {
+  const local = overlay.get(br.id);
+  const caps = new Set(br.x_model_router?.capabilities ?? []);
+  const provider = br.owned_by ?? br.id.split("/")[0] ?? "unknown";
+
+  const toolCalling =
+    caps.has("tools") ||
+    caps.has("functionCalling") ||
+    local?.capabilities.toolCalling ||
+    false;
+  const streaming =
+    caps.has("streaming") || local?.capabilities.streaming || true;
+  const vision = caps.has("vision") || local?.capabilities.vision || false;
+
+  return {
+    id: br.id,
+    provider,
+    name: local?.name ?? prettyNameFromId(br.id),
+    capabilities: {
+      toolCalling,
+      streaming,
+      vision,
+      reasoning: local?.capabilities.reasoning ?? false,
+      contextWindow: local?.capabilities.contextWindow ?? 128_000,
+      qualityTier: local?.capabilities.qualityTier ?? 2,
+      speedTier: local?.capabilities.speedTier ?? 2,
+      bestFor: local?.capabilities.bestFor ?? [
+        "code-generation",
+        "conversation",
+      ],
+      ...(local?.capabilities.capabilityScores
+        ? { capabilityScores: local.capabilities.capabilityScores }
+        : {}),
+    },
+    pricing: {
+      inputPer1MTokens:
+        br.x_model_router?.pricing?.input ??
+        local?.pricing.inputPer1MTokens ??
+        0,
+      outputPer1MTokens:
+        br.x_model_router?.pricing?.output ??
+        local?.pricing.outputPer1MTokens ??
+        0,
+      ...(local?.pricing.cachedInputPer1MTokens != null
+        ? { cachedInputPer1MTokens: local.pricing.cachedInputPer1MTokens }
+        : {}),
+    },
+    limits: local?.limits ?? {
+      contextWindow: 128_000,
+      maxOutputTokens: 16_384,
+    },
+    status: "available",
+    isLocal: false,
+    lastHealthCheck: Date.now(),
+  };
+}
+
+/**
+ * Merge BR's live catalog with the local CLOUD_MODELS overlay. Returns
+ * one ModelEntry per id present in BR's catalog. Local-only models
+ * (in CLOUD_MODELS but not in BR) are NOT included — BR is the source
+ * of truth for which models brainstorm can actually call via SaaS.
+ */
+export function mergeBrCatalog(
+  brEntries: BrCatalogEntry[],
+  localModels: ModelEntry[],
+): ModelEntry[] {
+  const overlay = new Map(localModels.map((m) => [m.id, m]));
+  return brEntries.map((br) => brEntryToModel(br, overlay));
+}
+
+function prettyNameFromId(id: string): string {
+  const [, ...rest] = id.split("/");
+  return rest.join("/") || id;
+}

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -33,6 +33,12 @@ export {
   type BrEnvelopeListener,
 } from "./cloud/br-envelope.js";
 export {
+  fetchBrCatalog,
+  mergeBrCatalog,
+  brEntryToModel,
+  type BrCatalogEntry,
+} from "./cloud/br-catalog.js";
+export {
   readDiscoveryCache,
   writeDiscoveryCache,
   invalidateDiscoveryCache,

--- a/packages/providers/src/registry.ts
+++ b/packages/providers/src/registry.ts
@@ -12,6 +12,7 @@ import { discoverLocalModels } from "./local/discovery.js";
 import { CLOUD_MODELS } from "./cloud/models.js";
 import { createBrainstormSaaSProvider } from "./cloud/brainstorm-saas.js";
 import type { BrEnvelopeListener } from "./cloud/br-envelope.js";
+import { fetchBrCatalog, mergeBrCatalog } from "./cloud/br-catalog.js";
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { createOpenAI } from "@ai-sdk/openai";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
@@ -140,9 +141,28 @@ export async function createProviderRegistry(
   // Models with direct provider keys are marked preferred for routing.
   const hasDirectKeys =
     availableCloudProviders.size > (hasBrainstormSaaS ? 1 : 0);
-  const reachableCloudModels = hasBrainstormSaaS
-    ? CLOUD_MODELS
-    : CLOUD_MODELS.filter((m) => availableCloudProviders.has(m.provider));
+
+  // Source-of-truth precedence for the cloud model list:
+  //   1. BR live `/v1/models` (when we have a BR key) — fresh, includes
+  //      models the local CLOUD_MODELS constant doesn't know about yet.
+  //   2. Disk cache from the last successful BR fetch — offline fallback.
+  //   3. Static CLOUD_MODELS — direct-key-only or first-run-offline.
+  // Local capability scores / qualityTier / bestFor are overlaid onto
+  // BR entries by id; BR doesn't track those heuristics.
+  let reachableCloudModels: ModelEntry[];
+  if (hasBrainstormSaaS && brApiKey) {
+    const brEntries = await fetchBrCatalog(brApiKey);
+    if (brEntries) {
+      reachableCloudModels = mergeBrCatalog(brEntries, CLOUD_MODELS);
+    } else {
+      const cached = loadProviderCache();
+      reachableCloudModels = cached?.models ?? CLOUD_MODELS;
+    }
+  } else {
+    reachableCloudModels = CLOUD_MODELS.filter((m) =>
+      availableCloudProviders.has(m.provider),
+    );
+  }
 
   let allModels = [...reachableCloudModels];
 
@@ -281,25 +301,34 @@ export async function createProviderRegistry(
  * Reading directly avoids a circular dependency (eval → providers → eval).
  */
 const CACHE_PATH = join(homedir(), ".brainstorm", ".providers.cache.json");
-const CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+// Cache TTL is intentionally long — its purpose is offline fallback when
+// BR /v1/models can't be reached, not freshness gating. A live BR fetch
+// at registry init takes precedence whenever it succeeds.
+const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const CACHE_VERSION = 2; // v1 stored only `modelIds`; v2 stores full ModelEntry[]
 
-interface ProviderCache {
+interface ProviderCacheV2 {
+  version: number;
   timestamp: number;
-  modelIds: string[];
+  models: ModelEntry[];
 }
 
-function loadProviderCache(): ProviderCache | null {
+function loadProviderCache(): ProviderCacheV2 | null {
   try {
     if (!existsSync(CACHE_PATH)) return null;
     const raw = readFileSync(CACHE_PATH, "utf-8");
     // Guard against corrupt/oversized cache files (max 1MB)
     if (raw.length > 1_000_000) return null;
     const data = JSON.parse(raw);
-    // Validate required fields exist
-    if (typeof data?.timestamp !== "number" || !Array.isArray(data?.modelIds))
+    if (
+      data?.version !== CACHE_VERSION ||
+      typeof data?.timestamp !== "number" ||
+      !Array.isArray(data?.models)
+    ) {
       return null;
+    }
     if (Date.now() - data.timestamp > CACHE_TTL_MS) return null;
-    return data as ProviderCache;
+    return data as ProviderCacheV2;
   } catch {
     return null;
   }
@@ -309,9 +338,10 @@ function saveProviderCache(models: ModelEntry[]): void {
   try {
     const dir = join(homedir(), ".brainstorm");
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-    const cache: ProviderCache = {
+    const cache: ProviderCacheV2 = {
+      version: CACHE_VERSION,
       timestamp: Date.now(),
-      modelIds: models.map((m) => m.id),
+      models,
     };
     writeFileSync(CACHE_PATH, JSON.stringify(cache), "utf-8");
   } catch {


### PR DESCRIPTION
## Summary

- **Source of truth flip:** `CLOUD_MODELS` was the authoritative list of cloud models brainstorm knew about (10 entries, hardcoded in `packages/providers/src/cloud/models.ts`). BR's `/v1/models` endpoint currently serves 34. This PR makes BR the source of truth for catalog *membership* while keeping `CLOUD_MODELS` as the local overlay for capability heuristics (`qualityTier`, `speedTier`, `bestFor`, `capabilityScores`) that drive routing strategies and that BR doesn't track.
- **Source precedence** in `createProviderRegistry`:
  1. BR `/v1/models` live fetch (when BR key present) — fresh
  2. `~/.brainstorm/.providers.cache.json` (now v2 schema: full `ModelEntry[]`, TTL 7 days) — offline fallback
  3. Static `CLOUD_MODELS` — direct-key-only or first-run-offline
- **Side fix:** `loadProviderCache` was defined but never called — the cache was write-only since it was added. v2 schema now stores enough to actually serve as offline fallback, and the registry reads it.

## Verification

Live smoke test against `api.brainstormrouter.com/v1/models` with a real BR key:

```
BR catalog count: 34
Merged count: 34
Opus 4.6 has local capability scores: true
Opus 4.6 qualityTier: 1
grok-3 qualityTier (default 2): 2
grok-3 has scores (should be false): false
```

Surfaces models that were silently unavailable to brainstorm CLI/desktop before this PR: `openai/gpt-4o`, `openai/gpt-4.1-nano`, `openai/o3`, `openai/o4-mini`, `anthropic/claude-3-5-sonnet-latest`, `anthropic/claude-3-7-sonnet-latest`, `google/gemini-2.5-pro`, `google/gemini-2.5-flash-lite`, `google/gemini-2.0-flash`, `deepseek/deepseek-v4-pro`, `deepseek/deepseek-v4-flash`, `deepseek/deepseek-reasoner`, `x-ai/grok-3`, `x-ai/grok-3-mini`, `groq/llama-3.3-70b-versatile`, `groq/llama-3.1-8b-instant`, `groq/mixtral-8x7b-32768`, `perplexity-ai/sonar-pro`, `perplexity-ai/sonar`, `moonshot/kimi-k2.6`, `anthropic/claude-sonnet-4-0`, `anthropic/claude-sonnet-4-20250514`.

## Tests

- 12 new tests in `br-catalog.test.ts` covering merge logic, fetch happy/error paths, header verification, default-application for BR-only ids, overlay preservation for matched ids
- All 44 pre-existing providers tests pass
- All 435 core tests + CLI + router tests pass (no downstream regressions)
- Full workspace build (46 tasks) succeeds

## What this PR does NOT fix

Models BR itself doesn't yet serve still won't appear in brainstorm — most notably `anthropic/claude-opus-4-7` and `openai/gpt-5.5`. Those need to be registered in the `brainstormrouter` repo's catalog and deployed. Tracked separately.

## Test plan

- [ ] Smoke: `node packages/cli/dist/brainstorm.js models` lists all 34 BR models with sane qualityTier defaults for BR-only entries
- [ ] Offline: rename `.providers.cache.json`, disable network, restart brainstorm — confirm fallback to static `CLOUD_MODELS`
- [ ] Online → offline transition: run once with BR reachable (writes v2 cache), then offline — confirm cached models load

🤖 Generated with [Claude Code](https://claude.com/claude-code)