### PR TITLE
feat(opus PR V-5): verify /api/v1/self + /api/v1/discovery in contract checker

### DIFF
--- a/packages/godmode/src/contract/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/godmode/src/contract/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -568,6 +568,18 @@ exports[`contract compiler — snapshots > endpoint registry is stable 1`] = `
     "path": "/health",
   },
   {
+    "auth": "none",
+    "id": "platform-self",
+    "method": "GET",
+    "path": "/api/v1/self",
+  },
+  {
+    "auth": "none",
+    "id": "platform-discovery",
+    "method": "GET",
+    "path": "/api/v1/discovery",
+  },
+  {
     "auth": "bearer",
     "id": "god-mode-tools",
     "method": "GET",
@@ -619,6 +631,45 @@ Liveness + identity probe. Always available, no auth. Returns 200 for healthy/de
 | \`product\` | string | Yes | Lowercase product slug. MUST match product.id in manifest. |
 | \`uptime_seconds\` | number | No | Seconds since the process started. |
 | \`checks\` | object<string, any> | No | Sub-system health states (database, cache, queues, ...). |
+",
+  },
+  {
+    "id": "platform-self",
+    "markdown": "### GET /api/v1/self
+
+**Auth:** None
+
+Product self-descriptor — product slug, version, variant (tool|orchestrator), capability domains, schema version. Public, no auth.
+
+**Response:**
+
+| Field | Type | Required | Description |
+| ----- | ---- | -------- | ----------- |
+| \`product\` | string | Yes | Lowercase product slug. MUST match product.id in manifest. |
+| \`version\` | string | Yes | Product semver string. |
+| \`variant\` | \`tool\` \\| \`orchestrator\` | Yes | Tool-producing or orchestrator-variant per platform-contract-v1-orchestrator.md. |
+| \`capabilities\` | array<string> | Yes | Capability domains the product covers. |
+| \`schema_version\` | number | Yes | Contract version this response conforms to. |
+",
+  },
+  {
+    "id": "platform-discovery",
+    "markdown": "### GET /api/v1/discovery
+
+**Auth:** None
+
+API URL map — tools_url OR workflows_url (depending on variant), self_url, events_url, openapi_url. Public, no auth.
+
+**Response:**
+
+| Field | Type | Required | Description |
+| ----- | ---- | -------- | ----------- |
+| \`tools_url\` | string | No |  |
+| \`workflows_url\` | string | No |  |
+| \`runs_url\` | string | No |  |
+| \`self_url\` | string | Yes | Path to GET /api/v1/self. |
+| \`events_url\` | string | No |  |
+| \`openapi_url\` | string | No |  |
 ",
   },
   {
@@ -766,6 +817,26 @@ exports[`contract compiler — snapshots > validator plan summary 1`] = `
     "id": "health",
     "method": "GET",
     "path": "/health",
+  },
+  {
+    "acceptStatuses": [
+      200,
+    ],
+    "auth": "none",
+    "hasRequestValidator": false,
+    "id": "platform-self",
+    "method": "GET",
+    "path": "/api/v1/self",
+  },
+  {
+    "acceptStatuses": [
+      200,
+    ],
+    "auth": "none",
+    "hasRequestValidator": false,
+    "id": "platform-discovery",
+    "method": "GET",
+    "path": "/api/v1/discovery",
   },
   {
     "acceptStatuses": [

--- a/packages/godmode/src/contract/schemas.ts
+++ b/packages/godmode/src/contract/schemas.ts
@@ -58,6 +58,60 @@ export const healthResponseSchema = z
   })
   .describe("Response body for GET /health. No auth required.");
 
+// ── Section 2.5/2.6: Self + Discovery (added 2026-05-21, contract v1.1) ──────
+//
+// The contract originally specified /api/v1/self and /api/v1/discovery
+// in narrative §5.5 / §5.6 but didn't include them in the verifier's
+// PLATFORM_ENDPOINTS array. Adding both here so `brainstorm platform
+// verify` actually checks for them — closes the V-5 action item from
+// .claude/notes/platform-verify-baseline-2026-05-21.md.
+
+export const productVariantEnum = z.enum(["tool", "orchestrator"]);
+
+export const platformSelfResponseSchema = z
+  .object({
+    product: z
+      .string()
+      .regex(/^[a-z0-9-]+$/)
+      .describe("Lowercase product slug. MUST match product.id in manifest."),
+    version: z.string().describe("Product semver string."),
+    variant: productVariantEnum.describe(
+      "Tool-producing or orchestrator-variant per platform-contract-v1-orchestrator.md.",
+    ),
+    capabilities: z
+      .array(z.string())
+      .describe("Capability domains the product covers."),
+    schema_version: z
+      .number()
+      .int()
+      .positive()
+      .describe("Contract version this response conforms to."),
+  })
+  .describe("Response body for GET /api/v1/self. No auth required.");
+
+export const platformDiscoveryResponseSchema = z
+  .object({
+    // Tool-variant products publish tools_url; orchestrator-variant
+    // publishes workflows_url + runs_url instead. Both are optional in
+    // the validator because a product may be one or the other.
+    tools_url: z.string().optional(),
+    workflows_url: z.string().optional(),
+    runs_url: z.string().optional(),
+    self_url: z.string().describe("Path to GET /api/v1/self."),
+    events_url: z.string().optional(),
+    openapi_url: z.string().optional(),
+  })
+  .refine(
+    (data) =>
+      typeof data.tools_url === "string" ||
+      typeof data.workflows_url === "string",
+    {
+      message:
+        "discovery response must have at least one of tools_url (tool-variant) or workflows_url (orchestrator-variant).",
+    },
+  )
+  .describe("Response body for GET /api/v1/discovery. No auth required.");
+
 // ── Section 3: Tool Discovery ──────────────────────────────────────
 
 export const riskLevelEnum = z.enum([
@@ -339,6 +393,26 @@ export const PLATFORM_ENDPOINTS: EndpointDef[] = defineEndpoints([
     summary:
       "Liveness + identity probe. Always available, no auth. Returns 200 for healthy/degraded, 503 for unhealthy.",
     response: healthResponseSchema,
+  },
+  {
+    id: "platform-self",
+    title: "Self-Descriptor",
+    method: "GET",
+    path: "/api/v1/self",
+    auth: "none",
+    summary:
+      "Product self-descriptor — product slug, version, variant (tool|orchestrator), capability domains, schema version. Public, no auth.",
+    response: platformSelfResponseSchema,
+  },
+  {
+    id: "platform-discovery",
+    title: "API Discovery",
+    method: "GET",
+    path: "/api/v1/discovery",
+    auth: "none",
+    summary:
+      "API URL map — tools_url OR workflows_url (depending on variant), self_url, events_url, openapi_url. Public, no auth.",
+    response: platformDiscoveryResponseSchema,
   },
   {
     id: "god-mode-tools",


### PR DESCRIPTION
## Summary

Closes V-5 from \`.claude/notes/platform-verify-baseline-2026-05-21.md\`.

The contract narrative (§5.5/§5.6) specified \`/api/v1/self\` and \`/api/v1/discovery\` but the verifier's \`PLATFORM_ENDPOINTS\` array didn't include them, so \`brainstorm platform verify\` was silently skipping the check. After this PR, those endpoints are part of every verification run.

## What this adds (packages/godmode/src/contract/schemas.ts)

- \`productVariantEnum\`: \`"tool" | "orchestrator"\`
- \`platformSelfResponseSchema\`: \`{ product, version, variant, capabilities, schema_version }\`
- \`platformDiscoveryResponseSchema\`:
  - \`tools_url?\` OR \`workflows_url?\` + \`runs_url?\` (orchestrator variant)
  - \`self_url\` required
  - \`events_url?\`, \`openapi_url?\` optional
  - \`.refine()\` enforces "at least one of tools_url or workflows_url"
- Two new \`PLATFORM_ENDPOINTS\` entries:
  - \`GET /api/v1/self\` (auth: none)
  - \`GET /api/v1/discovery\` (auth: none)

Snapshot updated in \`__snapshots__/snapshot.test.ts.snap\`.

## Verification

- \`turbo run build --filter=@brainst0rm/godmode\`: clean ✅
- \`vitest run\` (godmode): **162/162 tests pass** ✅

## Downstream effect

After merge, \`brainstorm platform verify <url>\` will check 7 endpoints (was 5):
- /health
- **/api/v1/self ← new**
- **/api/v1/discovery ← new**
- /api/v1/god-mode/tools
- /api/v1/god-mode/execute
- /api/v1/platform/events
- /api/v1/platform/tenants

This makes the PR 1.5* endpoint additions (MSP #179, BR #389, GTM #33) testable + makes any contract drift detectable post-deploy.

Under /goal — Business Harness Hub v1