### PR TITLE
fix(contract-checks): br-contract-map needle tracks BR_BASE_URL constant

### DIFF
--- a/artifacts/br-business-contract-map.json
+++ b/artifacts/br-business-contract-map.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "scope": "bounded to Brainstorm routes currently touching BR/product actuator contracts",
-  "repo_root": "/Users/justin/Projects/brainstorm-pr-br-seam",
+  "repo_root": "/Users/justin/Projects/brainstorm",
   "br_repo_root": "/Users/justin/Projects/brainstormrouter",
   "br_repo_detected": true,
   "ok": true,
@@ -9,10 +9,10 @@
     "routes": 20,
     "failures": 0,
     "warnings": 0,
-    "br_openapi_paths_seen": 490,
-    "br_capability_routes_seen": 616,
+    "br_openapi_paths_seen": 517,
+    "br_capability_routes_seen": 645,
     "br_rbac_entries_seen": 278,
-    "br_sdk_paths_seen": 124
+    "br_sdk_paths_seen": 132
   },
   "routes": [
     {
@@ -295,7 +295,7 @@
       "codeRefs": [
         [
           "packages/providers/src/cloud/brainstorm-saas.ts",
-          "baseURL: \"https://api.brainstormrouter.com/v1\""
+          "BR_BASE_URL = \"https://api.brainstormrouter.com/v1\""
         ],
         [
           "packages/providers/src/__tests__/br-live-contract.live.test.ts",
@@ -311,7 +311,7 @@
         "code": [
           {
             "file": "packages/providers/src/cloud/brainstorm-saas.ts",
-            "needle": "baseURL: \"https://api.brainstormrouter.com/v1\"",
+            "needle": "BR_BASE_URL = \"https://api.brainstormrouter.com/v1\"",
             "present": true
           },
           {

--- a/docs/internal/br-business-harness-contract-matrix.md
+++ b/docs/internal/br-business-harness-contract-matrix.md
@@ -10,8 +10,8 @@ Scope is intentionally bounded to the BR and product actuator routes this harnes
 - Failures: 0
 - Warnings: 0
 - BR repo detected: yes
-- BR OpenAPI paths seen: 490
-- BR capability routes seen: 616
+- BR OpenAPI paths seen: 517
+- BR capability routes seen: 645
 - BR RBAC entries seen: 278
 
 ## Route Matrix

--- a/scripts/br-business-contract-map.mjs
+++ b/scripts/br-business-contract-map.mjs
@@ -123,7 +123,7 @@ const ROUTES = [
     codeRefs: [
       [
         "packages/providers/src/cloud/brainstorm-saas.ts",
-        'baseURL: "https://api.brainstormrouter.com/v1"',
+        'BR_BASE_URL = "https://api.brainstormrouter.com/v1"',
       ],
       [
         "packages/providers/src/__tests__/br-live-contract.live.test.ts",


### PR DESCRIPTION
## Problem
The `br-contract-map` contract-preflight gate (job `build-and-test`) has been **failing on `main`**. The `br.chat_completions` route's code reference matched an inline literal in `packages/providers/src/cloud/brainstorm-saas.ts`:

```
baseURL: "https://api.brainstormrouter.com/v1"
```

but that file was refactored to source the URL from a constant (`export const BR_BASE_URL = "..."` then `baseURL: BR_BASE_URL`), so the exact-substring gate no longer matched.

## Fix
Point the needle at the constant definition itself — `BR_BASE_URL = "https://api.brainstormrouter.com/v1"` — which still proves the canonical BR base URL lives in that file and is stable across the inline→constant refactor. Changed in the generator (`scripts/br-business-contract-map.mjs`) and regenerated the committed snapshot + docs matrix from the live sibling BR repo.

## Scope / churn
- Semantic change is the 2 needle lines only. Still 20 routes, 0 failures, 0 warnings.
- The `*_seen` counts and `repo_root` refresh as a side effect of regeneration (existing gate behaviour — the snapshot is meant to be regenerated).

## Verification
`node scripts/contract-check.mjs` → **17/17 checks pass** (was 16/17, `br-contract-map` the lone drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)