### PR TITLE
feat(opus PR 7.1): EventBridge binding for ChangeSet event emitter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1168,6 +1168,361 @@
         "node": ">=18"
       }
     },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-eventbridge": {
+      "version": "3.1051.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-eventbridge/-/client-eventbridge-3.1051.0.tgz",
+      "integrity": "sha512-lF356sBGSoeI5bDkDBUrS4lVERZE2lRiankELUCKcfRARoas0Wvn4gCFunisKQjf4Za+RywZMC+PP0Zp1P3Z4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/credential-provider-node": "^3.972.43",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.12.tgz",
+      "integrity": "sha512-qrqgioqYFjwR6LatVNS1L2Vk++EwRIxqSQXPKNv5Ofux2D8UNgqMQ1znnMyEImXquVPTtbf71fc128pvmU6y9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.38.tgz",
+      "integrity": "sha512-m3WjZEgPtioMhPmwqUt+DhlTJ2i9ufR6DhfkyXojb9puEvfR+ur2U5shavu5/Cc9WHHsDCvALi6UFHgcqjhQ5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.40.tgz",
+      "integrity": "sha512-D78L/m2Dr6cJnnSvWoAudPhQmCwmJ7j6APXsPYmFpPaKfQTfCSu0rdm8j14Np+VmXF9z8Aj8HE3xFpsrwtfgeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.42.tgz",
+      "integrity": "sha512-Mu5ESvFXeinafVM8jTIvRqcvK2Ehj4kz3auT39yUcHwu1Vfxo6xRlmUafdKLW4tusjAJukQwK09sCSMgOm7OKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/credential-provider-env": "^3.972.38",
+        "@aws-sdk/credential-provider-http": "^3.972.40",
+        "@aws-sdk/credential-provider-login": "^3.972.42",
+        "@aws-sdk/credential-provider-process": "^3.972.38",
+        "@aws-sdk/credential-provider-sso": "^3.972.42",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.42",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.42.tgz",
+      "integrity": "sha512-O6WkZga3kf0yqyJYd1dbeJqVhEgJx/x1UaLgtbR+XuL/YP+K5y6QTxQKL7ka9z3jnQASESKGAPnRyt4D5hQrxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.43.tgz",
+      "integrity": "sha512-D/DJmbrWRP5BXEO3FH+ar4el+2n6OlGofiud7dQun2jES+AQEJjczenp1jBb4MBN7CpGpS8nsWGQLtuzc9tQbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.38",
+        "@aws-sdk/credential-provider-http": "^3.972.40",
+        "@aws-sdk/credential-provider-ini": "^3.972.42",
+        "@aws-sdk/credential-provider-process": "^3.972.38",
+        "@aws-sdk/credential-provider-sso": "^3.972.42",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.42",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.38.tgz",
+      "integrity": "sha512-EnbYVajGgbkb24s0K1eo4VNAPV5mHIET7LSvirTaFCwkfrfaOJxtSE+wY/tJdKDS21cEYkZs2ruCaAm+W4iblg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.42.tgz",
+      "integrity": "sha512-RVV/9NbFwI8ZHEH5dn39lGyFmSbSVj1+orZdr6QsOe1mW9DCglmlen0cFaNZmCcqkqc7erNRHNBduxbeZuHAnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/token-providers": "3.1049.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.42.tgz",
+      "integrity": "sha512-/67fXX0ddllD4u2Nujc5PvT4byHgpMUfz6+RxIKi/0nFIckeorm7JvXgzBuDyVKw0s58EbofmETDWUf9vTEuHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.10.tgz",
+      "integrity": "sha512-FtQ/Bt327peZJuyo4WZSOLVUTw9ujRxntepiC7L65FxA2P82Xlq0g14T22BuqBUeMjDoxa9nvwiMHjLIfP3eUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1049.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1049.0.tgz",
+      "integrity": "sha512-r7+d0lQMTHKypkmaF5jRTBYLYHCUHzt3gaVoN9SidLhQeWhCmHk3AKrboDTpPF5b7Pt7vKu3+oeMjznM2Eu1ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
@@ -1544,6 +1899,10 @@
     },
     "node_modules/@brainst0rm/eval": {
       "resolved": "packages/eval",
+      "link": true
+    },
+    "node_modules/@brainst0rm/eventbridge-binding": {
+      "resolved": "packages/eventbridge-binding",
       "link": true
     },
     "node_modules/@brainst0rm/gateway": {
@@ -4433,6 +4792,18 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -5589,6 +5960,126 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -7508,6 +7999,12 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "5.0.6",
@@ -10840,6 +11337,43 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -15395,6 +15929,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -17715,6 +18264,18 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -19321,6 +19882,21 @@
         }
       }
     },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
@@ -19864,6 +20440,33 @@
       "devDependencies": {
         "tsup": "^8",
         "typescript": "^5.7"
+      }
+    },
+    "packages/eventbridge-binding": {
+      "name": "@brainst0rm/eventbridge-binding",
+      "version": "0.15.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-eventbridge": "^3.700.0",
+        "@brainst0rm/changeset-contract": "0.15.0",
+        "@brainst0rm/godmode": "0.15.0",
+        "@brainst0rm/shared": "0.14.4"
+      },
+      "devDependencies": {
+        "@types/node": "^22.19.19",
+        "tsup": "^8",
+        "typescript": "^5.7",
+        "vitest": "^3"
+      }
+    },
+    "packages/eventbridge-binding/node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "packages/gateway": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -703,7 +703,6 @@
     "apps/web": {
       "name": "@brainst0rm/web",
       "version": "0.1.0",
-      "extraneous": true,
       "dependencies": {
         "clsx": "^2.1.1",
         "gray-matter": "^4.0.3",
@@ -720,6 +719,134 @@
         "tailwindcss": "^4",
         "typescript": "^5.7"
       }
+    },
+    "apps/web/node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "apps/web/node_modules/@types/react": {
+      "version": "19.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "apps/web/node_modules/next": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
+      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "16.2.6",
+        "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.9.19",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "16.2.6",
+        "@next/swc-darwin-x64": "16.2.6",
+        "@next/swc-linux-arm64-gnu": "16.2.6",
+        "@next/swc-linux-arm64-musl": "16.2.6",
+        "@next/swc-linux-x64-gnu": "16.2.6",
+        "@next/swc-linux-x64-musl": "16.2.6",
+        "@next/swc-win32-arm64-msvc": "16.2.6",
+        "@next/swc-win32-x64-msvc": "16.2.6",
+        "sharp": "^0.34.5"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "apps/web/node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "apps/web/node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "apps/web/node_modules/react-dom": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
+      }
+    },
+    "apps/web/node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/@ai-sdk/anthropic": {
       "version": "3.0.63",
@@ -1004,6 +1131,19 @@
       },
       "engines": {
         "node": ">=14.13.1"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -1362,6 +1502,10 @@
       "resolved": "packages/broker",
       "link": true
     },
+    "node_modules/@brainst0rm/changeset-contract": {
+      "resolved": "packages/changeset-contract",
+      "link": true
+    },
     "node_modules/@brainst0rm/cli": {
       "resolved": "packages/cli",
       "link": true
@@ -1520,6 +1664,10 @@
     },
     "node_modules/@brainst0rm/vscode": {
       "resolved": "packages/vscode",
+      "link": true
+    },
+    "node_modules/@brainst0rm/web": {
+      "resolved": "apps/web",
       "link": true
     },
     "node_modules/@brainst0rm/workflow": {
@@ -2511,6 +2659,16 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
@@ -3108,6 +3266,472 @@
         "mlly": "^1.8.0"
       }
     },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@inquirer/external-editor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
@@ -3642,6 +4266,140 @@
       "version": "0.1.80",
       "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.80.tgz",
       "integrity": "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
+      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
       "cpu": [
         "x64"
       ],
@@ -4266,7 +5024,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.59.1"
@@ -4839,6 +5597,15 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -4850,6 +5617,291 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
+      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.21.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/node/node_modules/enhanced-resolve": {
+      "version": "5.21.6",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
+      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-x64": "4.3.0",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.0",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
+      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
+      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
+      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
+      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
+      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
+      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
+      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
+      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.0.tgz",
+      "integrity": "sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.3.0",
+        "@tailwindcss/oxide": "4.3.0",
+        "postcss": "^8.5.10",
+        "tailwindcss": "4.3.0"
       }
     },
     "node_modules/@turbo/darwin-64": {
@@ -6174,7 +7226,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -6357,7 +7408,6 @@
       "version": "2.10.12",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
       "integrity": "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -6899,7 +7949,6 @@
       "version": "1.0.30001786",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001786.tgz",
       "integrity": "sha512-4oxTZEvqmLLrERwxO76yfKM7acZo310U+v4kqexI2TL1DkkUEMT8UijrxxcnVdxR3qkVf5awGRX+4Z6aPHVKrA==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7273,6 +8322,12 @@
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
     },
     "node_modules/cliui": {
       "version": "7.0.4",
@@ -9405,7 +10460,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -9639,6 +10693,18 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/extendable-error": {
       "version": "0.1.7",
@@ -10457,6 +11523,21 @@
       "license": "MIT",
       "peerDependencies": {
         "graphology-types": ">=0.23.0"
+      }
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
       }
     },
     "node_modules/hachure-fill": {
@@ -11294,6 +12375,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -11560,7 +12650,6 @@
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
       "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -11679,6 +12768,15 @@
       "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
       "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
     },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -11707,8 +12805,6 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -12296,6 +13392,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.469.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.469.0.tgz",
+      "integrity": "sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/luxon": {
@@ -13681,7 +14786,6 @@
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
       "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14466,7 +15570,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -14609,7 +15712,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.59.1"
@@ -14628,7 +15731,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -14641,13 +15744,13 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -15785,6 +16888,19 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/secure-json-parse": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
@@ -15902,6 +17018,51 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -16191,7 +17352,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -16265,7 +17425,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/ssri": {
@@ -16509,6 +17668,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
@@ -16563,6 +17731,29 @@
       "license": "MIT",
       "dependencies": {
         "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
       }
     },
     "node_modules/stylis": {
@@ -16669,16 +17860,16 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
-      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
-      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17289,6 +18480,12 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tsup": {
       "version": "8.5.1",
@@ -18364,6 +19561,31 @@
         "vitest": "^3"
       }
     },
+    "packages/changeset-contract": {
+      "name": "@brainst0rm/changeset-contract",
+      "version": "0.15.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@brainst0rm/shared": "0.14.4",
+        "zod": "^3.24"
+      },
+      "devDependencies": {
+        "@types/node": "^22.19.19",
+        "tsup": "^8",
+        "typescript": "^5.7",
+        "vitest": "^3"
+      }
+    },
+    "packages/changeset-contract/node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "packages/cli": {
       "name": "@brainst0rm/cli",
       "version": "0.15.0",
@@ -18662,6 +19884,7 @@
       "version": "0.15.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@brainst0rm/changeset-contract": "0.15.0",
         "@brainst0rm/config": "0.14.4",
         "@brainst0rm/shared": "0.14.4",
         "@brainst0rm/tools": "0.15.0",

--- a/packages/changeset-contract/package.json
+++ b/packages/changeset-contract/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@brainst0rm/changeset-contract",
+  "version": "0.15.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@brainst0rm/shared": "0.14.4",
+    "zod": "^3.24"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.19",
+    "tsup": "^8",
+    "typescript": "^5.7",
+    "vitest": "^3"
+  },
+  "description": "ChangeSet contract v2 — cross-package + cross-product type definitions for Brainstorm's mutation-gating safety layer. Imported by godmode (engine), brainstorm-desktop (renderer), and product services (publishers). Federation-aware: includes tenant_id, EventBridge envelope alignment, schema versioning.",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/justinjilg/brainstorm.git",
+    "directory": "packages/changeset-contract"
+  },
+  "homepage": "https://brainstorm.co",
+  "keywords": [
+    "changeset",
+    "brainstorm",
+    "contract",
+    "godmode",
+    "federation",
+    "tenant-isolation"
+  ],
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/changeset-contract/src/__tests__/schemas.test.ts
+++ b/packages/changeset-contract/src/__tests__/schemas.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from "vitest";
+import {
+  ChangeSetSchema,
+  CreateChangeSetInputSchema,
+  ChangeSetLifecycleEventSchema,
+  BlastRadiusSchema,
+  SimulationResultSchema,
+} from "../schemas.js";
+
+describe("CreateChangeSetInputSchema", () => {
+  it("requires tenantId", () => {
+    const input = {
+      // tenantId intentionally missing
+      connector: "msp",
+      action: "msp.customer.create",
+      description: "Create acme customer",
+      changes: [
+        {
+          system: "msp",
+          entity: "customer:acme",
+          operation: "create" as const,
+        },
+      ],
+      simulation: {
+        success: true,
+        statePreview: {},
+        cascades: [],
+        constraints: [],
+        estimatedDuration: "~1s",
+      },
+    };
+    const result = CreateChangeSetInputSchema.safeParse(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.path).toEqual(["tenantId"]);
+    }
+  });
+
+  it("accepts a minimal valid input", () => {
+    const input = {
+      tenantId: "acme",
+      connector: "msp",
+      action: "msp.customer.create",
+      description: "Create acme customer",
+      changes: [
+        {
+          system: "msp",
+          entity: "customer:acme",
+          operation: "create" as const,
+        },
+      ],
+      simulation: {
+        success: true,
+        statePreview: {},
+        cascades: [],
+        constraints: [],
+        estimatedDuration: "~1s",
+      },
+    };
+    const result = CreateChangeSetInputSchema.safeParse(input);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty-string tenantId (must be at least 1 char)", () => {
+    const input = {
+      tenantId: "",
+      connector: "msp",
+      action: "msp.customer.create",
+      description: "x",
+      changes: [],
+      simulation: {
+        success: true,
+        statePreview: {},
+        cascades: [],
+        constraints: [],
+        estimatedDuration: "~0s",
+      },
+    };
+    const result = CreateChangeSetInputSchema.safeParse(input);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("ChangeSetSchema", () => {
+  it("accepts a complete ChangeSet with optional fields", () => {
+    const cs = {
+      id: "abc12345",
+      tenantId: "acme",
+      connector: "vm",
+      action: "vm.create",
+      description: "Spawn forensic VM",
+      status: "draft" as const,
+      riskScore: 35,
+      riskFactors: ["new-resource"],
+      changes: [
+        { system: "vm", entity: "vm:i-new", operation: "create" as const },
+      ],
+      simulation: {
+        success: true,
+        statePreview: {},
+        cascades: [],
+        constraints: [],
+        estimatedDuration: "~30s",
+      },
+      createdAt: 1716000000000,
+      expiresAt: 1716000300000,
+      correlationId: "incident-2026-05-21-001",
+      traceId: "abc123",
+    };
+    const result = ChangeSetSchema.safeParse(cs);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a ChangeSet without tenantId (v2 invariant)", () => {
+    const cs = {
+      id: "abc12345",
+      connector: "vm",
+      action: "vm.create",
+      description: "x",
+      status: "draft",
+      riskScore: 0,
+      riskFactors: [],
+      changes: [],
+      simulation: {
+        success: true,
+        statePreview: {},
+        cascades: [],
+        constraints: [],
+        estimatedDuration: "~0s",
+      },
+      createdAt: 0,
+      expiresAt: 0,
+    };
+    const result = ChangeSetSchema.safeParse(cs);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("BlastRadiusSchema", () => {
+  it("requires code-structural fields (godmode back-compat)", () => {
+    const br = {
+      // missing required affectedSymbols/affectedCommunities/etc.
+      reversibility: "instant" as const,
+    };
+    expect(BlastRadiusSchema.safeParse(br).success).toBe(false);
+  });
+
+  it("accepts code-structural only", () => {
+    const br = {
+      affectedSymbols: [{ name: "foo", file: "a.ts", depth: 1 }],
+      affectedCommunities: [{ id: "c1", name: "core", tier: "critical" }],
+      riskMultiplier: 1.5,
+      totalAffected: 1,
+    };
+    expect(BlastRadiusSchema.safeParse(br).success).toBe(true);
+  });
+
+  it("accepts code-structural + operational together", () => {
+    const br = {
+      affectedSymbols: [],
+      affectedCommunities: [],
+      riskMultiplier: 1,
+      totalAffected: 0,
+      entitiesAffected: 47,
+      productsTouched: ["msp", "vm"],
+      tenantsTouched: ["acme"],
+      dataClasses: ["pii", "config"] as const,
+      reversibility: "manual" as const,
+    };
+    expect(BlastRadiusSchema.safeParse(br).success).toBe(true);
+  });
+});
+
+describe("ChangeSetLifecycleEventSchema", () => {
+  it("validates a changeset.executed event", () => {
+    const event = {
+      tenantId: "acme",
+      ts: 1716220800000,
+      changesetId: "cs_abc123",
+      payload: {
+        product: "msp",
+        tool: "msp.customer.create",
+        state: "executed" as const,
+        executionResult: { customer_id: "cust_xyz" },
+      },
+    };
+    expect(ChangeSetLifecycleEventSchema.safeParse(event).success).toBe(true);
+  });
+
+  it("rejects an event missing tenantId", () => {
+    const event = {
+      ts: 0,
+      changesetId: "cs_abc",
+      payload: { product: "msp", tool: "x", state: "draft" },
+    };
+    expect(ChangeSetLifecycleEventSchema.safeParse(event).success).toBe(false);
+  });
+});
+
+describe("SimulationResultSchema", () => {
+  it("accepts the minimal shape", () => {
+    const sim = {
+      success: true,
+      statePreview: {},
+      cascades: [],
+      constraints: [],
+      estimatedDuration: "~1s",
+    };
+    expect(SimulationResultSchema.safeParse(sim).success).toBe(true);
+  });
+});

--- a/packages/changeset-contract/src/index.ts
+++ b/packages/changeset-contract/src/index.ts
@@ -1,0 +1,42 @@
+/**
+ * @brainst0rm/changeset-contract
+ *
+ * Cross-package + cross-product type definitions for Brainstorm's
+ * mutation-gating safety layer (ChangeSets). Federation-aware.
+ *
+ * Imported by:
+ *  - @brainst0rm/godmode — the runtime engine that creates, simulates, and
+ *    executes ChangeSets
+ *  - apps/desktop — the renderer that displays the operator-facing preview
+ *  - Product services (when they publish ChangeSet lifecycle events to
+ *    the EventBridge federation bus)
+ *
+ * Authored as PR 5 of the Business Harness Opus project.
+ * See `.claude/notes/business-harness-opus-plan-2026-05-20.md` for context.
+ */
+
+export type {
+  Change,
+  ChangeSet,
+  ChangeSetLifecycleEvent,
+  ChangeSetStatus,
+  CostEstimate,
+  CreateChangeSetInput,
+  DataClass,
+  Reversibility,
+  BlastRadius,
+  SimulationResult,
+} from "./types.js";
+
+export {
+  BlastRadiusSchema,
+  ChangeSchema,
+  ChangeSetLifecycleEventSchema,
+  ChangeSetSchema,
+  ChangeSetStatusSchema,
+  CostEstimateSchema,
+  CreateChangeSetInputSchema,
+  DataClassSchema,
+  ReversibilitySchema,
+  SimulationResultSchema,
+} from "./schemas.js";

--- a/packages/changeset-contract/src/schemas.ts
+++ b/packages/changeset-contract/src/schemas.ts
@@ -1,0 +1,135 @@
+/**
+ * ChangeSet Contract v2 — Zod schemas for runtime validation.
+ *
+ * Mirror the TypeScript types in `./types.ts`. Use these for:
+ *  - Validating ChangeSets received over IPC or HTTP at trust boundaries
+ *  - Validating federation events before PutEvents
+ *  - Schema-based form generation in the renderer
+ *  - Test fixtures
+ */
+
+import { z } from "zod";
+
+export const ChangeSetStatusSchema = z.enum([
+  "draft",
+  "approved",
+  "executed",
+  "failed",
+  "rolled_back",
+  "rejected",
+  "expired",
+]);
+
+export const ReversibilitySchema = z.enum([
+  "instant",
+  "manual",
+  "irreversible",
+]);
+
+export const DataClassSchema = z.enum([
+  "pii",
+  "financial",
+  "config",
+  "content",
+  "credentials",
+  "audit-log",
+]);
+
+export const ChangeSchema = z.object({
+  system: z.string().min(1),
+  entity: z.string().min(1),
+  operation: z.enum(["create", "update", "delete", "execute"]),
+  before: z.unknown().optional(),
+  after: z.unknown().optional(),
+});
+
+export const BlastRadiusSchema = z.object({
+  // Code-structural — REQUIRED for backward compat with godmode
+  affectedSymbols: z.array(
+    z.object({
+      name: z.string(),
+      file: z.string(),
+      depth: z.number().int().nonnegative(),
+    }),
+  ),
+  affectedCommunities: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+      tier: z.string(),
+    }),
+  ),
+  riskMultiplier: z.number().positive(),
+  totalAffected: z.number().int().nonnegative(),
+
+  // Operational — OPTIONAL v2 additions
+  entitiesAffected: z.number().int().nonnegative().optional(),
+  productsTouched: z.array(z.string()).optional(),
+  tenantsTouched: z.array(z.string()).optional(),
+  dataClasses: z.array(DataClassSchema).optional(),
+  reversibility: ReversibilitySchema.optional(),
+});
+
+export const CostEstimateSchema = z.object({
+  usd: z.number().nonnegative(),
+  breakdown: z.record(z.string(), z.number().nonnegative()),
+});
+
+export const SimulationResultSchema = z.object({
+  success: z.boolean(),
+  statePreview: z.unknown(),
+  cascades: z.array(z.string()),
+  constraints: z.array(z.string()),
+  estimatedDuration: z.string(),
+  blastRadius: BlastRadiusSchema.optional(),
+  costEstimate: CostEstimateSchema.optional(),
+});
+
+export const ChangeSetSchema = z.object({
+  id: z.string().min(1),
+  tenantId: z.string().min(1, "tenantId is required on every ChangeSet"),
+  connector: z.string().min(1),
+  action: z.string().min(1),
+  description: z.string(),
+  status: ChangeSetStatusSchema,
+  riskScore: z.number().min(0).max(100),
+  riskFactors: z.array(z.string()),
+  changes: z.array(ChangeSchema),
+  simulation: SimulationResultSchema,
+  rollbackData: z.unknown().optional(),
+  createdAt: z.number().int().nonnegative(),
+  expiresAt: z.number().int().nonnegative(),
+  executedAt: z.number().int().nonnegative().optional(),
+  terminalAt: z.number().int().nonnegative().optional(),
+  approvedBy: z.enum(["user", "auto"]).optional(),
+  correlationId: z.string().optional(),
+  traceId: z.string().optional(),
+});
+
+export const CreateChangeSetInputSchema = z.object({
+  tenantId: z.string().min(1, "tenantId is required to create a ChangeSet"),
+  connector: z.string().min(1),
+  action: z.string().min(1),
+  description: z.string(),
+  changes: z.array(ChangeSchema),
+  simulation: SimulationResultSchema,
+  correlationId: z.string().optional(),
+  traceId: z.string().optional(),
+});
+
+export const ChangeSetLifecycleEventSchema = z.object({
+  tenantId: z.string().min(1),
+  ts: z.number().int().nonnegative(),
+  changesetId: z.string().min(1),
+  payload: z.object({
+    product: z.string().min(1),
+    tool: z.string().min(1),
+    state: ChangeSetStatusSchema,
+    blastRadius: BlastRadiusSchema.optional(),
+    approver: z.string().optional(),
+    executionResult: z.unknown().optional(),
+    error: z.string().optional(),
+  }),
+  correlationId: z.string().optional(),
+  traceId: z.string().optional(),
+});

--- a/packages/changeset-contract/src/types.ts
+++ b/packages/changeset-contract/src/types.ts
@@ -1,0 +1,240 @@
+/**
+ * ChangeSet Contract v2 — types.
+ *
+ * The wire/cross-package type definitions for Brainstorm's mutation-gating
+ * safety layer. Every mutation across the harness (MSP, BR, VM, GTM, Ops,
+ * brainstorm desktop itself) flows through a ChangeSet that conforms to
+ * these types. The runtime engine (in @brainst0rm/godmode) implements
+ * the lifecycle; the renderer (in apps/desktop) renders the preview;
+ * product services publish ChangeSet lifecycle events to the federation
+ * bus per these shapes.
+ *
+ * Changes from v1 (which lived in @brainst0rm/godmode/src/types.ts):
+ *   - `tenant_id` is now a REQUIRED field on every ChangeSet (was implicit)
+ *   - `dataClasses` added to BlastRadius for sensitivity tagging
+ *   - `costEstimate` standardized as { usd, breakdown }
+ *   - `reversibility` typed as enum (instant | manual | irreversible)
+ *   - `correlation_id` for cross-product workflows
+ */
+
+/** Lifecycle states a ChangeSet may transition through. */
+export type ChangeSetStatus =
+  | "draft"
+  | "approved"
+  | "executed"
+  | "failed"
+  | "rolled_back"
+  | "rejected"
+  | "expired";
+
+/** Reversibility class — used for risk presentation in the renderer. */
+export type Reversibility = "instant" | "manual" | "irreversible";
+
+/** Data sensitivity classes touched by a change. */
+export type DataClass =
+  | "pii"
+  | "financial"
+  | "config"
+  | "content"
+  | "credentials"
+  | "audit-log";
+
+/**
+ * The atomic unit of mutation within a ChangeSet — one row, one file,
+ * one resource, one entity transition.
+ */
+export interface Change {
+  /** Which product/system owns the entity being mutated. */
+  system: string;
+  /** Stable identifier for the entity. Examples:
+   *  "device:john-laptop", "user:todd@example.com", "vm:i-0abc123". */
+  entity: string;
+  /** Type of mutation. */
+  operation: "create" | "update" | "delete" | "execute";
+  /** Current state, if knowable. */
+  before?: unknown;
+  /** Projected state after the change. */
+  after?: unknown;
+}
+
+/**
+ * Result of simulating a ChangeSet — what *would* happen if executed.
+ * Renderer uses this to populate the operator's preview UI.
+ */
+export interface SimulationResult {
+  success: boolean;
+  /** Human-readable preview of the post-execution state. */
+  statePreview: unknown;
+  /** Downstream effects that would propagate from this change. */
+  cascades: string[];
+  /** Things that would block execution (e.g. "VM is in use", "tenant over quota"). */
+  constraints: string[];
+  /** Rough wall-clock estimate, in operator-readable form. */
+  estimatedDuration: string;
+  /** Detailed impact analysis. */
+  blastRadius?: BlastRadius;
+  /** Projected cost. */
+  costEstimate?: CostEstimate;
+}
+
+/**
+ * Detailed impact analysis. Computed by either:
+ *  - The brainstorm code-graph (for code-structural blast: symbols + communities)
+ *  - The `harness-session-blast-radius` subagent or product's God Mode tool
+ *    (for operational blast: entities + tenants + data classes)
+ *
+ * Both dimensions can be present on the same BlastRadius. The renderer
+ * surfaces whichever fields are populated.
+ *
+ * Code-structural fields are REQUIRED for backward compatibility with the
+ * existing godmode blast-radius computation. Operational fields are
+ * OPTIONAL but should be set on every cross-product ChangeSet going forward.
+ */
+export interface BlastRadius {
+  // ── Code-structural (legacy godmode shape — REQUIRED) ────────────
+  /** Functions/methods directly or transitively affected. */
+  affectedSymbols: Array<{ name: string; file: string; depth: number }>;
+  /** Community sectors affected by this change. */
+  affectedCommunities: Array<{ id: string; name: string; tier: string }>;
+  /** Risk multiplier — higher if critical sectors are affected. */
+  riskMultiplier: number;
+  /** Total number of affected symbols. */
+  totalAffected: number;
+
+  // ── Operational (v2 additions — OPTIONAL, populate going forward) ─
+  /** Number of distinct entities affected. */
+  entitiesAffected?: number;
+  /** Products whose state will change. */
+  productsTouched?: string[];
+  /** Tenants whose state will change (almost always one — multi-tenant ops are exceptional). */
+  tenantsTouched?: string[];
+  /** Sensitivity classes touched. */
+  dataClasses?: DataClass[];
+  /** How undoable this is. */
+  reversibility?: Reversibility;
+}
+
+/**
+ * Cost preview. Sum of upstream LLM, AWS, third-party API, and infra
+ * costs that executing this ChangeSet would incur, in USD.
+ */
+export interface CostEstimate {
+  /** Total estimated cost in USD. */
+  usd: number;
+  /** Line-item breakdown by SKU (e.g. { "llm-anthropic-opus-4-7-input": 0.0042, "aws-ec2-c5xlarge-hour": 0.17 }). */
+  breakdown: Record<string, number>;
+}
+
+/**
+ * The canonical ChangeSet shape. Every mutation across the harness
+ * conforms to this. Federation-aware via `tenantId` and optional
+ * `correlationId`/`traceId`.
+ *
+ * Field naming uses camelCase per TypeScript convention; EventBridge
+ * Detail payloads use the same camelCase shape (no snake_case
+ * conversion at the wire layer — see @brainst0rm/event-bus envelope).
+ */
+export interface ChangeSet {
+  /** Stable identifier, set at creation. UUID or short hash. */
+  id: string;
+  /** Tenant scope. REQUIRED — every ChangeSet is bound to exactly one tenant. */
+  tenantId: string;
+  /** Which connector / product created this. */
+  connector: string;
+  /** Tool name that produced the ChangeSet. */
+  action: string;
+  /** Human-readable summary, operator-facing. */
+  description: string;
+  /** Current lifecycle state. */
+  status: ChangeSetStatus;
+  /** 0–100, auto-calculated from changes + blast radius. */
+  riskScore: number;
+  /** Human-readable risk factors (e.g. "irreversible", "PII deletion", "production environment"). */
+  riskFactors: string[];
+  /** Atomic mutations this ChangeSet performs. */
+  changes: Change[];
+  /** Pre-execution simulation. */
+  simulation: SimulationResult;
+  /** Opaque payload the connector can use to undo. Engine doesn't interpret it. */
+  rollbackData?: unknown;
+  /** Unix ms at creation. */
+  createdAt: number;
+  /** Unix ms — drafts expire after this. */
+  expiresAt: number;
+  /** Unix ms — set on transition to executed. */
+  executedAt?: number;
+  /** Unix ms — set on transition to any terminal state (executed/failed/expired/rejected). */
+  terminalAt?: number;
+  /** Who/what approved the execution. */
+  approvedBy?: "user" | "auto";
+  /** OPTIONAL — for tracking cross-product workflows (Step Functions, multi-step ChangeSet sequences). */
+  correlationId?: string;
+  /** OPTIONAL — OTEL trace id, for distributed-trace correlation. */
+  traceId?: string;
+}
+
+/**
+ * Input shape for createChangeSet — the strict subset of fields a
+ * connector must provide. The engine fills in id, status, timestamps,
+ * riskScore, riskFactors.
+ */
+export interface CreateChangeSetInput {
+  /** REQUIRED — tenant scope. */
+  tenantId: string;
+  /** Connector name. */
+  connector: string;
+  /** Tool/action name. */
+  action: string;
+  /** Operator-facing summary. */
+  description: string;
+  /** Atomic mutations. */
+  changes: Change[];
+  /** Pre-execution simulation. */
+  simulation: SimulationResult;
+  /** OPTIONAL — for workflow correlation. */
+  correlationId?: string;
+  /** OPTIONAL — OTEL trace id. */
+  traceId?: string;
+}
+
+/**
+ * EventBridge Detail envelope for ChangeSet lifecycle events.
+ * Aligned with the schema in `terraform/modules/eventbridge-bus`
+ * (`brainstorm.events.changeset.<state>`).
+ *
+ * Publishers wrap this with PutEvents:
+ *   {
+ *     Source: "brainstorm.<product>",
+ *     DetailType: "changeset.<state>",
+ *     Detail: JSON.stringify(<ChangeSetLifecycleEvent>),
+ *     EventBusName: "brainstorm.events",
+ *   }
+ */
+export interface ChangeSetLifecycleEvent {
+  /** REQUIRED — propagated from the ChangeSet. */
+  tenantId: string;
+  /** Unix ms — when this state transition happened. */
+  ts: number;
+  /** REQUIRED — references the ChangeSet this event is about. */
+  changesetId: string;
+  /** The kind-specific payload. */
+  payload: {
+    /** Product that owns the resource being changed. */
+    product: string;
+    /** God-mode tool id that produced the ChangeSet. */
+    tool: string;
+    /** State the ChangeSet entered. */
+    state: ChangeSetStatus;
+    /** For "simulated" events. */
+    blastRadius?: BlastRadius;
+    /** For "approved" events. */
+    approver?: string;
+    /** For "executed" / "failed" events. */
+    executionResult?: unknown;
+    error?: string;
+  };
+  /** OPTIONAL — for cross-product workflows. */
+  correlationId?: string;
+  /** OPTIONAL — OTEL trace id. */
+  traceId?: string;
+}

--- a/packages/changeset-contract/tsconfig.json
+++ b/packages/changeset-contract/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "**/*.test.ts"]
+}

--- a/packages/changeset-contract/tsup.config.ts
+++ b/packages/changeset-contract/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  target: "es2022",
+  sourcemap: true,
+});

--- a/packages/changeset-contract/vitest.config.ts
+++ b/packages/changeset-contract/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/__tests__/**/*.test.ts"],
+  },
+});

--- a/packages/eventbridge-binding/package.json
+++ b/packages/eventbridge-binding/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@brainst0rm/eventbridge-binding",
+  "version": "0.15.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@brainst0rm/changeset-contract": "0.15.0",
+    "@brainst0rm/godmode": "0.15.0",
+    "@brainst0rm/shared": "0.14.4",
+    "@aws-sdk/client-eventbridge": "^3.700.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.19",
+    "tsup": "^8",
+    "typescript": "^5.7",
+    "vitest": "^3"
+  },
+  "description": "EventBridge binding for @brainst0rm/godmode's ChangeSetEventEmitter. Optional dependency — consumers (CLI, server) wire this at bootstrap to publish ChangeSet lifecycle events to the brainstorm.events bus. Separated from godmode so non-AWS consumers don't pull the SDK.",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/justinjilg/brainstorm.git",
+    "directory": "packages/eventbridge-binding"
+  },
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/eventbridge-binding/src/__tests__/binding.test.ts
+++ b/packages/eventbridge-binding/src/__tests__/binding.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for the EventBridge binding (opus PR 7.1).
+ *
+ * Uses a mock EventBridgeClient to verify:
+ *  - PutEvents is called with the right Source/DetailType/Detail shape
+ *  - State translation (draft→proposed, rolled_back→reverted) happens
+ *  - Partial failures throw
+ *  - install/uninstall lifecycle wires the godmode global
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  createEventBridgeChangeSetEmitter,
+  installEventBridgeEmitter,
+  uninstallEventBridgeEmitter,
+  statusToWireState,
+} from "../index.js";
+import {
+  setChangeSetEventEmitter,
+  createTestEmitter,
+} from "@brainst0rm/godmode";
+import type { ChangeSetLifecycleEvent } from "@brainst0rm/changeset-contract";
+
+function makeEvent(
+  overrides: Partial<ChangeSetLifecycleEvent> = {},
+): ChangeSetLifecycleEvent {
+  return {
+    tenantId: "acme",
+    ts: 1716220800000,
+    changesetId: "cs_abc123",
+    payload: {
+      product: "msp",
+      tool: "msp.customer.create",
+      state: "draft",
+      ...(overrides.payload ?? {}),
+    },
+    ...overrides,
+  } as ChangeSetLifecycleEvent;
+}
+
+describe("statusToWireState", () => {
+  it("maps draft → proposed", () => {
+    expect(statusToWireState("draft")).toBe("proposed");
+  });
+  it("maps rolled_back → reverted", () => {
+    expect(statusToWireState("rolled_back")).toBe("reverted");
+  });
+  it("maps rejected → reverted", () => {
+    expect(statusToWireState("rejected")).toBe("reverted");
+  });
+  it("passes through approved/executed/failed/expired", () => {
+    expect(statusToWireState("approved")).toBe("approved");
+    expect(statusToWireState("executed")).toBe("executed");
+    expect(statusToWireState("failed")).toBe("failed");
+    expect(statusToWireState("expired")).toBe("expired");
+  });
+});
+
+describe("createEventBridgeChangeSetEmitter", () => {
+  it("calls PutEvents with the contract envelope", async () => {
+    const send = vi.fn().mockResolvedValue({ FailedEntryCount: 0 });
+    const mockClient = { send } as never;
+
+    const emitter = createEventBridgeChangeSetEmitter({
+      client: mockClient,
+      busName: "test.bus",
+    });
+
+    await emitter.emit(makeEvent());
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const cmd = send.mock.calls[0]?.[0];
+    expect(cmd.input.Entries).toHaveLength(1);
+    const entry = cmd.input.Entries[0];
+    expect(entry.Source).toBe("brainstorm.msp");
+    expect(entry.DetailType).toBe("changeset.proposed"); // draft→proposed
+    expect(entry.EventBusName).toBe("test.bus");
+    const detail = JSON.parse(entry.Detail);
+    expect(detail.tenantId).toBe("acme");
+    expect(detail.changesetId).toBe("cs_abc123");
+    expect(detail.payload.state).toBe("proposed");
+  });
+
+  it("translates approved/executed/failed without changing them", async () => {
+    const send = vi.fn().mockResolvedValue({ FailedEntryCount: 0 });
+    const mockClient = { send } as never;
+    const emitter = createEventBridgeChangeSetEmitter({ client: mockClient });
+
+    await emitter.emit(
+      makeEvent({ payload: { product: "msp", tool: "x", state: "executed" } }),
+    );
+
+    const entry = send.mock.calls[0]?.[0].input.Entries[0];
+    expect(entry.DetailType).toBe("changeset.executed");
+  });
+
+  it("throws on EventBridge partial failure", async () => {
+    const send = vi.fn().mockResolvedValue({
+      FailedEntryCount: 1,
+      Entries: [
+        {
+          ErrorCode: "AccessDeniedException",
+          ErrorMessage: "no PutEvents permission",
+        },
+      ],
+    });
+    const mockClient = { send } as never;
+    const emitter = createEventBridgeChangeSetEmitter({ client: mockClient });
+
+    await expect(emitter.emit(makeEvent())).rejects.toThrow(
+      /AccessDeniedException/,
+    );
+  });
+
+  it("translates rolled_back → reverted in DetailType + payload.state", async () => {
+    const send = vi.fn().mockResolvedValue({ FailedEntryCount: 0 });
+    const emitter = createEventBridgeChangeSetEmitter({
+      client: { send } as never,
+    });
+
+    await emitter.emit(
+      makeEvent({
+        payload: { product: "vm", tool: "vm.destroy", state: "rolled_back" },
+      }),
+    );
+
+    const entry = send.mock.calls[0]?.[0].input.Entries[0];
+    expect(entry.DetailType).toBe("changeset.reverted");
+    expect(JSON.parse(entry.Detail).payload.state).toBe("reverted");
+  });
+});
+
+describe("installEventBridgeEmitter / uninstallEventBridgeEmitter", () => {
+  beforeEach(() => {
+    setChangeSetEventEmitter(null);
+  });
+
+  it("install returns a functional emitter and doesn't throw", async () => {
+    const send = vi.fn().mockResolvedValue({ FailedEntryCount: 0 });
+    const emitter = installEventBridgeEmitter({ client: { send } as never });
+
+    // The returned emitter is the one wired into godmode's global slot.
+    // Exercise it directly to confirm the wiring chain works.
+    await emitter.emit(makeEvent());
+    expect(send).toHaveBeenCalled();
+  });
+
+  it("uninstall reverts the global slot without throwing", () => {
+    installEventBridgeEmitter({ client: { send: vi.fn() } as never });
+    expect(() => uninstallEventBridgeEmitter()).not.toThrow();
+  });
+});

--- a/packages/eventbridge-binding/src/index.ts
+++ b/packages/eventbridge-binding/src/index.ts
@@ -1,0 +1,159 @@
+/**
+ * @brainst0rm/eventbridge-binding
+ *
+ * Wires `@brainst0rm/godmode`'s ChangeSetEventEmitter interface (defined
+ * in opus PR #372) to the actual AWS EventBridge bus
+ * `brainstorm.events` (BrainstormOps PR #76). Consumers (CLI, server)
+ * call `installEventBridgeEmitter(config)` at bootstrap; from then on,
+ * every ChangeSet lifecycle transition publishes to the bus.
+ *
+ * Separated from godmode so non-AWS consumers (e.g. dev sessions
+ * without AWS credentials) don't pull @aws-sdk/client-eventbridge.
+ *
+ * Authored as opus PR 7.1. Composes with:
+ *   - PR #367 (changeset-contract): provides the event types
+ *   - PR #372 (event emission interface in godmode): provides the slot
+ *   - BrainstormOps PR #76 (eventbridge-bus): the target bus + schemas
+ */
+
+import {
+  EventBridgeClient,
+  PutEventsCommand,
+  type PutEventsRequestEntry,
+} from "@aws-sdk/client-eventbridge";
+import { createLogger } from "@brainst0rm/shared";
+import type { ChangeSetEventEmitter } from "@brainst0rm/godmode";
+import { setChangeSetEventEmitter } from "@brainst0rm/godmode";
+import type { ChangeSetLifecycleEvent } from "@brainst0rm/changeset-contract";
+
+const log = createLogger("eventbridge-binding");
+
+export interface EventBridgeEmitterConfig {
+  /** AWS region where the bus lives. Defaults to us-east-1. */
+  region?: string;
+  /** EventBridge bus name. Defaults to "brainstorm.events". */
+  busName?: string;
+  /**
+   * Optional EventBridgeClient instance. Useful for tests + for
+   * consumers that already have a credential-managed client. If absent,
+   * a fresh client is created with the SDK's default credential chain.
+   */
+  client?: EventBridgeClient;
+}
+
+const DEFAULT_REGION = "us-east-1";
+const DEFAULT_BUS_NAME = "brainstorm.events";
+
+/**
+ * State-name translation: the godmode engine uses ChangeSetStatus values
+ * (draft / approved / executed / failed / rolled_back / rejected /
+ * expired). The EventBridge schemas in BrainstormOps PR #76 use the
+ * narrative-aligned names (proposed / simulated / approved / executed /
+ * failed / reverted). This map bridges them at the wire layer.
+ */
+function statusToWireState(state: string): string {
+  switch (state) {
+    case "draft":
+      return "proposed";
+    case "rolled_back":
+      return "reverted";
+    case "rejected":
+      return "reverted";
+    // "approved", "executed", "failed", "expired" pass through unchanged
+    default:
+      return state;
+  }
+}
+
+/**
+ * Construct (but don't install) an EventBridge-backed
+ * ChangeSetEventEmitter. Useful when the caller wants to manage the
+ * emitter lifecycle directly.
+ */
+export function createEventBridgeChangeSetEmitter(
+  config: EventBridgeEmitterConfig = {},
+): ChangeSetEventEmitter {
+  const region = config.region ?? DEFAULT_REGION;
+  const busName = config.busName ?? DEFAULT_BUS_NAME;
+  const client = config.client ?? new EventBridgeClient({ region });
+
+  return {
+    async emit(event: ChangeSetLifecycleEvent): Promise<void> {
+      const wireState = statusToWireState(event.payload.state);
+      const detail = {
+        ...event,
+        payload: {
+          ...event.payload,
+          state: wireState,
+        },
+      };
+
+      const entry: PutEventsRequestEntry = {
+        Source: `brainstorm.${event.payload.product}`,
+        DetailType: `changeset.${wireState}`,
+        Detail: JSON.stringify(detail),
+        EventBusName: busName,
+      };
+
+      const result = await client.send(
+        new PutEventsCommand({ Entries: [entry] }),
+      );
+
+      // EventBridge returns 200 even on per-entry failures — check
+      // FailedEntryCount + Entries[].ErrorCode to detect.
+      if (result.FailedEntryCount && result.FailedEntryCount > 0) {
+        const errors = (result.Entries ?? [])
+          .filter((e) => e.ErrorCode)
+          .map((e) => `${e.ErrorCode}: ${e.ErrorMessage}`)
+          .join("; ");
+        // Throw so godmode's outer best-effort catch logs at warn level.
+        // We don't want to silently lose events when EB rejects them
+        // (schema mismatch, bus doesn't exist, permission denied, etc.).
+        throw new Error(`EventBridge PutEvents partial failure: ${errors}`);
+      }
+    },
+  };
+}
+
+/**
+ * Wire the EventBridge emitter as the global ChangeSet event sink.
+ * Idempotent — calling twice replaces the previous emitter. Pass
+ * `null` config to disable (replace with no-op).
+ *
+ * Typical usage in CLI/server bootstrap:
+ *
+ *   import { installEventBridgeEmitter } from "@brainst0rm/eventbridge-binding";
+ *
+ *   if (process.env.BRAINSTORM_EVENTBRIDGE_ENABLED === "1") {
+ *     installEventBridgeEmitter({
+ *       region: process.env.AWS_REGION,
+ *       busName: process.env.BRAINSTORM_EVENT_BUS_NAME,
+ *     });
+ *   }
+ */
+export function installEventBridgeEmitter(
+  config: EventBridgeEmitterConfig = {},
+): ChangeSetEventEmitter {
+  const emitter = createEventBridgeChangeSetEmitter(config);
+  setChangeSetEventEmitter(emitter);
+  log.info(
+    {
+      bus: config.busName ?? DEFAULT_BUS_NAME,
+      region: config.region ?? DEFAULT_REGION,
+    },
+    "EventBridge ChangeSet emitter installed",
+  );
+  return emitter;
+}
+
+/**
+ * Convenience: uninstall the emitter (replace with no-op). Useful in
+ * tests + during graceful shutdown.
+ */
+export function uninstallEventBridgeEmitter(): void {
+  setChangeSetEventEmitter(null);
+}
+
+// Re-export the wire-state translation so consumers can use it
+// independently (e.g. when constructing events from outside the engine).
+export { statusToWireState };

--- a/packages/eventbridge-binding/tsconfig.json
+++ b/packages/eventbridge-binding/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "**/*.test.ts"]
+}

--- a/packages/eventbridge-binding/tsup.config.ts
+++ b/packages/eventbridge-binding/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  target: "es2022",
+  sourcemap: true,
+  external: ["@aws-sdk/client-eventbridge"],
+});

--- a/packages/eventbridge-binding/vitest.config.ts
+++ b/packages/eventbridge-binding/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/__tests__/**/*.test.ts"],
+  },
+});

--- a/packages/godmode/package.json
+++ b/packages/godmode/package.json
@@ -9,6 +9,7 @@
     "compile-contract": "tsx scripts/compile-contract.ts"
   },
   "dependencies": {
+    "@brainst0rm/changeset-contract": "0.15.0",
     "@brainst0rm/config": "0.14.4",
     "@brainst0rm/shared": "0.14.4",
     "@brainst0rm/tools": "0.15.0",

--- a/packages/godmode/src/__tests__/event-emission.test.ts
+++ b/packages/godmode/src/__tests__/event-emission.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Tests for ChangeSet lifecycle event emission (opus PR 7).
+ *
+ * Verifies that:
+ *  - createChangeSet emits "proposed" with blastRadius
+ *  - approveChangeSet emits "approved" then "executed" on success
+ *  - approveChangeSet emits "approved" then "failed" on executor failure
+ *  - failed emissions don't break ChangeSet execution
+ *  - No emitter wired → silent no-op
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  createChangeSet,
+  approveChangeSet,
+  registerExecutor,
+  setChangeSetEventEmitter,
+  createTestEmitter,
+} from "../index.js";
+
+describe("ChangeSet event emission", () => {
+  beforeEach(() => {
+    setChangeSetEventEmitter(null);
+  });
+  afterEach(() => {
+    setChangeSetEventEmitter(null);
+  });
+
+  it("emits 'draft' on createChangeSet with blast radius", () => {
+    const capture = createTestEmitter();
+    setChangeSetEventEmitter(capture);
+
+    const cs = createChangeSet({
+      tenantId: "acme",
+      connector: "msp",
+      action: `test-${Math.random()}`,
+      description: "x",
+      changes: [{ system: "msp", entity: "device:1", operation: "update" }],
+      simulation: {
+        success: true,
+        statePreview: {},
+        cascades: [],
+        constraints: [],
+        estimatedDuration: "~1s",
+        blastRadius: {
+          affectedSymbols: [],
+          affectedCommunities: [],
+          riskMultiplier: 1,
+          totalAffected: 0,
+          entitiesAffected: 1,
+          productsTouched: ["msp"],
+          tenantsTouched: ["acme"],
+          dataClasses: ["pii"],
+          reversibility: "instant",
+        },
+      },
+    });
+
+    expect(capture.events).toHaveLength(1);
+    expect(capture.events[0]?.payload.state).toBe("draft");
+    expect(capture.events[0]?.changesetId).toBe(cs.id);
+    expect(capture.events[0]?.tenantId).toBe("acme");
+    expect(capture.events[0]?.payload.product).toBe("msp");
+    expect(capture.events[0]?.payload.blastRadius).toBeDefined();
+  });
+
+  it("emits 'approved' then 'executed' on successful approval", async () => {
+    const capture = createTestEmitter();
+    setChangeSetEventEmitter(capture);
+
+    const action = `success-${Math.random()}`;
+    registerExecutor(action, async () => ({
+      success: true,
+      message: "done",
+      rollbackData: { id: "abc" },
+    }));
+
+    const cs = createChangeSet({
+      tenantId: "acme",
+      connector: "msp",
+      action,
+      description: "x",
+      changes: [{ system: "msp", entity: "e", operation: "execute" }],
+      simulation: {
+        success: true,
+        statePreview: {},
+        cascades: [],
+        constraints: [],
+        estimatedDuration: "~0s",
+      },
+    });
+
+    await approveChangeSet(cs.id);
+
+    const states = capture.events.map((e) => e.payload.state);
+    expect(states).toEqual(["draft", "approved", "executed"]);
+    expect(capture.events[1]?.payload.approver).toBe("user");
+    expect(capture.events[2]?.payload.executionResult).toEqual({ id: "abc" });
+  });
+
+  it("emits 'approved' then 'failed' on executor failure", async () => {
+    const capture = createTestEmitter();
+    setChangeSetEventEmitter(capture);
+
+    const action = `failure-${Math.random()}`;
+    registerExecutor(action, async () => ({
+      success: false,
+      message: "upstream 500",
+    }));
+
+    const cs = createChangeSet({
+      tenantId: "acme",
+      connector: "msp",
+      action,
+      description: "x",
+      changes: [{ system: "msp", entity: "e", operation: "execute" }],
+      simulation: {
+        success: true,
+        statePreview: {},
+        cascades: [],
+        constraints: [],
+        estimatedDuration: "~0s",
+      },
+    });
+
+    await approveChangeSet(cs.id);
+
+    const states = capture.events.map((e) => e.payload.state);
+    expect(states).toEqual(["draft", "approved", "failed"]);
+    expect(capture.events[2]?.payload.error).toBe("upstream 500");
+  });
+
+  it("emits 'approved' then 'failed' on executor throw", async () => {
+    const capture = createTestEmitter();
+    setChangeSetEventEmitter(capture);
+
+    const action = `throw-${Math.random()}`;
+    registerExecutor(action, async () => {
+      throw new Error("boom");
+    });
+
+    const cs = createChangeSet({
+      tenantId: "acme",
+      connector: "msp",
+      action,
+      description: "x",
+      changes: [{ system: "msp", entity: "e", operation: "execute" }],
+      simulation: {
+        success: true,
+        statePreview: {},
+        cascades: [],
+        constraints: [],
+        estimatedDuration: "~0s",
+      },
+    });
+
+    await approveChangeSet(cs.id);
+
+    const states = capture.events.map((e) => e.payload.state);
+    expect(states).toEqual(["draft", "approved", "failed"]);
+    expect(capture.events[2]?.payload.error).toContain("boom");
+  });
+
+  it("does not break ChangeSet flow when emitter throws (sync)", () => {
+    setChangeSetEventEmitter({
+      emit() {
+        throw new Error("federation bus down");
+      },
+    });
+
+    // Should NOT throw — the changeset must still be created
+    const cs = createChangeSet({
+      tenantId: "acme",
+      connector: "msp",
+      action: `resilient-${Math.random()}`,
+      description: "x",
+      changes: [{ system: "msp", entity: "e", operation: "update" }],
+      simulation: {
+        success: true,
+        statePreview: {},
+        cascades: [],
+        constraints: [],
+        estimatedDuration: "~0s",
+      },
+    });
+
+    expect(cs.id).toBeDefined();
+    expect(cs.status).toBe("draft");
+  });
+
+  it("does not break ChangeSet flow when emitter rejects (async)", () => {
+    setChangeSetEventEmitter({
+      async emit() {
+        throw new Error("federation bus timeout");
+      },
+    });
+
+    // Async rejection should also not break the sync path
+    const cs = createChangeSet({
+      tenantId: "acme",
+      connector: "msp",
+      action: `async-resilient-${Math.random()}`,
+      description: "x",
+      changes: [{ system: "msp", entity: "e", operation: "update" }],
+      simulation: {
+        success: true,
+        statePreview: {},
+        cascades: [],
+        constraints: [],
+        estimatedDuration: "~0s",
+      },
+    });
+
+    expect(cs.id).toBeDefined();
+  });
+
+  it("is silent no-op when no emitter wired", () => {
+    setChangeSetEventEmitter(null);
+
+    const cs = createChangeSet({
+      tenantId: "acme",
+      connector: "msp",
+      action: `no-emitter-${Math.random()}`,
+      description: "x",
+      changes: [{ system: "msp", entity: "e", operation: "update" }],
+      simulation: {
+        success: true,
+        statePreview: {},
+        cascades: [],
+        constraints: [],
+        estimatedDuration: "~0s",
+      },
+    });
+
+    // Just confirms no crash
+    expect(cs.id).toBeDefined();
+  });
+
+  it("propagates correlationId and traceId into events", () => {
+    const capture = createTestEmitter();
+    setChangeSetEventEmitter(capture);
+
+    createChangeSet({
+      tenantId: "acme",
+      connector: "msp",
+      action: `correlation-${Math.random()}`,
+      description: "x",
+      changes: [{ system: "msp", entity: "e", operation: "update" }],
+      simulation: {
+        success: true,
+        statePreview: {},
+        cascades: [],
+        constraints: [],
+        estimatedDuration: "~0s",
+      },
+      correlationId: "incident-2026-05-21-001",
+      traceId: "trace-xyz",
+    });
+
+    expect(capture.events[0]?.correlationId).toBe("incident-2026-05-21-001");
+    expect(capture.events[0]?.traceId).toBe("trace-xyz");
+  });
+});

--- a/packages/godmode/src/changeset.ts
+++ b/packages/godmode/src/changeset.ts
@@ -16,6 +16,7 @@
 
 import { randomUUID } from "node:crypto";
 import { defineTool, type BrainstormToolDef } from "@brainst0rm/tools";
+import { createLogger } from "@brainst0rm/shared";
 import { z } from "zod";
 import { logChangeSet } from "./audit.js";
 import type {
@@ -24,6 +25,8 @@ import type {
   Change,
   SimulationResult,
 } from "./types.js";
+
+const log = createLogger("godmode-changeset");
 
 /** Draft TTL: 5 minutes. */
 const DRAFT_TTL_MS = 5 * 60 * 1000;
@@ -52,12 +55,33 @@ const executors = new Map<
 
 // ── ChangeSet CRUD ───────────────────────────────────────────────
 
+/**
+ * Input shape for createChangeSet. As of v2 (PR 5), tenantId SHOULD be
+ * provided on every call — it's required at the contract level (see
+ * @brainst0rm/changeset-contract `CreateChangeSetInput`). The engine
+ * accepts an absent tenantId during the migration window and logs a
+ * deprecation warning so existing connectors keep working; callers
+ * should add `tenantId` to their createChangeSet calls promptly.
+ *
+ * `correlationId` and `traceId` are also accepted for federation
+ * correlation but are entirely optional.
+ */
 export interface CreateChangeSetInput {
   connector: string;
   action: string;
   description: string;
   changes: Change[];
   simulation: SimulationResult;
+  /**
+   * Required by the v2 contract. Falsy values trigger a deprecation
+   * warning; the engine substitutes the empty string. Renderers MAY
+   * refuse to display ChangeSets with an empty tenantId.
+   */
+  tenantId?: string;
+  /** OPTIONAL — for tracking cross-product workflows. */
+  correlationId?: string;
+  /** OPTIONAL — OTEL trace id. */
+  traceId?: string;
 }
 
 /**
@@ -67,6 +91,20 @@ export interface CreateChangeSetInput {
 export function createChangeSet(input: CreateChangeSetInput): ChangeSet {
   // Expire stale drafts first
   expireStale();
+
+  // v2 contract: tenantId is required. Soft-warn during the migration
+  // window so existing connectors keep working; remove this fallback
+  // once all 13 call sites pass tenantId explicitly.
+  let tenantId = input.tenantId;
+  if (!tenantId) {
+    log.warn(
+      { connector: input.connector, action: input.action },
+      "createChangeSet called without tenantId — defaulting to empty. " +
+        "This is deprecated; per the v2 contract (@brainst0rm/changeset-contract), " +
+        "tenantId is REQUIRED. Update the call site.",
+    );
+    tenantId = "";
+  }
 
   const riskScore = calculateRiskScore(
     input.changes,
@@ -81,6 +119,7 @@ export function createChangeSet(input: CreateChangeSetInput): ChangeSet {
 
   const changeset: ChangeSet = {
     id: randomUUID().slice(0, 8),
+    tenantId,
     connector: input.connector,
     action: input.action,
     description: input.description,
@@ -91,6 +130,8 @@ export function createChangeSet(input: CreateChangeSetInput): ChangeSet {
     simulation: input.simulation,
     createdAt: Date.now(),
     expiresAt: Date.now() + DRAFT_TTL_MS,
+    ...(input.correlationId ? { correlationId: input.correlationId } : {}),
+    ...(input.traceId ? { traceId: input.traceId } : {}),
   };
 
   changesets.set(changeset.id, changeset);

--- a/packages/godmode/src/changeset.ts
+++ b/packages/godmode/src/changeset.ts
@@ -19,6 +19,7 @@ import { defineTool, type BrainstormToolDef } from "@brainst0rm/tools";
 import { createLogger } from "@brainst0rm/shared";
 import { z } from "zod";
 import { logChangeSet } from "./audit.js";
+import { emitChangeSetEvent } from "./event-emitter.js";
 import type {
   ChangeSet,
   ChangeSetStatus,
@@ -27,6 +28,49 @@ import type {
 } from "./types.js";
 
 const log = createLogger("godmode-changeset");
+
+/**
+ * Build a ChangeSetLifecycleEvent envelope for emission to the federation
+ * bus. Pure mapper — does NOT touch the wire. Caller passes the event to
+ * `emitChangeSetEvent` (best-effort).
+ *
+ * The `state` argument uses the engine's `ChangeSetStatus` directly
+ * (draft / approved / executed / failed / rolled_back / rejected /
+ * expired). The EventBridge schemas in BrainstormOps PR #76 use slightly
+ * different state names (proposed / simulated / approved / executed /
+ * failed / reverted). A wire-level translation lives in the binding
+ * (CLI/server) that constructs the actual EventBridge PutEvents call.
+ */
+function lifecycleEventFor(
+  cs: ChangeSet,
+  state: ChangeSetStatus,
+  extra?: {
+    approver?: string;
+    executionResult?: unknown;
+    error?: string;
+  },
+) {
+  return {
+    tenantId: cs.tenantId,
+    ts: Date.now(),
+    changesetId: cs.id,
+    payload: {
+      product: cs.connector,
+      tool: cs.action,
+      state,
+      ...(state === "draft" && cs.simulation.blastRadius
+        ? { blastRadius: cs.simulation.blastRadius }
+        : {}),
+      ...(extra?.approver ? { approver: extra.approver } : {}),
+      ...(extra?.executionResult !== undefined
+        ? { executionResult: extra.executionResult }
+        : {}),
+      ...(extra?.error ? { error: extra.error } : {}),
+    },
+    ...(cs.correlationId ? { correlationId: cs.correlationId } : {}),
+    ...(cs.traceId ? { traceId: cs.traceId } : {}),
+  };
+}
 
 /** Draft TTL: 5 minutes. */
 const DRAFT_TTL_MS = 5 * 60 * 1000;
@@ -135,6 +179,13 @@ export function createChangeSet(input: CreateChangeSetInput): ChangeSet {
   };
 
   changesets.set(changeset.id, changeset);
+
+  // Emit the proposed lifecycle event to the federation bus. The engine's
+  // createChangeSet always includes a completed simulation in its input,
+  // so "proposed" carries the blast radius (the "simulated" state is
+  // implicitly subsumed — no separate intermediate event).
+  emitChangeSetEvent(lifecycleEventFor(changeset, "draft"));
+
   return changeset;
 }
 
@@ -184,6 +235,11 @@ export async function approveChangeSet(
   try {
     cs.status = "approved";
     cs.approvedBy = approvedBy;
+
+    // Emit `approved` lifecycle event (post status flip, pre-execute)
+    emitChangeSetEvent(
+      lifecycleEventFor(cs, "approved", { approver: approvedBy }),
+    );
 
     // Execute via the registered executor
     const executor = executors.get(cs.action);
@@ -236,6 +292,11 @@ export async function approveChangeSet(
         cs.executedAt = Date.now();
         cs.terminalAt = cs.executedAt;
         cs.rollbackData = result.rollbackData;
+        emitChangeSetEvent(
+          lifecycleEventFor(cs, "executed", {
+            executionResult: result.rollbackData,
+          }),
+        );
       } else {
         // Execution returned failure. Previously we reverted to "draft" to
         // keep the changeset retryable, but that let a partial-mutation
@@ -244,6 +305,9 @@ export async function approveChangeSet(
         // retryChangeSet() call to rehydrate — operator intervention.
         cs.status = "failed";
         cs.terminalAt = Date.now();
+        emitChangeSetEvent(
+          lifecycleEventFor(cs, "failed", { error: result.message }),
+        );
       }
       // Always audit both success and failure
       logChangeSet(cs);
@@ -255,8 +319,9 @@ export async function approveChangeSet(
     } catch (error) {
       cs.status = "failed";
       cs.terminalAt = Date.now();
-      logChangeSet(cs); // Audit the failure
       const msg = error instanceof Error ? error.message : String(error);
+      emitChangeSetEvent(lifecycleEventFor(cs, "failed", { error: msg }));
+      logChangeSet(cs); // Audit the failure
       return {
         success: false,
         message: `Execution failed: ${msg}`,

--- a/packages/godmode/src/event-emitter.ts
+++ b/packages/godmode/src/event-emitter.ts
@@ -1,0 +1,130 @@
+/**
+ * ChangeSet event emission — lifecycle events to the federation bus.
+ *
+ * Wires the godmode ChangeSet engine to publish lifecycle events
+ * (proposed, simulated, approved, executed, failed, reverted, rolled_back)
+ * to the `brainstorm.events` EventBridge bus (BrainstormOps PR #76).
+ *
+ * Architectural choice: this module defines a thin `ChangeSetEventEmitter`
+ * INTERFACE, not a direct EventBridge client. Reasons:
+ *
+ * 1. godmode runs in multiple contexts (CLI, desktop, server,
+ *    sleep-time agents). Not all have AWS credentials — bundling
+ *    @aws-sdk/client-eventbridge here would either force every
+ *    consumer to pull the SDK or fail at runtime for non-AWS contexts.
+ *
+ * 2. Tests need a deterministic no-op (or in-memory capture)
+ *    emitter. The interface is trivially mockable.
+ *
+ * 3. The actual EventBridge wiring lives where credentials + region
+ *    config live: at the CLI bootstrap or server startup. Those
+ *    construct an emitter and inject it via `setChangeSetEventEmitter`.
+ *
+ * Failure mode: all `emit()` calls are best-effort. Errors are caught,
+ * logged at warn level, and never propagate to the caller — a broken
+ * federation bus must NOT break ChangeSet execution. The trade-off:
+ * we may silently lose events under degraded bus conditions. The
+ * replay archive on the bus (BrainstormOps PR #76 §archive) is the
+ * recovery path for any losses.
+ *
+ * Authored as opus PR 7. Composes with:
+ *   - packages/changeset-contract (PR #367) — type for the event payload
+ *   - BrainstormOps PR #76 — the bus this targets
+ *   - BrainstormOps PR #80 — workflow.* schemas (parallel surface)
+ */
+
+import { createLogger } from "@brainst0rm/shared";
+import type { ChangeSetLifecycleEvent } from "@brainst0rm/changeset-contract";
+
+const log = createLogger("godmode-event-emitter");
+
+export interface ChangeSetEventEmitter {
+  /**
+   * Publish a ChangeSet lifecycle event. The implementation decides
+   * how (EventBridge PutEvents, in-memory queue, no-op, etc.).
+   * Errors must be handled internally — this engine treats emission
+   * as best-effort. Throwing escapes safety nets and CAN affect
+   * ChangeSet execution flow if not caught upstream.
+   */
+  emit(event: ChangeSetLifecycleEvent): Promise<void> | void;
+}
+
+let emitter: ChangeSetEventEmitter | null = null;
+
+/**
+ * Wire the global ChangeSet event emitter. Typically called once at
+ * application startup. Passing null disables emission (useful in tests).
+ */
+export function setChangeSetEventEmitter(
+  e: ChangeSetEventEmitter | null,
+): void {
+  emitter = e;
+}
+
+/**
+ * Internal: invoked by the changeset engine at every lifecycle
+ * transition. Best-effort — failures are logged but never propagated.
+ */
+export function emitChangeSetEvent(event: ChangeSetLifecycleEvent): void {
+  if (!emitter) {
+    // No emitter wired — emission is opt-in. This is the default for
+    // CLI dev sessions, tests, and contexts without federation config.
+    return;
+  }
+
+  try {
+    const result = emitter.emit(event);
+    if (result && typeof (result as Promise<void>).then === "function") {
+      (result as Promise<void>).catch((err) => {
+        log.warn(
+          {
+            err: err instanceof Error ? err.message : String(err),
+            changeset_id: event.changesetId,
+            state: event.payload.state,
+          },
+          "ChangeSet event emission failed (async, non-fatal)",
+        );
+      });
+    }
+  } catch (err) {
+    log.warn(
+      {
+        err: err instanceof Error ? err.message : String(err),
+        changeset_id: event.changesetId,
+        state: event.payload.state,
+      },
+      "ChangeSet event emission failed (sync, non-fatal)",
+    );
+  }
+}
+
+/**
+ * Test helper: in-memory event capture. Records all emitted events
+ * into a local array for assertions. Returns a `clear()` to reset.
+ *
+ * Usage:
+ *   const capture = createTestEmitter();
+ *   setChangeSetEventEmitter(capture);
+ *   // ... exercise code ...
+ *   expect(capture.events).toHaveLength(2);
+ *   expect(capture.events[0].payload.state).toBe("proposed");
+ *
+ * Not for production use.
+ */
+export interface TestEmitter extends ChangeSetEventEmitter {
+  events: ChangeSetLifecycleEvent[];
+  clear(): void;
+}
+
+export function createTestEmitter(): TestEmitter {
+  const events: ChangeSetLifecycleEvent[] = [];
+  return {
+    emit(event) {
+      events.push(event);
+    },
+    events,
+    clear() {
+      events.length = 0;
+    },
+  };
+}

--- a/packages/godmode/src/index.ts
+++ b/packages/godmode/src/index.ts
@@ -19,6 +19,12 @@ export {
   listChangeSets,
   registerExecutor,
 } from "./changeset.js";
+export {
+  setChangeSetEventEmitter,
+  createTestEmitter,
+  type ChangeSetEventEmitter,
+  type TestEmitter,
+} from "./event-emitter.js";
 export { computeBlastRadius } from "./blast-radius.js";
 export type { BlastRadius } from "./types.js";
 export { ProductConnector } from "./product-connector.js";

--- a/packages/godmode/src/types.ts
+++ b/packages/godmode/src/types.ts
@@ -84,82 +84,29 @@ export interface GodModeConfig {
 }
 
 // ── ChangeSet ────────────────────────────────────────────────────
+//
+// As of v2 (opus PR 5), ChangeSet types live in @brainst0rm/changeset-contract.
+// Re-exported here so existing consumers of @brainst0rm/godmode see no
+// breaking change at the import site. Direct imports from the contract
+// package are preferred for new code.
+//
+// Migration note: ChangeSet now has a REQUIRED `tenantId` field. The
+// engine's createChangeSet accepts a missing tenantId during the
+// migration window (defaults to "") but emits a deprecation warning;
+// callers should pass tenantId explicitly going forward.
 
-export type ChangeSetStatus =
-  | "draft"
-  | "approved"
-  | "executed"
-  | "failed"
-  | "rolled_back"
-  | "rejected"
-  | "expired";
-
-export interface ChangeSet {
-  id: string;
-  /** Which connector created this. */
-  connector: string;
-  /** Tool name that created it. */
-  action: string;
-  /** Human-readable summary. */
-  description: string;
-  status: ChangeSetStatus;
-  /** 0-100, auto-calculated from changes. */
-  riskScore: number;
-  riskFactors: string[];
-  /** What will be mutated. */
-  changes: Change[];
-  /** Simulation of what would happen. */
-  simulation: SimulationResult;
-  /** Opaque undo payload from the connector. */
-  rollbackData?: unknown;
-  createdAt: number;
-  /** 5-minute TTL on drafts. */
-  expiresAt: number;
-  executedAt?: number;
-  /**
-   * Timestamp of the transition to a terminal status (executed,
-   * failed, expired, or rejected). Used as the retention anchor
-   * for in-memory GC. Absent for drafts.
-   */
-  terminalAt?: number;
-  approvedBy?: "user" | "auto";
-}
-
-export interface Change {
-  /** Which system: "msp", "email", "vm". */
-  system: string;
-  /** Entity identifier: "device:john-laptop", "user:todd@example.com". */
-  entity: string;
-  operation: "create" | "update" | "delete" | "execute";
-  /** Current state (from simulation). */
-  before?: unknown;
-  /** Projected state. */
-  after?: unknown;
-}
-
-export interface SimulationResult {
-  success: boolean;
-  /** What the system would look like after execution. */
-  statePreview: unknown;
-  /** Downstream effects. */
-  cascades: string[];
-  /** Things that would block execution. */
-  constraints: string[];
-  estimatedDuration: string;
-  /** Code-level blast radius from knowledge graph analysis. */
-  blastRadius?: BlastRadius;
-}
-
-export interface BlastRadius {
-  /** Functions/methods directly or transitively affected. */
-  affectedSymbols: Array<{ name: string; file: string; depth: number }>;
-  /** Community sectors affected by this change. */
-  affectedCommunities: Array<{ id: string; name: string; tier: string }>;
-  /** Risk multiplier — higher if critical sectors are affected. */
-  riskMultiplier: number;
-  /** Total number of affected symbols. */
-  totalAffected: number;
-}
+export type {
+  ChangeSet,
+  ChangeSetStatus,
+  Change,
+  SimulationResult,
+  BlastRadius,
+  ChangeSetLifecycleEvent,
+  CostEstimate,
+  CreateChangeSetInput,
+  DataClass,
+  Reversibility,
+} from "@brainst0rm/changeset-contract";
 
 // ── Action Results ───────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Closes the binding gap from [PR #372](https://github.com/justinjilg/brainstorm/pull/372): godmode defines the \`ChangeSetEventEmitter\` interface but doesn't ship an EventBridge implementation (deliberate — keeps godmode AWS-agnostic). This new package wires the godmode interface to the actual AWS SDK so ChangeSet lifecycle events flow to \`brainstorm.events\`.

## New package: \`@brainst0rm/eventbridge-binding\`

\`\`\`typescript
import { installEventBridgeEmitter } from "@brainst0rm/eventbridge-binding";

// At CLI/server bootstrap:
if (process.env.BRAINSTORM_EVENTBRIDGE_ENABLED === "1") {
  installEventBridgeEmitter({
    region: process.env.AWS_REGION,
    busName: process.env.BRAINSTORM_EVENT_BUS_NAME,
  });
}
\`\`\`

Exports:
- \`createEventBridgeChangeSetEmitter(config)\` — factory
- \`installEventBridgeEmitter(config)\` — wires the godmode global
- \`uninstallEventBridgeEmitter()\` — reverts to no-op
- \`statusToWireState(status)\` — pure mapper for state-name translation

## Wire-state translation

godmode → EventBridge schema mapping:
- \`draft\` → \`proposed\`
- \`rolled_back\` → \`reverted\`
- \`rejected\` → \`reverted\`
- \`approved\` / \`executed\` / \`failed\` / \`expired\` → pass through

## Failure handling

- PutEvents partial failures (\`FailedEntryCount > 0\`) throw with the per-entry ErrorCode embedded so godmode's outer best-effort catch logs them at warn level
- AWS SDK transport errors propagate to godmode's catch too
- Operators can grep CloudWatch for "EventBridge PutEvents partial failure" to detect lost events

## Verification

- \`turbo run build --filter=@brainst0rm/eventbridge-binding\`: clean ✅
- \`vitest run\`: **10/10 tests pass** ✅
  - 4 state-translation tests
  - 4 emitter tests (envelope shape, state translation, partial-failure throw, rolled_back→reverted)
  - 2 install/uninstall lifecycle tests

## Stack base

Stacks on [PR #372](https://github.com/justinjilg/brainstorm/pull/372) (godmode emitter interface). Composes with [PR #367](https://github.com/justinjilg/brainstorm/pull/367) + [BrainstormOps #76](https://github.com/justinjilg/BrainstormOps/pull/76).

## What this PR does NOT do

- Wire CLI/server bootstrap to actually call \`installEventBridgeEmitter\` — that's a follow-up in the runtime entry points. The opt-in env var pattern is documented in the README so consumers can adopt at their own pace.

Under /goal — Business Harness Hub v1