### PR TITLE
fix(cli): move bundled-only internal packages out of runtime dependencies

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,9 +34,6 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@brainst0rm/channels": "workspace:*",
-    "@brainst0rm/orchestrator": "workspace:*",
-    "@brainst0rm/projects": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "ai": "^6",
     "better-sqlite3": "^12.2.0",
@@ -60,6 +57,7 @@
     "@brainst0rm/archetype-msp": "workspace:*",
     "@brainst0rm/archetype-saas-platform": "workspace:*",
     "@brainst0rm/broker": "workspace:*",
+    "@brainst0rm/channels": "workspace:*",
     "@brainst0rm/code-graph": "workspace:*",
     "@brainst0rm/config": "workspace:*",
     "@brainst0rm/contracts": "workspace:*",
@@ -76,6 +74,8 @@
     "@brainst0rm/ingest": "workspace:*",
     "@brainst0rm/mcp": "workspace:*",
     "@brainst0rm/onboard": "workspace:*",
+    "@brainst0rm/orchestrator": "workspace:*",
+    "@brainst0rm/projects": "workspace:*",
     "@brainst0rm/providers": "workspace:*",
     "@brainst0rm/relay": "workspace:*",
     "@brainst0rm/router": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,15 +286,6 @@ importers:
 
   packages/cli:
     dependencies:
-      "@brainst0rm/channels":
-        specifier: workspace:*
-        version: link:../channels
-      "@brainst0rm/orchestrator":
-        specifier: workspace:*
-        version: link:../orchestrator
-      "@brainst0rm/projects":
-        specifier: workspace:*
-        version: link:../projects
       "@modelcontextprotocol/sdk":
         specifier: ^1.29.0
         version: 1.29.0(zod@3.25.76)
@@ -359,6 +350,9 @@ importers:
       "@brainst0rm/broker":
         specifier: workspace:*
         version: link:../broker
+      "@brainst0rm/channels":
+        specifier: workspace:*
+        version: link:../channels
       "@brainst0rm/code-graph":
         specifier: workspace:*
         version: link:../code-graph
@@ -407,6 +401,12 @@ importers:
       "@brainst0rm/onboard":
         specifier: workspace:*
         version: link:../onboard
+      "@brainst0rm/orchestrator":
+        specifier: workspace:*
+        version: link:../orchestrator
+      "@brainst0rm/projects":
+        specifier: workspace:*
+        version: link:../projects
       "@brainst0rm/providers":
         specifier: workspace:*
         version: link:../providers


### PR DESCRIPTION
## Problem
The **Fresh-Environment Install Verification** workflow (`pack + global install + smoke`) fails on all three OSes:

```
npm error 404 '@brainst0rm/channels@0.14.4' is not in this registry.
```

A real user running `npm install -g @brainst0rm/cli` from a clean machine hits the same wall.

## Root cause
Three workspace packages — `@brainst0rm/channels`, `@brainst0rm/orchestrator`, `@brainst0rm/projects` — sat in the CLI's **runtime `dependencies`**. `pnpm pack` rewrites `workspace:*` to concrete versions in the tarball, so a fresh global install tries to fetch them from the public registry:
- `channels` — never published → 404
- `orchestrator` / `projects` — only published at `0.14.3`, but the tarball pins `0.14.4` → would also 404 (channels just failed first)

This contradicts the CLI's own tsup contract, which bundles **all** internal packages into the dist binary:
```ts
const noExternal = [/^@brainst0rm\//]; // "the published tarball doesn't reference them as npm-registry deps"
```
The other 28 internal packages already live in `devDependencies`; these three were the inconsistency.

## Fix
Move the three to `devDependencies` (bundled into dist, not resolved from the registry). Lockfile importer moved by hand to keep the diff to 9 lines and avoid a pnpm 10.9.0 full-lockfile reserialization.

## Verification (local repro of the CI pack)
- `pnpm pack` → tarball `dependencies` now has **zero** `@brainst0rm/*` entries (17 third-party runtime deps only)
- Channels code **is bundled** into `dist/brainstorm.js` (the dynamic `import("@brainst0rm/channels")` resolves at runtime)
- `pnpm install --frozen-lockfile` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)